### PR TITLE
[fix] Avoid log propagation when using root logger #131

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -285,7 +285,12 @@ LOGGING = {
         }
     },
     'loggers': {
-        'py.warnings': {'handlers': ['console']},
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+            'propagate': False,
+        },
+        'py.warnings': {'handlers': ['console'], 'propagate': False},
         'celery': {'handlers': ['console'], 'level': 'DEBUG'},
         'celery.task': {'handlers': ['console'], 'level': 'DEBUG'},
     },


### PR DESCRIPTION
I have checked that celery logs aren't being duplicated but don't know for `py.warnings` log but it should be safe to have `propagate` disabled for it.