### PR TITLE
[timeseries] Refactor order parameter to only allow 'time' / '-time'

### DIFF
--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -146,6 +146,16 @@ class DatabaseClient(object):
             conditions = 'WHERE %s' % ' AND '.join(conditions)
             q = f'{q} {conditions}'
         if order:
+            # InfluxDB only allows ordering results by time
+            if order == 'time':
+                order = 'time ASC'
+            elif order == '-time':
+                order = 'time DESC'
+            else:
+                raise self.client_error(
+                    f'Invalid order "{order}" passed.\nYou may pass "time" / "-time" to get '
+                    'result sorted in ascending /descending order respectively.'
+                )
             q = f'{q} ORDER BY {order}'
         if limit:
             q = f'{q} LIMIT {limit}'

--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -63,13 +63,13 @@ class DeviceMonitoringTestCase(TestDeviceMonitoringMixin, TestCase):
                 m = Metric.objects.get(
                     key=ifname, field_name=field_name, object_id=d.pk
                 )
-                points = m.read(limit=10, order='time DESC')
+                points = m.read(limit=10, order='-time')
                 self.assertEqual(len(points), 1)
                 self.assertEqual(
                     points[0][m.field_name], iface['statistics'][field_name]
                 )
             m = Metric.objects.get(key=ifname, field_name='clients', object_id=d.pk)
-            points = m.read(limit=10, order='time DESC')
+            points = m.read(limit=10, order='-time')
             self.assertEqual(len(points), len(iface['wireless']['clients']))
         return dd
 

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -84,12 +84,12 @@ class TestDeviceApi(DeviceMonitoringTestCase):
                 m = Metric.objects.get(
                     key=ifname, field_name=field_name, object_id=d.pk
                 )
-                points = m.read(limit=10, order='time DESC')
+                points = m.read(limit=10, order='-time')
                 self.assertEqual(len(points), 2)
                 expected = iface['statistics'][field_name] - points[1][m.field_name]
                 self.assertEqual(points[0][m.field_name], expected)
             m = Metric.objects.get(key=ifname, field_name='clients', object_id=d.pk)
-            points = m.read(limit=10, order='time DESC')
+            points = m.read(limit=10, order='-time')
             self.assertEqual(len(points), len(iface['wireless']['clients']) * 2)
 
     def test_200_traffic_counter_reset(self):
@@ -115,12 +115,12 @@ class TestDeviceApi(DeviceMonitoringTestCase):
                 m = Metric.objects.get(
                     key=ifname, field_name=field_name, object_id=d.pk
                 )
-                points = m.read(limit=10, order='time DESC')
+                points = m.read(limit=10, order='-time')
                 self.assertEqual(len(points), 2)
                 expected = iface['statistics'][field_name]
                 self.assertEqual(points[0][m.field_name], expected)
             m = Metric.objects.get(key=ifname, field_name='clients', object_id=d.pk)
-            points = m.read(limit=10, order='time DESC')
+            points = m.read(limit=10, order='-time')
             self.assertEqual(len(points), len(iface['wireless']['clients']) * 2)
 
     def test_200_multiple_measurements(self):
@@ -133,14 +133,14 @@ class TestDeviceApi(DeviceMonitoringTestCase):
         }
         # wlan0 rx_bytes
         m = Metric.objects.get(key='wlan0', field_name='rx_bytes', object_id=dd.pk)
-        points = m.read(limit=10, order='time DESC')
+        points = m.read(limit=10, order='-time')
         self.assertEqual(len(points), 4)
         expected = [700000000, 100000000, 399999676, 324]
         for i, point in enumerate(points):
             self.assertEqual(point['rx_bytes'], expected[i])
         # wlan0 tx_bytes
         m = Metric.objects.get(key='wlan0', field_name='tx_bytes', object_id=dd.pk)
-        points = m.read(limit=10, order='time DESC')
+        points = m.read(limit=10, order='-time')
         self.assertEqual(len(points), 4)
         expected = [300000000, 200000000, 99999855, 145]
         for i, point in enumerate(points):
