### PR TITLE
[device] Added notification types for Device events

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -435,13 +435,20 @@ it is not sent if the response was not successful.
 Default Alerts / Notifications
 ------------------------------
 
-+----------------------------+------------------------------------------------------------------------------------------------+
-|    Notification Types      | Uses                                                                                           |
-+----------------------------+------------------------------------------------------------------------------------------------+
-| ``threshold_crossed``      | Fires when a metric crosses the boundary defined in the threshold value of the alert settings. |
-+----------------------------+------------------------------------------------------------------------------------------------+
-| ``threshold_recovery``     | Fires when a metric goes back within the expected range.                                       |
-+----------------------------+------------------------------------------------------------------------------------------------+
++-------------------------------+------------------------------------------------------------------+
+| Notification Type             | Use                                                              |
++-------------------------------+------------------------------------------------------------------+
+| ``threshold_crossed``         | Fires when a metric crosses the boundary defined in the          |
+|                               | threshold value of the alert settings.                           |
++-------------------------------+------------------------------------------------------------------+
+| ``threshold_recovery``        | Fires when a metric goes back within the expected range.         |
++-------------------------------+------------------------------------------------------------------+
+| ``connection_is_working``     | Fires when the connection to a device is working.                |
++-------------------------------+------------------------------------------------------------------+
+| ``connection_is_not_working`` | Fires when the connection (eg: SSH) to a device stops working    |
+|                               | (eg: credentials are outdated, management IP address is          |
+|                               | outdated, or device is not reachable).                           |
++-------------------------------+------------------------------------------------------------------+
 
 Installing for development
 --------------------------

--- a/openwisp_monitoring/device/tests/test_device_notifcations.py
+++ b/openwisp_monitoring/device/tests/test_device_notifcations.py
@@ -1,0 +1,94 @@
+from django.core import mail
+from django.utils.html import strip_tags
+from swapper import load_model
+
+from openwisp_controller.connection.models import Credentials, DeviceConnection
+
+from .test_models import BaseTestCase
+
+Notification = load_model('openwisp_notifications', 'Notification')
+
+
+class TestDeviceNotifications(BaseTestCase):
+    def setUp(self):
+        self._create_admin()
+        self.d = self._create_device()
+        self.creds = Credentials.objects.create(
+            connector='openwisp_controller.connection.connectors.ssh.Ssh'
+        )
+        self.dc = DeviceConnection.objects.create(credentials=self.creds, device=self.d)
+
+    def _generic_notification_test(
+        self, exp_level, exp_type, exp_verb, exp_message, exp_email_subject
+    ):
+        exp_target_link = f'http://example.com/admin/config/device/{self.d.id}/change/'
+        exp_email_body = '{message}' f'\n\nFor more information see {exp_target_link}.'
+
+        n = Notification.objects.first()
+        email = mail.outbox.pop()
+        html_message, content_type = email.alternatives.pop()
+        self.assertEqual(n.type, exp_type)
+        self.assertEqual(n.level, exp_level)
+        self.assertEqual(n.verb, exp_verb)
+        self.assertEqual(n.actor, self.dc)
+        self.assertEqual(n.target, self.d)
+        self.assertEqual(
+            n.message, exp_message.format(n=n, target_link=exp_target_link)
+        )
+        self.assertEqual(
+            n.email_subject, exp_email_subject.format(n=n),
+        )
+        self.assertEqual(email.subject, n.email_subject)
+        self.assertEqual(
+            email.body, exp_email_body.format(message=strip_tags(n.message))
+        )
+        self.assertIn(n.message, html_message)
+        self.assertIn(
+            f'<a href="{exp_target_link}">'
+            'For further information see "device: test-device".</a>',
+            html_message,
+        )
+
+    def test_connection_working_notification(self):
+        self.dc.is_working = True
+        self.dc.save()
+        self._generic_notification_test(
+            exp_level='info',
+            exp_type='connection_is_working',
+            exp_verb='working',
+            exp_message=(
+                '<p>(SSH) connection to <a href="{target_link}">'
+                'Device: {n.target}</a> is {n.verb}. </p>'
+            ),
+            exp_email_subject='[example.com] RECOVERY: Device "{n.target}"',
+        )
+
+    def test_connection_not_working_notification(self):
+        self.dc.is_working = False
+        self.dc.save()
+        self._generic_notification_test(
+            exp_level='error',
+            exp_type='connection_is_not_working',
+            exp_verb='not working',
+            exp_message=(
+                '<p>(SSH) connection to <a href="{target_link}">'
+                'Device: {n.target}</a> is {n.verb}. </p>'
+            ),
+            exp_email_subject='[example.com] PROBLEM: Device "{n.target}"',
+        )
+
+    def test_unreachable_after_upgrade_notification(self):
+        self.dc.is_working = False
+        self.dc.failure_reason = 'Giving up, device not reachable anymore after upgrade'
+        self.dc.save()
+        self._generic_notification_test(
+            exp_level='error',
+            exp_type='connection_is_not_working',
+            exp_verb='not working',
+            exp_message=(
+                '<p>(SSH) connection to <a href="{target_link}">'
+                'Device: {n.target}</a> is {n.verb}.'
+                ' Giving up, device not reachable anymore after upgrade</p>'
+            ),
+            exp_email_subject='[example.com] PROBLEM: Device "{n.target}"',
+        )

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -587,38 +587,6 @@ class TestDeviceMonitoring(BaseTestCase):
         ping.write(0)
         self.assertEqual(dm.status, 'critical')
 
