### PR TITLE
[celery] Make tasks resilient to failures #181

### DIFF
--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -11,6 +11,7 @@ from openwisp_controller.connection.tests.base import CreateConnectionsMixin
 from openwisp_utils.tests import catch_signal
 
 from ..signals import health_status_changed
+from ..tasks import trigger_device_checks
 from . import DeviceMonitoringTestCase
 
 Check = load_model('check', 'Check')
@@ -459,6 +460,12 @@ class TestDeviceData(BaseTestCase):
             del data['resources']['disk']
             dd.data = data
             dd.validate_data()
+
+    @patch('logging.Logger.warning')
+    def test_trigger_device_checks_task_resiliency(self, mock):
+        dd = DeviceData(name='Test Device')
+        trigger_device_checks.delay(dd.pk)
+        mock.assert_called_with(f'The device with uuid {dd.pk} has been deleted')
 
 
 class TestDeviceMonitoring(CreateConnectionsMixin, BaseTestCase):


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes

Steps followed,
1) Added a `time.sleep` of 20s in `perform_check`
2) Created a check (say `Test Resiliency`)
3) triggered `perform_check` for `Test Resiliency` check
4) while the task was frozen for **20s** (due to step 1), deleted the check `Test Resiliency`
5) After sleep duration got over celery worker info showed as below (*exception is caught* and *warning logged*):~
![Screenshot from 2020-08-12 01-38-13](https://user-images.githubusercontent.com/54471024/89944286-2e87f800-dc3d-11ea-9f73-30e82f41c28e.png)

- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)


Closes #181