### PR TITLE
[CI] Configured travis builds #15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,59 @@
 language: python
+sudo: false
+dist: bionic
+
 cache: pip
+
+python:
+  - "3.6"
+  - "3.7"
+
+env:
+  - DJANGO="django>=2.2,<3.0"
+  - DJANGO="django>=3.0,<3.1"
 
 addons:
   apt:
     packages:
       - sqlite3
+      - fping
       - gdal-bin
       - libproj-dev
       - libgeos-dev
       - libspatialite-dev
+      - spatialite-bin
+      - libsqlite3-mod-spatialite
 
-python:
-  - "3.6"
+services:
+  - docker
+  - redis-server
 
 branches:
   only:
     - master
 
 before_install:
+  - docker run -d --name influxdb -p 8086:8086 influxdb
+  - docker exec -it influxdb influx -execute 'CREATE DATABASE openwisp2'
+  # TODO: this is temporary, remove it when openwisp-utils-0.4.5 is released
+  - pip install https://github.com/openwisp/openwisp-utils/tarball/master
   - pip install -U pip wheel setuptools
-  - pip install --no-cache-dir -U -r requirements-test.txt
-  - ./runflake8
-  - ./runisort
+  - pip install -U -r requirements-test.txt
 
 install:
-  - python setup.py -q develop
+  - pip install $DJANGO
+  - pip install -e .
 
 script:
+  - |
+    openwisp-utils-qa-checks \
+          --migration-path \
+          "./openwisp_monitoring/check/migrations \
+          ./openwisp_monitoring/device/migrations \
+          ./openwisp_monitoring/monitoring/migrations \
+          ./openwisp_monitoring/notifications/migrations" \
+          --migration-module "check device_monitoring monitoring notifications"
   - coverage run --source=openwisp_monitoring runtests.py
-  ./tests/manage.py makemigrations monitoring device check --dry-run | grep "No changes detected";
 
 after_success:
   coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 openwisp-monitoring
 ===================
 
+.. image:: https://travis-ci.com/openwsip/openwisp-monitoring.svg?branch=master
+    :target: https://travis-ci.com/openwisp/openwisp-monitoring
+
+.. image:: https://coveralls.io/repos/github/openwisp/openwisp-monitoring/badge.svg?branch=master
+    :target: https://coveralls.io/github/openwisp/openwisp-monitoring?branch=master
+
 ------------
 
 OpenWISP 2 monitoring module (Work in progress).

--- a/runflake8
+++ b/runflake8
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -e
-flake8

--- a/runisort
+++ b/runisort
@@ -1,3 +1,0 @@
-#!/bin/bash
-set -e
-isort --check-only --recursive --diff || exit 1


### PR DESCRIPTION
Closes #15

`pip` was erroring out due to incompatible requirements for `cryptography` module, so had to mention it in `requirements.txt`. [See for more info](https://travis-ci.com/github/TheOneAboveAllTitan/openwisp-monitoring/builds/158418833#L547)

Kindly suggest any other way to mitigate this problem.
@nemesisdesign please turn on Travis and Coveralls for this repository. 