-    def test_unknown_problem_ok(self):
-        dm, ping, load, process_count = self._create_env()
-        self._set_env_unknown(load, process_count, ping, dm)
-        dm.refresh_from_db()
-        self.assertEqual(dm.status, 'unknown')
-        load.check_threshold(100)
-        self.assertEqual(dm.status, 'problem')
-        load.check_threshold(20)
-        self.assertEqual(dm.status, 'ok')
-
-    def test_device_connection_change(self):
-        admin = self._create_admin()
-        Notification = load_model('openwisp_notifications', 'Notification')
-        d = self._create_device()
-        dm = d.monitoring
-        dm.status = 'unknown'
-        dm.save()
-        c = Credentials.objects.create()
-        dc = DeviceConnection.objects.create(credentials=c, device=d)
-        dc.is_working = True
-        dc.save()
-        self.assertEqual(dm.status, 'ok')
-        n = Notification.objects.get(level='info')
-        self.assertEqual(n.verb, 'connected successfully')
-        self.assertEqual(n.actor, d)
-        dc.is_working = False
-        dc.save()
-        n = Notification.objects.get(level='warning')
-        self.assertEqual(n.verb, 'not working')
-        self.assertEqual(n.actor, d)
-        self.assertEqual(n.recipient, admin)
-
     @patch.object(Check, 'perform_check')
     def test_is_working_false_true(self, mocked_call):
         d = self._create_device()

--- a/openwisp_monitoring/device/tests/test_recovery.py
+++ b/openwisp_monitoring/device/tests/test_recovery.py
@@ -55,14 +55,14 @@ class TestRecovery(DeviceMonitoringTestCase):
             'openwisp_monitoring.device.apps.app_settings.DEVICE_RECOVERY_DETECTION',
             False,
         ):
-            device_monitoring_app.ready()
+            device_monitoring_app.device_recovery_detection()
         dm = self._create_device_monitoring()
         cache_key = get_device_recovery_cache_key(device=dm.device)
         dm.update_status('critical')
         dm.refresh_from_db()
         self.assertEqual(dm.status, 'critical')
         self.assertEqual(cache.get(cache_key), None)
-        device_monitoring_app.ready()
+        device_monitoring_app.device_recovery_detection()
 
     def test_device_recovery_cache_key_set(self):
         dm = self._create_device_monitoring()

--- a/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
+++ b/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
@@ -18,7 +18,9 @@ start_time = timezone.now()
 ten_minutes_ago = start_time - timedelta(minutes=10)
 
 
-class TestNotifications(CreateConfigTemplateMixin, TestMonitoringMixin, TestCase):
+class TestMonitoringNotifications(
+    CreateConfigTemplateMixin, TestMonitoringMixin, TestCase
+):
     device_model = Device
     config_model = Config
 


### PR DESCRIPTION
Related to https://github.com/openwisp/openwisp-notifications/issues/26

Notification Types Added:
- `unreachable_after_upgrade` - Notification specifically for a case like https://github.com/openwisp/openwisp-notifications/issues/26
- `device_up` - Notification when device becomes reachabel
- `device_down` - Generic notification when device is not reachable

When a device goes offline after an upgrade, two notifications are being generated

1. `threshold_crossed`
2. `unreachable_after_upgrade`