### PR TITLE
[deps] Upgrade InfluxDB python library to 5.3 #191

### DIFF
--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -284,17 +284,17 @@ class TestDeviceApi(DeviceMonitoringTestCase):
                 '2',
                 '0.4',
                 '0.1',
-                '2',
-                '1',
+                '2.0',
+                '1.0',
                 '9.73',
-                '0',
+                '0.0',
                 '8.27',
             ],
         )
         self.assertEqual(rows[-4].strip(), '')
         self.assertEqual(rows[-3].strip(), 'Histogram')
-        self.assertEqual(rows[-2].strip().split(','), ['ssh', '100'])
-        self.assertEqual(rows[-1].strip().split(','), ['http2', '90'])
+        self.assertEqual(rows[-2].strip().split(','), ['ssh', '100.0'])
+        self.assertEqual(rows[-1].strip().split(','), ['http2', '90.0'])
 
     def test_histogram_csv_none_value(self):
         d = self._create_device(organization=self._create_org())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openwisp-controller~=0.7.post1
-influxdb>=5.2,<5.3
+influxdb~=5.3
 django-notifications-hq>=1.6,<1.7
 django-celery-email>=3.0.0,<3.1
 djangorestframework>=3.11,<3.12


### PR DESCRIPTION
Closes #191

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [ ] ~~I have written new test cases to avoid regressions (if necessary)~~
- [ ] ~~I have updated the documentation (e.g. README.rst)~~

Read the change log at https://github.com/influxdata/influxdb-python/blob/master/CHANGELOG.md#v530---2020-04-10.
There seem no breaking change and did a manual testing of the influxdb methods we are using in the tsdb client.

Also, there seems to be an improvement where we can pass in the time-precision of the timestamp we want in the latest version, noting here for future refs.

:warning: To be merged after #228.