### PR TITLE
[monitoring] Related object URL in notification email

### DIFF
--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -21,7 +21,7 @@ class DeviceAdmin(BaseDeviceAdmin):
         ctx = super().get_extra_context(pk)
         if pk:
             device_data = DeviceData(pk=pk)
-            api_url = reverse(f'monitoring:api_device_metric', args=[pk])
+            api_url = reverse('monitoring:api_device_metric', args=[pk])
             ctx.update(
                 {
                     'device_data': device_data.data_user_friendly,

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -214,17 +214,17 @@ class AbstractMetric(TimeStampedEditableModel):
         if not self.is_healthy:
             info = ' ({0} {1})'.format(t.get_operator_display(), t.value)
         desc = 'Metric "{metric}" {verb}{info}.'.format(
-            status=status, metric=metric, verb=verb, info=info
+            metric=metric, verb=verb, info=info
         )
         opts['description'] = desc
-        opts['data'] = {
-            'email_subject': '[{status}] {metric}'.format(status=status, metric=metric)
-        }
+        opts['email_subject'] = '[{status}] {metric}'.format(
+            status=status, metric=metric
+        )
         if target and target.__class__.__name__.lower() == 'device':
             current_site = Site.objects.get_current()
             base_url = 'https://{}'.format(current_site.domain)
             device_url = reverse('admin:config_device_change', args=[target.pk])
-            opts['data']['url'] = '{}{}'.format(base_url, device_url)
+            opts['url'] = '{}{}'.format(base_url, device_url)
 
 
 class AbstractGraph(TimeStampedEditableModel):


### PR DESCRIPTION
Link to related object was not present in notification email, therefore fixed that. 

These changes are also present in #93, but for a quick redressal I have made this patch. :smile: 