### PR TITLE
[bug] Fixed error in _get_or_create when metrics are renamed

### DIFF
--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -77,10 +77,13 @@ class AbstractMetric(TimeStampedEditableModel):
         like ``get_or_create`` method of django model managers
         but with validation before creation
         """
+        assert 'name' in kwargs
         if 'key' in kwargs:
             kwargs['key'] = cls._makekey(kwargs['key'])
         try:
-            metric = cls.objects.get(**kwargs)
+            lookup_kwargs = kwargs.copy()
+            del lookup_kwargs['name']
+            metric = cls.objects.get(**lookup_kwargs)
             created = False
         except cls.DoesNotExist:
             metric = cls(**kwargs)


### PR DESCRIPTION
The _get_or_create method of Metric took into account the "name" field when looking if the metric already exists, effectively preventing the metric from being renamed.