### PR TITLE
[fix] Do not call update_status directly if any check is present

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -345,6 +345,13 @@ or to send monitoring metrics).
 
 This feature is enabled by default.
 
+If you use OpenVPN as the management VPN, you may want to check out a similar
+integration built in **openwisp-network-topology**: when the status of an OpenVPN link
+changes (detected by monitoring the status information of OpenVPN), the
+network topology module will trigger the monitoring checks.
+For more information see:
+`Network Topology Device Integration <https://github.com/openwisp/openwisp-network-topology#integration-with-openwisp-controller-and-openwisp-monitoring>`_
+
 ``OPENWISP_MONITORING_CHARTS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/openwisp_monitoring/device/tasks.py
+++ b/openwisp_monitoring/device/tasks.py
@@ -5,17 +5,20 @@ from ..check.tasks import perform_check
 
 
 @shared_task
-def trigger_device_checks(pk):
+def trigger_device_checks(pk, recovery=True):
     """
     Retrieves all related checks to the passed ``device``
     and calls the ``perform_check`` task from each of them.
-    If no check exists changes the status to ``OK``.
+    If no check exists changes the status according to the
+    ``recovery`` argument.
     """
     DeviceData = load_model('device_monitoring', 'DeviceData')
     device = DeviceData.objects.get(pk=pk)
     checks = device.checks.filter(active=True).only('id').values('id')
+    has_checks = False
     for check in checks:
         perform_check.delay(check['id'])
-    # if there's no available check for this device, we'll flag it as OK directly
-    else:
-        device.monitoring.update_status('ok')
+        has_checks = True
+    if not has_checks:
+        status = 'ok' if recovery else 'critical'
+        device.monitoring.update_status(status)


### PR DESCRIPTION
Added recovery argument to allow to be used also as a way to signal device issues.
Needed for https://github.com/openwisp/openwisp-network-topology/issues/75

Added mention of this integration in the README.
Will test this manually soon and then merge.

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)
