### PR TITLE
[monitoring] Added migration to create ping for existing devices. #16

### DIFF
--- a/openwisp_monitoring/check/migrations/0003_create_ping.py
+++ b/openwisp_monitoring/check/migrations/0003_create_ping.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+from openwisp_monitoring.check.settings import AUTO_PING
+from openwisp_monitoring.check.tasks import auto_create_ping
+
+
+def create_device_ping(apps, schema_editor):
+    if AUTO_PING:
+        Device = apps.get_model('config', 'Device')
+        for device in Device.objects.all():
+            auto_create_ping(model=Device.__name__.lower(),
+                            app_label=Device._meta.app_label,
+                            object_id=str(device.pk),
+                            created=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('check', '0002_check_unique_together'),
+        ('config', '0026_hardware_id_not_unique')
+    ]
+
+    operations = [
+        migrations.RunPython(create_device_ping,
+                             reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Closes #16

`flake8` :heavy_check_mark: 
`isort`. :heavy_check_mark: 

Steps I took to check : 
1. After migration ran `python tests/manage.py migrate monitoring 0004`
2. Create few device using admin interface
3. Applied `0005_create_ping` migration,
4. Verified that ping checks were created. 