### PR TITLE
[models] Fix Graph.label property

### DIFF
--- a/openwisp_monitoring/monitoring/models.py
+++ b/openwisp_monitoring/monitoring/models.py
@@ -307,8 +307,7 @@ class Graph(TimeStampedEditableModel):
 
     @property
     def label(self):
-        label = self.config_dict.get('label')
-        return label or self.title
+        return self.config_dict.get('label') or self.title
 
     @property
     def description(self):

--- a/openwisp_monitoring/monitoring/models.py
+++ b/openwisp_monitoring/monitoring/models.py
@@ -308,8 +308,7 @@ class Graph(TimeStampedEditableModel):
     @property
     def label(self):
         label = self.config_dict.get('label')
-        if not label:
-            return self.title
+        return label or self.title
 
     @property
     def description(self):


### PR DESCRIPTION
```
In [1]: Graph.objects.all()
Out[1]: <QuerySet [<Graph: Uptime>, <Graph: Packet loss>, <Graph: Round Trip Time>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>, <Graph: None>]>

In [10]: Graph.objects.first().label
Out[10]: 'Round Trip Time'

In [11]: Graph.objects.last().label

```