### PR TITLE
[fix] Sometimes mac_address key is not present in the dictionary

### DIFF
--- a/openwisp_monitoring/device/models.py
+++ b/openwisp_monitoring/device/models.py
@@ -151,8 +151,11 @@ class DeviceData(Device):
                 client['vendor'] = self._mac_lookup(client['mac'])
         for neighbor in self.data.get('neighbors', []):
             # Neighbors with state = FAILED have no mac_address
-            mac_address = neighbor.get('mac_address', '')
-            neighbor['vendor'] = self._mac_lookup(mac_address)
+            try:
+                mac_address = neighbor['mac_address']
+                neighbor['vendor'] = self._mac_lookup(mac_address)
+            except KeyError:
+                neighbor['vendor'] = ''
 
     def _mac_lookup(self, value):
         try:

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -194,6 +194,7 @@ class BaseTestCase(DeviceMonitoringTestCase):
                 "ip_address": "192.168.56.2",
                 "mac_address": "44:D1:FA:4B:00:04",
                 "interface": "br-mng",
+                "state": "STALE",
             },
         ],
     }
@@ -345,6 +346,20 @@ class TestDeviceData(BaseTestCase):
         for neighbor in dd.data['neighbors']:
             self.assertIn('vendor', neighbor)
             self.assertEqual(neighbor['vendor'], vendor)
+
+    @patch('openwisp_monitoring.device.settings.MAC_VENDOR_DETECTION', True)
+    def test_mac_vendor_info_empty(self):
+        dd = self._create_device_data()
+        dd.data = deepcopy(self._sample_data)
+        dd.data['neighbors'] = [
+            {
+                "ip_address": "2001:db80::1",
+                "interface": "eth2.1",
+                "state": "FAILED",
+            },
+        ]
+        dd.save_data()
+        self.assertEqual(dd.data['neighbors'][0]['vendor'], '')
 
 
 class TestDeviceMonitoring(BaseTestCase):

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -352,11 +352,7 @@ class TestDeviceData(BaseTestCase):
         dd = self._create_device_data()
         dd.data = deepcopy(self._sample_data)
         dd.data['neighbors'] = [
-            {
-                "ip_address": "2001:db80::1",
-                "interface": "eth2.1",
-                "state": "FAILED",
-            },
+            {'ip_address': '2001:db80::1', 'interface': 'eth2.1', 'state': 'FAILED'},
         ]
         dd.save_data()
         self.assertEqual(dd.data['neighbors'][0]['vendor'], '')


### PR DESCRIPTION
An extract of what `ip neigh -json` returns in my device:

```
  ...
  {
    "dst": "fddc:c8c3:5b6c:0:8ca3:2665:625d:5921",
    "dev": "br-lan",
    "lladdr": "18:5e:0f:12:12:0e",
    "state": [
      "STALE"
    ]
  },
  {
    "dst": "2001:db80::1",
    "dev": "eth0.3",
    "state": [
      "FAILED"
    ]
  },
  ...
```