### PR TITLE
[admin] Fix crash due to showing unexisting description field

### DIFF
--- a/openwisp_monitoring/monitoring/admin.py
+++ b/openwisp_monitoring/monitoring/admin.py
@@ -29,18 +29,7 @@ class MetricAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
     save_on_top = True
     inlines = [ChartInline, AlertSettingsInline]
     fieldsets = [
-        (
-            None,
-            {
-                'fields': (
-                    'name',
-                    'description',
-                    'content_type',
-                    'object_id',
-                    'configuration',
-                )
-            },
-        ),
+        (None, {'fields': ('name', 'content_type', 'object_id', 'configuration',)},),
         (
             _('Advanced options'),
             {'classes': ('collapse',), 'fields': ('key', 'field_name')},

--- a/openwisp_monitoring/monitoring/tests/test_admin.py
+++ b/openwisp_monitoring/monitoring/tests/test_admin.py
@@ -1,0 +1,20 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from . import TestMonitoringMixin
+
+
+class TestAdmin(TestMonitoringMixin, TestCase):
+
+    def _login_admin(self):
+        User = get_user_model()
+        u = User.objects.create_superuser('admin', 'admin', 'test@test.com')
+        self.client.force_login(u)
+
+    def test_metric_admin(self):
+        m = self._create_general_metric()
+        url = reverse('admin:monitoring_metric_change', args=[m.pk])
+        self._login_admin()
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
Fixed crash when viewing the Metric detail page. The description column was removed in 03097f8fba05644c784ab4321225f388a70104fd

```
Traceback (most recent call last):
  File "/home/pablo/.virtualenvs/openwisp-monitoring/lib/python3.6/site-packages/django/contrib/admin/options.py", line 702, in get_form
    return modelform_factory(self.model, **defaults)
  File "/home/pablo/.virtualenvs/openwisp-monitoring/lib/python3.6/site-packages/django/forms/models.py", line 554, in modelform_factory
    return type(form)(class_name, (form,), form_class_attrs)
  File "/home/pablo/.virtualenvs/openwisp-monitoring/lib/python3.6/site-packages/django/forms/models.py", line 267, in __new__
    raise FieldError(message)
django.core.exceptions.FieldError: Unknown field(s) (description) specified for Metric
```