### PR TITLE
[chores] Made unregistering "default" notification type resilient to failure

### DIFF
--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models.signals import post_delete, post_save
 from django.utils.translation import gettext_lazy as _
 from openwisp_notifications.signals import notify
@@ -179,7 +180,10 @@ class DeviceMonitoringConfig(AppConfig):
                 ),
             },
         )
-        unregister_notification_type('default')
+        try:
+            unregister_notification_type('default')
+        except ImproperlyConfigured:
+            pass
 
     @classmethod
     def connect_config_modified(cls):

--- a/tests/openwisp2/sample_device_monitoring/tests.py
+++ b/tests/openwisp2/sample_device_monitoring/tests.py
@@ -49,7 +49,7 @@ class TestAdmin(BaseTestAdmin):
 
 
 class TestDeviceNotifications(BaseTestDeviceNotifications):
-    pass
+    app_label = 'sample_device_monitoring'
 
 
 # this is necessary to avoid excuting the base test suites


### PR DESCRIPTION
Added object notification widget for DeviceAdmin which enables user
to disable notification for that device.

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
