### PR TITLE
[tests] Updating mock to unittest.mock

### DIFF
--- a/openwisp_monitoring/check/tests/test_ping.py
+++ b/openwisp_monitoring/check/tests/test_ping.py
@@ -1,4 +1,5 @@
-import mock
+from unittest.mock import patch
+
 from django.core.exceptions import ValidationError
 from django.test import TransactionTestCase
 
@@ -71,7 +72,7 @@ class TestPing(TestDeviceMonitoringMixin, TransactionTestCase):
         self.assertFalse(result['reachable'], 0)
         self.assertEqual(result['loss'], 100.0)
 
-    @mock.patch.object(Ping, '_command', return_value=_UNRECOGNIZED_OUTPUT)
+    @patch.object(Ping, '_command', return_value=_UNRECOGNIZED_OUTPUT)
     def test_operational_error(self, _command):
         device = self._create_device(organization=self._create_org())
         device.management_ip = '127.0.0.1'
@@ -163,7 +164,7 @@ class TestPing(TestDeviceMonitoringMixin, TransactionTestCase):
             else:
                 self.fail('ValidationError not raised')
 
-    @mock.patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
+    @patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
     def test_store_result(self, mocked_method):
         self.assertEqual(Check.objects.count(), 0)
         device = self._create_device(organization=self._create_org())
@@ -190,8 +191,8 @@ class TestPing(TestDeviceMonitoringMixin, TransactionTestCase):
         self.assertEqual(points[0]['rtt_avg'], result['rtt_avg'])
         self.assertEqual(points[0]['rtt_max'], result['rtt_max'])
 
-    @mock.patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
-    @mock.patch.object(monitoring_settings, 'AUTO_GRAPHS', return_value=[])
+    @patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
+    @patch.object(monitoring_settings, 'AUTO_GRAPHS', return_value=[])
     def test_auto_graph_disabled(self, *args):
         device = self._create_device(organization=self._create_org())
         device.last_ip = '127.0.0.1'

--- a/openwisp_monitoring/check/tests/test_utils.py
+++ b/openwisp_monitoring/check/tests/test_utils.py
@@ -1,4 +1,5 @@
-import mock
+from unittest.mock import patch
+
 from django.core import management
 from django.test import TransactionTestCase
 
@@ -19,12 +20,12 @@ class TestUtils(TestDeviceMonitoringMixin, TransactionTestCase):
         device.save()
         # check is automatically created via django signal
 
-    @mock.patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
+    @patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
     def test_run_checks_async_success(self, mocked_method):
         self._create_check()
         run_checks_async()
 
-    @mock.patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
+    @patch.object(Ping, '_command', return_value=_FPING_OUTPUT)
     def test_management_command(self, mocked_method):
         self._create_check()
         management.call_command('run_checks')

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -1,6 +1,6 @@
 import json
+from unittest.mock import patch
 
-import mock
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
@@ -357,7 +357,7 @@ class TestDeviceApi(DeviceMonitoringTestCase):
         self.assertEqual(Metric.objects.count(), 1)
         self.assertEqual(Graph.objects.count(), 1)
 
-    @mock.patch.object(monitoring_settings, 'AUTO_GRAPHS', return_value=[])
+    @patch.object(monitoring_settings, 'AUTO_GRAPHS', return_value=[])
     def test_auto_graph_disabled(self, *args):
         self.assertEqual(Graph.objects.count(), 0)
         o = self._create_org()


### PR DESCRIPTION
I just noticed that `mock` wasn't specified in `requirements-test.txt`, so I have updated the tests using `mock` module to now use `unittest.mock` which is built-in. Also, I have narrowed down the scope of import to just `patch` as that was only being used.