### PR TITLE
[monitoring] Allow to store IP addresses of interfaces in DeviceData.data #30

### DIFF
--- a/openwisp_monitoring/device/models.py
+++ b/openwisp_monitoring/device/models.py
@@ -68,9 +68,10 @@ class DeviceData(Device):
                 remove.append(interface)
                 continue
             # human readable mode
-            interface['wireless']['mode'] = interface['wireless']['mode'].replace(
-                '_', ' '
-            )
+            if 'wireless' in interface and 'mode' in interface['wireless']:
+                interface['wireless']['mode'] = interface['wireless']['mode'].replace(
+                    '_', ' '
+                )
             # convert to GHz
             if 'wireless' in interface and 'frequency' in interface['wireless']:
                 interface['wireless']['frequency'] /= 1000

--- a/openwisp_monitoring/device/schema.py
+++ b/openwisp_monitoring/device/schema.py
@@ -145,6 +145,27 @@ schema = {
                             "tx_carrier_errors": {"type": "integer"},
                         },
                     },
+                    "addresses": {
+                        "type": "array",
+                        "title": "Addresses",
+                        "uniqueItems": True,
+                        "additionalItems": True,
+                        "items": {
+                            "additionalProperties": True,
+                            "title": "Address",
+                            "type": "object",
+                            "required": ["proto", "family", "address", "mask"],
+                            "properties": {
+                                "proto": {"type": "string"},
+                                "family": {"type": "string"},
+                                "address": {
+                                    "type": "string",
+                                    "anyOf": [{"format": "ipv4"}, {"format": "ipv6"}],
+                                },
+                                "mask": {"type": "integer"},
+                            },
+                        },
+                    },
                 },
             },
         },

--- a/openwisp_monitoring/device/static/monitoring/css/monitoring.css
+++ b/openwisp_monitoring/device/static/monitoring/css/monitoring.css
@@ -158,3 +158,11 @@ td.field-health_status,
 #ow-graph-container b{
     background-color: #000 !important;
 }
+
+table.device-addresses {
+  margin-top: 20px;
+}
+
+table.device-addresses td.dhcp {
+  background-color: lightgray;
+}

--- a/openwisp_monitoring/device/templates/admin/config/device/change_form.html
+++ b/openwisp_monitoring/device/templates/admin/config/device/change_form.html
@@ -141,6 +141,28 @@
                   {% endif %}
                   {% endif %}
               </div>
+              {% if interface.addresses %}
+              <table class="device-addresses">
+                  <thead>
+                      <tr>
+                          <th>{% trans 'Address' %}</th>
+                          <th>{% trans 'Mask' %}</th> 
+                          <th>{% trans 'DHCP client ?' %}</th>
+                      </tr>
+                  </thead>
+                  {% for address in interface.addresses %}
+                  <tr>
+                      <td>{{ address.address }}</td>
+                      <td>{{ address.mask }}</td>
+                      {% if address.proto == "static" %}
+                          <td class="static">{% trans 'No' %}</td>
+                      {% else %}
+                          <td class="dhcp">{% trans 'Yes' %}</td>
+                      {% endif %}
+                  </tr>
+                  {% endfor %}
+              </table>
+              {% endif %}
               {% endfor %}
               {% endif %}
             </fieldset>

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -102,6 +103,32 @@ class BaseTestCase(DeviceMonitoringTestCase):
                     "ssid": "testnet",
                     "tx_power": 6,
                 },
+                "addresses": [
+                    {
+                        "proto": "static",
+                        "family": "ipv4",
+                        "address": "192.168.1.1",
+                        "mask": 8,
+                    },
+                    {
+                        "proto": "dhcp",
+                        "family": "ipv4",
+                        "address": "10.0.0.4",
+                        "mask": 24,
+                    },
+                    {
+                        "proto": "static",
+                        "family": "ipv6",
+                        "address": "2001:3238:dfe1:ec63::fefb",
+                        "mask": 12,
+                    },
+                    {
+                        "proto": "dhcp",
+                        "family": "ipv6",
+                        "address": "fd46:9038:f983::1",
+                        "mask": 22,
+                    },
+                ],
             },
         ],
         "arp_table": [
@@ -222,6 +249,19 @@ class TestDeviceData(BaseTestCase):
             pass
         else:
             self.fail('metric was not deleted')
+
+    def test_bad_address_fail(self):
+        dd = self._create_device_data()
+        data = copy.deepcopy(self._sample_data)
+        data['interfaces'][1]['addresses'][0]['address'] = '123'
+        try:
+            dd.data = data
+            dd.validate_data()
+        except ValidationError as e:
+            self.assertIn('Invalid data in', e.message)
+            self.assertIn("'123\' is not a \'ipv4\'", e.message)
+        else:
+            self.fail('ValidationError not raised')
 
 
 class TestDeviceMonitoring(BaseTestCase):


### PR DESCRIPTION
~~This is still WIP. The following need to be done:-~~
* [x] show the addresses in the device status tab: https://github.com/openwisp/openwisp-monitoring/blob/master/openwisp_monitoring/device/templates/admin/config/device/change_form.html
* [x] add tests to ensure bogus addresses will be rejected
* [x] Creating a PR in `monitoring-lua` as mentioned in the issue

**PS**: The JSON type for `family` was provided as `integer` [here](http://netjson.org/rfc.html#addresses1) but it appeared visibly as `string` to me

Closes #30