### PR TITLE
[metrics] Merge traffic metrics #133

### DIFF
--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -43,7 +43,6 @@ class DeviceMetricView(GenericAPIView):
     serializer_class = serializers.Serializer
     permission_classes = [DevicePermission]
     schema = schema
-    statistics_stored = ['rx_bytes', 'tx_bytes']
 
     def get(self, request, pk):
         # ensure valid UUID
@@ -191,19 +190,29 @@ class DeviceMetricView(GenericAPIView):
         ct = ContentType.objects.get_for_model(Device)
         for interface in data.get('interfaces', []):
             ifname = interface['name']
-            for key, value in interface.get('statistics', {}).items():
-                if key not in self.statistics_stored:
-                    continue
-                name = '{0} {1}'.format(ifname, key)
+            ifstats = interface.get('statistics', {})
+            # Explicitly stated None to avoid skipping in case the stats are zero
+            if (
+                ifstats.get('rx_bytes') is not None
+                and ifstats.get('rx_bytes') is not None
+            ):
+                field_value = self._calculate_increment(
+                    ifname, 'rx_bytes', ifstats['rx_bytes']
+                )
+                extra_values = {
+                    'tx_bytes': self._calculate_increment(
+                        ifname, 'tx_bytes', ifstats['tx_bytes']
+                    )
+                }
+                name = f'{ifname} traffic'
                 metric, created = Metric._get_or_create(
                     object_id=pk,
                     content_type=ct,
-                    configuration=f'traffic_{key}',
+                    configuration='traffic',
                     name=name,
                     key=ifname,
                 )
-                increment = self._calculate_increment(ifname, key, value)
-                metric.write(increment)
+                metric.write(field_value, extra_values=extra_values)
                 if created:
                     self._create_traffic_chart(metric)
             try:
@@ -320,10 +329,7 @@ class DeviceMetricView(GenericAPIView):
         """
         create "traffic (GB)" chart
         """
-        if (
-            metric.field_name != 'tx_bytes'
-            or 'traffic' not in monitoring_settings.AUTO_CHARTS
-        ):
+        if 'traffic' not in monitoring_settings.AUTO_CHARTS:
             return
         chart = Chart(metric=metric, configuration='traffic')
         chart.full_clean()

--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -51,23 +51,19 @@ class DeviceMonitoringTestCase(TestDeviceMonitoringMixin, TestCase):
         dd = DeviceData(pk=d.pk)
         self.assertDictEqual(dd.data, data)
         if no_resources:
-            metric_count, chart_count = 6, 4
+            metric_count, chart_count = 4, 4
         else:
-            metric_count, chart_count = 9, 7
+            metric_count, chart_count = 7, 7
         self.assertEqual(Metric.objects.count(), metric_count)
         self.assertEqual(Chart.objects.count(), chart_count)
         if_dict = {'wlan0': data['interfaces'][0], 'wlan1': data['interfaces'][1]}
         for ifname in ['wlan0', 'wlan1']:
             iface = if_dict[ifname]
-            for field_name in ['rx_bytes', 'tx_bytes']:
-                m = Metric.objects.get(
-                    key=ifname, field_name=field_name, object_id=d.pk
-                )
-                points = m.read(limit=10, order='-time')
-                self.assertEqual(len(points), 1)
-                self.assertEqual(
-                    points[0][m.field_name], iface['statistics'][field_name]
-                )
+            m = Metric.objects.get(key=ifname, field_name='rx_bytes', object_id=d.pk)
+            points = m.read(limit=10, order='-time', extra_fields=['tx_bytes'])
+            self.assertEqual(len(points), 1)
+            for field in ['rx_bytes', 'tx_bytes']:
+                self.assertEqual(points[0][field], iface['statistics'][field])
             m = Metric.objects.get(key=ifname, field_name='clients', object_id=d.pk)
             points = m.read(limit=10, order='-time')
             self.assertEqual(len(points), len(iface['wireless']['clients']))

--- a/openwisp_monitoring/monitoring/metrics.py
+++ b/openwisp_monitoring/monitoring/metrics.py
@@ -12,17 +12,12 @@ DEFAULT_METRICS = {
         'field_name': 'reachable',
         'related_fields': ['loss', 'rtt_min', 'rtt_max', 'rtt_avg'],
     },
-    'traffic_rx_bytes': {
+    'traffic': {
         'label': _('Traffic'),
         'name': '{name}',
         'key': '{key}',
         'field_name': 'rx_bytes',
-    },
-    'traffic_tx_bytes': {
-        'label': _('Traffic'),
-        'name': '{name}',
-        'key': '{key}',
-        'field_name': 'tx_bytes',
+        'related_fields': ['tx_bytes'],
     },
     'clients': {
         'label': _('Clients'),

--- a/openwisp_monitoring/monitoring/migrations/0014_merge_traffic_metrics.py
+++ b/openwisp_monitoring/monitoring/migrations/0014_merge_traffic_metrics.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+from swapper import load_model
+
+
+def merge_traffic_metrics(apps, schema_editor):
+    Metric = load_model('monitoring', 'Metric')
+    Chart = load_model('monitoring', 'Chart')
+    rx_metrics = Metric.objects.filter(field_name='rx_bytes')
+    for rx_metric in rx_metrics:
+        # Traffic chart is created with tx_bytes metric
+        tx_metric = Metric.objects.get(name=f'{rx_metric.name.split()[0]} tx_bytes')
+        chart = Chart.objects.get(metric=tx_metric)
+        new_name = f'{rx_metric.name.split()[0]} traffic'
+        print(f'Renamed metric "{rx_metric.name}" to "{new_name}"')
+        rx_metric.name = new_name
+        rx_metric.save()
+        chart.metric = rx_metric
+        chart.save()
+        tx_metric.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('monitoring', '0013_metric_configuration'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            merge_traffic_metrics, reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
Closes #133
* I have created a migration script to delete traffic metrics (just in case there are too many interfaces so to avoid doing it manually)
* The new metric created automatically is able to communicate with the old measurement (thus the new chart is able to display old data, no data loss I mean :) )