### PR TITLE
[models] Use ContentType.objects.get_for_model #135

### DIFF
--- a/openwisp_monitoring/check/classes/ping.py
+++ b/openwisp_monitoring/check/classes/ping.py
@@ -13,6 +13,7 @@ from .. import settings as app_settings
 from ..exceptions import OperationalError
 
 Chart = load_model('monitoring', 'Chart')
+Check = load_model('check', 'Check')
 Metric = load_model('monitoring', 'Metric')
 AlertSettings = load_model('monitoring', 'AlertSettings')
 
@@ -171,9 +172,7 @@ class Ping(object):
             ct = check.content_type
         else:
             obj_id = str(check.id)
-            ct = ContentType.objects.get(
-                app_label=check._meta.app_label, model=check.__class__.__name__.lower()
-            )
+            ct = ContentType.objects.get_for_model(Check)
         options = dict(
             name=check.name,
             object_id=obj_id,

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -52,9 +52,7 @@ class DeviceMetricView(GenericAPIView):
         except ValueError:
             return Response({'detail': 'not found'}, status=404)
         self.instance = self.get_object()
-        ct = ContentType.objects.get(
-            model=Device.__name__.lower(), app_label=Device._meta.app_label
-        )
+        ct = ContentType.objects.get_for_model(Device)
         charts = Chart.objects.filter(
             metric__object_id=pk, metric__content_type=ct
         ).select_related('metric')
@@ -176,7 +174,7 @@ class DeviceMetricView(GenericAPIView):
         # saves raw device data
         self.instance.save_data()
         data = self.instance.data
-        ct = ContentType.objects.get(model='device', app_label='config')
+        ct = ContentType.objects.get_for_model(Device)
         for interface in data.get('interfaces', []):
             ifname = interface['name']
             for key, value in interface.get('statistics', {}).items():

--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -84,7 +85,7 @@ class TestModels(TestMonitoringMixin, TestCase):
 
     def test_get_or_create_renamed_object(self):
         obj = self._create_user()
-        ct = ContentType.objects.get(model='user', app_label='openwisp_users')
+        ct = ContentType.objects.get_for_model(get_user_model())
         m, created = Metric._get_or_create(
             name='logins',
             key='users',


### PR DESCRIPTION
Closes #135

* `ContentType.objects.get_for_model()` can't be used in celery task as we can't pass a model as an argument to the shared task method (not JSON serializable).
* I am not sure whether to replace instances in migration scripts (skipped them currently). There are two such instances (one in main module and another in sample_app)