### PR TITLE
[tests] Fix flaky test: test_wifi_hostapd #7

### DIFF
--- a/openwisp_monitoring/monitoring/tests/test_graphs.py
+++ b/openwisp_monitoring/monitoring/tests/test_graphs.py
@@ -217,11 +217,12 @@ class TestGraphs(TestMonitoringMixin, TestCase):
             name='wifi associations', key='hostapd', field_name='mac_address'
         )
         g = self._create_graph(metric=m, test_data=False, configuration='wifi_clients')
+        now_ = now()
         for n in range(0, 9):
-            m.write('00:16:3e:00:00:00', time=now() - timedelta(days=n))
-            m.write('00:23:4b:00:00:00', time=now() - timedelta(days=n, seconds=1))
-        m.write('00:16:3e:00:00:00', time=now() - timedelta(days=2))
-        m.write('00:16:3e:00:00:00', time=now() - timedelta(days=4))
+            m.write('00:16:3e:00:00:00', time=now_ - timedelta(days=n))
+            m.write('00:23:4b:00:00:00', time=now_ - timedelta(days=n, seconds=1))
+        m.write('00:16:3e:00:00:00', time=now_ - timedelta(days=2))
+        m.write('00:16:3e:00:00:00', time=now_ - timedelta(days=4))
         m.write('00:23:4a:00:00:00')
         m.write('00:14:5c:00:00:00')
         g.save()


### PR DESCRIPTION
Fixes #7

```
======================================================================                                                                                                                                                                    
FAIL: test_wifi_hostapd (openwisp_monitoring.monitoring.tests.test_graphs.TestGraphs)                                                                                                                                                     
----------------------------------------------------------------------                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                                                        
  File "/home/travis/build/openwisp/openwisp-monitoring/openwisp_monitoring/monitoring/tests/test_graphs.py", line 231, in test_wifi_hostapd                                                                                              
    self.assertEqual(data['traces'][0][1][-10:], [0, 2, 2, 2, 2, 2, 2, 2, 2, 4])                                                                                                                                                          
AssertionError: Lists differ: [0, 2, 2, 1, 2, 2, 2, 2, 2, 4] != [0, 2, 2, 2, 2, 2, 2, 2, 2, 4]                                                                                                                                            
```

[Travis](https://travis-ci.org/github/openwisp/openwisp-monitoring/jobs/697374480#L1038-L1054)