### PR TITLE
[fix] Fixed tolerance to be checked in minutes and not seconds #219

### DIFF
--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -548,7 +548,7 @@ class AbstractAlertSettings(TimeStampedEditableModel):
         return getattr(current_value, method)(threshold_value)
 
     def _time_crossed(self, time):
-        threshold_time = timezone.now() - timedelta(seconds=self.tolerance)
+        threshold_time = timezone.now() - timedelta(minutes=self.tolerance)
         return time < threshold_time
 
     def _is_crossed_by(self, current_value, time=None, retention_policy=None):
@@ -562,8 +562,8 @@ class AbstractAlertSettings(TimeStampedEditableModel):
             return True
         if time is None:
             # retrieves latest measurements up to the maximum
-            # threshold in seconds allowed plus a small margin
-            since = f'now() - {int(self._MINUTES_MAX * 1.05)}s'
+            # threshold in minutes allowed plus a small margin
+            since = f'now() - {int(self._MINUTES_MAX * 1.05)}m'
             points = self.metric.read(
                 since=since,
                 limit=None,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)

* Fixed comparison and retrieval of metrics from timeseries database which was still taking place in seconds.
* Updated the two existing tests and added a new test which (tests tolerance and) will now fail without the fix.
* Double checked if any other instances were left out in the tests to be converted from seconds to minutest at https://github.com/openwisp/openwisp-monitoring/commit/791b7cd7b122d5078700484417c3d5a0f4b346de

Closes #219