@@ -153,14 +153,14 @@ class TestDeviceApi(DeviceMonitoringTestCase):
         self.assertEqual(data['traces'][1][1][-1], 0.6)
         # wlan1 rx_bytes
         m = Metric.objects.get(key='wlan1', field_name='rx_bytes', object_id=dd.pk)
-        points = m.read(limit=10, order='time DESC')
+        points = m.read(limit=10, order='-time')
         self.assertEqual(len(points), 4)
         expected = [1000000000, 0, 1999997725, 2275]
         for i, point in enumerate(points):
             self.assertEqual(point['rx_bytes'], expected[i])
         # wlan1 tx_bytes
         m = Metric.objects.get(key='wlan1', field_name='tx_bytes', object_id=dd.pk)
-        points = m.read(limit=10, order='time DESC')
+        points = m.read(limit=10, order='-time')
         self.assertEqual(len(points), 4)
         expected = [500000000, 0, 999999174, 826]
         for i, point in enumerate(points):
@@ -383,14 +383,14 @@ class TestDeviceApi(DeviceMonitoringTestCase):
             del data['resources']['memory']['available']
             r = self._post_data(d.id, d.key, data)
             m = Metric.objects.get(key='memory')
-            metric_data = m.read(order='DESC', extra_fields='*')[0]
+            metric_data = m.read(order='-time', extra_fields='*')[0]
             self.assertAlmostEqual(metric_data['percent_used'], 0.09729, places=5)
             self.assertIsNone(metric_data.get('available_memory'))
             self.assertEqual(r.status_code, 200)
         with self.subTest('Test when available memory is less than free memory'):
             data['resources']['memory']['available'] = 2232664
             r = self._post_data(d.id, d.key, data)
-            metric_data = m.read(order='DESC', extra_fields='*')[0]
+            metric_data = m.read(order='-time', extra_fields='*')[0]
             self.assertAlmostEqual(metric_data['percent_used'], 0.09729, places=5)
             self.assertEqual(metric_data['available_memory'], 2232664)
             self.assertEqual(r.status_code, 200)
@@ -398,7 +398,7 @@ class TestDeviceApi(DeviceMonitoringTestCase):
             data['resources']['memory']['available'] = 225567664
             r = self._post_data(d.id, d.key, data)
             m = Metric.objects.get(key='memory')
-            metric_data = m.read(order='DESC', extra_fields='*')[0]
+            metric_data = m.read(order='-time', extra_fields='*')[0]
             self.assertAlmostEqual(metric_data['percent_used'], 0.09301, places=5)
             self.assertEqual(metric_data['available_memory'], 225567664)
             self.assertEqual(r.status_code, 200)

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -469,7 +469,7 @@ class AbstractAlertSettings(TimeStampedEditableModel):
             # retrieves latest measurements up to the maximum
             # threshold in seconds allowed plus a small margin
             since = 'now() - {0}s'.format(int(self._SECONDS_MAX * 1.05))
-            points = self.metric.read(since=since, limit=None, order='time DESC')
+            points = self.metric.read(since=since, limit=None, order='-time')
             # loop on each measurement starting from the most recent
             for i, point in enumerate(points):
                 # skip the first point because it was just added before this

--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -112,7 +112,7 @@ class TestModels(TestMonitoringMixin, TestCase):
         self.assertEqual(m.read()[0][m.field_name], 50)
         m.write(1, check=False)
         self.assertEqual(m.read()[0][m.field_name], 50)
-        self.assertEqual(m.read(order='time DESC')[0][m.field_name], 1)
+        self.assertEqual(m.read(order='-time')[0][m.field_name], 1)
 
     def test_read_object_metric(self):
         om = self._create_object_metric(name='load')


### PR DESCRIPTION
Please refer to https://github.com/openwisp/openwisp-monitoring/pull/142#discussion_r444553485