### PR TITLE
[fix] Avoid register_chart, unregister chart import while apps are being loaded

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -484,7 +484,7 @@ An example usage has been shown below.
 
 .. code-block:: python
 
-    from openwisp_monitoring.monitoring import register_chart
+    from openwisp_monitoring.monitoring.charts import register_chart
 
     # Define configuration of your chart
     chart_config = {
@@ -523,7 +523,7 @@ An example usage is shown below.
 
 .. code-block:: python
 
-    from openwisp_monitoring.monitoring import unregister_chart
+    from openwisp_monitoring.monitoring.charts import unregister_chart
 
     # Unregister previously registered chart configuration
     unregister_chart('chart_name')

--- a/openwisp_monitoring/monitoring/__init__.py
+++ b/openwisp_monitoring/monitoring/__init__.py
@@ -1,3 +1,1 @@
-from .charts import register_chart, unregister_chart  # noqa
-
 default_app_config = 'openwisp_monitoring.monitoring.apps.MonitoringConfig'

--- a/openwisp_monitoring/monitoring/tests/__init__.py
+++ b/openwisp_monitoring/monitoring/tests/__init__.py
@@ -7,7 +7,7 @@ from openwisp_users.tests.utils import TestOrganizationMixin
 
 from ...db import timeseries_db
 from ...db.backends import TIMESERIES_DB
-from .. import register_chart, unregister_chart
+from ..charts import register_chart, unregister_chart
 
 start_time = now()
 ten_minutes_ago = start_time - timedelta(minutes=10)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [ ] I have manually tested the proposed changes (**can't reproduce locally**)
- [ ] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)

Closes #174
