### PR TITLE
[minor] Replace ugettext_lazy with gettext_lazy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,7 +368,7 @@ call in your custom code (eg: a custom check class), you can do so as follows:
 
 .. code-block:: python
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     OPENWISP_MONITORING_CHARTS = {
         'ram': {

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jsonfield import JSONField
 from openwisp_monitoring.check import settings as app_settings
 

--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from swapper import load_model
 
 from openwisp_controller.config.admin import DeviceAdmin as BaseDeviceAdmin

--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_netjsonconfig.signals import checksum_requested
 from openwisp_notifications.signals import notify
 from swapper import load_model

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -8,7 +8,7 @@ from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jsonschema import draft7_format_checker, validate
 from jsonschema.exceptions import ValidationError as SchemaError
 from mac_vendor_lookup import MacLookup

--- a/openwisp_monitoring/device/migrations/0002_devicemonitoring.py
+++ b/openwisp_monitoring/device/migrations/0002_devicemonitoring.py
@@ -1,7 +1,7 @@
 from django.db import migrations, models
 import django.db.models.deletion
 import django.utils.timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import model_utils.fields
 import uuid
 

--- a/openwisp_monitoring/monitoring/admin.py
+++ b/openwisp_monitoring/monitoring/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from swapper import load_model
 
 from openwisp_utils.admin import TimeReadonlyAdminMixin

--- a/openwisp_monitoring/monitoring/apps.py
+++ b/openwisp_monitoring/monitoring/apps.py
@@ -2,7 +2,7 @@ from time import sleep
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from openwisp_notifications.types import register_notification_type
 from requests.exceptions import ConnectionError
 

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.timezone import make_aware
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from influxdb.exceptions import InfluxDBClientError
 from openwisp_notifications.signals import notify
 from pytz import timezone as tz

--- a/openwisp_monitoring/monitoring/charts.py
+++ b/openwisp_monitoring/monitoring/charts.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import settings as app_settings
 


### PR DESCRIPTION
`ugettext_lazy` is currently a legacy method which comes with a warning that it's to be dropped in Django4.0. `gettext_lazy` is to be used in place of it from Django2.0 onwards.

Source: https://docs.djangoproject.com/en/3.0/_modules/django/utils/translation/