### PR TITLE
[dependencies] Bump openwisp-utils version and few changes for qa-checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ install:
   - pip install -U https://github.com/openwisp/openwisp-utils/tarball/master#egg=openwisp_utils[qa]
   # temporary: remove when openwisp-notifications is released
   - pip install -U https://github.com/openwisp/openwisp-notifications/tarball/master
+  # Remove after new release of celery
+  - pip install future
 
 script:
   - ./run-qa-checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ install:
   - pip install --upgrade https://github.com/openwisp/openwisp-controller/tarball/master
   # Until release of django-netjsonconfig 0.12.0
   - pip install --upgrade https://github.com/openwisp/django-netjsonconfig/tarball/master
-  # temporary: remove when openwisp-utils 0.5.0 is released
-  - pip install -U https://github.com/openwisp/openwisp-utils/tarball/master#egg=openwisp_utils[qa]
   # temporary: remove when openwisp-notifications is released
   - pip install -U https://github.com/openwisp/openwisp-notifications/tarball/master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ install:
   - pip install -U https://github.com/openwisp/openwisp-utils/tarball/master#egg=openwisp_utils[qa]
   # temporary: remove when openwisp-notifications is released
   - pip install -U https://github.com/openwisp/openwisp-notifications/tarball/master
-  # Remove after new release of celery
-  - pip install future
 
 script:
   - ./run-qa-checks

--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -21,7 +21,7 @@ class DeviceAdmin(BaseDeviceAdmin):
         ctx = super().get_extra_context(pk)
         if pk:
             device_data = DeviceData(pk=pk)
-            api_url = reverse(f'monitoring:api_device_metric', args=[pk])
+            api_url = reverse('monitoring:api_device_metric', args=[pk])
             ctx.update(
                 {
                     'device_data': device_data.data_user_friendly,

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -214,7 +214,7 @@ class AbstractMetric(TimeStampedEditableModel):
         if not self.is_healthy:
             info = ' ({0} {1})'.format(t.get_operator_display(), t.value)
         desc = 'Metric "{metric}" {verb}{info}.'.format(
-            status=status, metric=metric, verb=verb, info=info
+            metric=metric, verb=verb, info=info
         )
         opts['description'] = desc
         opts['data'] = {

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-openwisp-utils[qa]>=0.4.5
+openwisp-utils[qa]>=0.5.0
 redis
 django-redis


### PR DESCRIPTION
* Minor changes for qa-checks
* Bump `openwisp-utils` version to 0.5.0
* ~~Temporarily added `future` in travis until new `celery` release~~
* ~~Added `openwisp-utils` as a dependency.~~

**PS**: Realized that `openwisp-utils` is a dependency of `django-netjsonconfig`. So, it shouldn't be added but I didn't remove it from travis because `django-netjsonconfig` has locked `openwisp-utils` version to `0.4.5` (currently).