### PR TITLE
[fix] Ensure background tasks are executed on transaction commit

### DIFF
--- a/openwisp_monitoring/device/models.py
+++ b/openwisp_monitoring/device/models.py
@@ -1,8 +1,8 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from swapper import get_model_name, swappable_setting
 
+from ..utils import load_model_patched
 from .base.models import AbstractDeviceData, AbstractDeviceMonitoring
-from .utils import load_model_patched
 
 BaseDevice = load_model_patched('config', 'Device', require_ready=False)
 

--- a/openwisp_monitoring/device/tests/test_transactions.py
+++ b/openwisp_monitoring/device/tests/test_transactions.py
@@ -1,0 +1,179 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+from openwisp_notifications.signals import notify
+from swapper import load_model
+
+from openwisp_controller.config.signals import config_modified
+from openwisp_controller.connection.tests.base import CreateConnectionsMixin
+from openwisp_utils.tests import catch_signal
+
+from ...check.classes import Ping
+from ...check.tests import _FPING_REACHABLE, _FPING_UNREACHABLE
+from ..tasks import trigger_device_checks
+from . import DeviceMonitoringTransactionTestcase
+
+Check = load_model('check', 'Check')
+DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
+DeviceConnection = load_model('connection', 'DeviceConnection')
+Credentials = load_model('connection', 'Credentials')
+Check = load_model('check', 'Check')
+
+
+class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestcase):
+    def _delete_non_ping_checks(self):
+        Check.objects.exclude(name='Ping').delete()
+        self.assertEqual(Check.objects.count(), 1)
+
+    @patch('openwisp_monitoring.check.tasks.perform_check.delay')
+    def test_config_modified_receiver(self, mock_method):
+        c = self._create_config(status='applied', organization=self._create_org())
+        c.config = {'general': {'description': 'test'}}
+        c.full_clean()
+        with catch_signal(config_modified) as handler:
+            c.save()
+            handler.assert_called_once()
+        self.assertEqual(c.status, 'modified')
+        self.assertEqual(mock_method.call_count, 1)
+
+    @patch.object(Ping, '_command', return_value=_FPING_REACHABLE)
+    def test_trigger_device_recovery_task(self, mocked_method):
+        d = self._create_device(organization=self._create_org())
+        d.management_ip = '10.40.0.5'
+        d.save()
+        data = self._data()
+        # Creation of resources, clients and traffic metrics can be avoided here
+        # as they are not involved. This speeds up the test by reducing requests made.
+        del data['resources']
+        del data['interfaces']
+        self._delete_non_ping_checks()
+        d.monitoring.update_status('critical')
+        url = reverse('monitoring:api_device_metric', args=[d.pk.hex])
+        url = '{0}?key={1}'.format(url, d.key)
+        with patch.object(Check, 'perform_check') as mock:
+            self._post_data(d.id, d.key, data)
+            mock.assert_called_once()
+
+    @patch.object(Ping, '_command', return_value=_FPING_UNREACHABLE)
+    @patch.object(DeviceMonitoring, 'update_status')
+    def test_trigger_device_recovery_task_regression(
+        self, mocked_update_status, mocked_ping
+    ):
+        dm = self._create_device_monitoring()
+        dm.device.management_ip = None
+        dm.device.save()
+        trigger_device_checks.delay(dm.device.pk)
+        self.assertTrue(Check.objects.exists())
+        # we expect update_status() to be called once (by the check)
+        # and not a second time directly by our code
+        mocked_update_status.assert_called_once()
+
+    @patch.object(Check, 'perform_check')
+    @patch.object(notify, 'send')
+    def test_is_working_false_true(self, notify_send, perform_check):
+        d = self._create_device()
+        dm = d.monitoring
+        dm.status = 'unknown'
+        dm.save()
+        self._delete_non_ping_checks()
+        c = Credentials.objects.create()
+        dc = DeviceConnection.objects.create(credentials=c, device=d, is_working=False)
+        self.assertFalse(dc.is_working)
+        dc.is_working = True
+        dc.save()
+        perform_check.assert_called_once()
+        notify_send.assert_called_once()
+
+    @patch.object(Check, 'perform_check')
+    @patch.object(notify, 'send')
+    def test_is_working_changed_to_false(self, notify_send, perform_check):
+        d = self._create_device()
+        dm = d.monitoring
+        dm.status = 'ok'
+        dm.save()
+        self._delete_non_ping_checks()
+        c = Credentials.objects.create()
+        dc = DeviceConnection.objects.create(credentials=c, device=d)
+        dc.is_working = False
+        dc.save()
+        perform_check.assert_called_once()
+        notify_send.assert_called_once()
+
+    @patch.object(Check, 'perform_check')
+    @patch.object(notify, 'send')
+    def test_is_working_none_true(self, notify_send, perform_check):
+        d = self._create_device()
+        dm = d.monitoring
+        dm.status = 'unknown'
+        dm.save()
+        self._delete_non_ping_checks()
+        c = Credentials.objects.create()
+        dc = DeviceConnection.objects.create(credentials=c, device=d)
+        self.assertIsNone(dc.is_working)
+        dc.is_working = True
+        dc.save()
+        notify_send.assert_not_called()
+        perform_check.assert_not_called()
+
+    @patch.object(Check, 'perform_check')
+    @patch.object(notify, 'send')
+    def test_is_working_changed_unable_to_connect(self, notify_send, perform_check):
+        ckey = self._create_credentials_with_key(port=self.ssh_server.port)
+        dc = self._create_device_connection(credentials=ckey)
+        dc.is_working = True
+        dc.save()
+        notify_send.assert_not_called()
+        perform_check.assert_not_called()
+
+        d = self.device_model.objects.first()
+        d.monitoring.update_status('ok')
+        self._delete_non_ping_checks()
+        dc.is_working = False
+        dc.failure_reason = '[Errno None] Unable to connect to port 5555 on 127.0.0.1'
+        dc.full_clean()
+        dc.save()
+
+        notify_send.assert_not_called()
+        perform_check.assert_not_called()
+
+    @patch.object(Check, 'perform_check')
+    @patch.object(notify, 'send')
+    def test_is_working_changed_timed_out(self, notify_send, perform_check):
+        ckey = self._create_credentials_with_key(port=self.ssh_server.port)
+        dc = self._create_device_connection(credentials=ckey)
+        dc.is_working = True
+        dc.save()
+        notify_send.assert_not_called()
+        perform_check.assert_not_called()
+
+        d = self.device_model.objects.first()
+        d.monitoring.update_status('ok')
+        self._delete_non_ping_checks()
+        dc.is_working = False
+        dc.failure_reason = 'timed out'
+        dc.full_clean()
+        dc.save()
+
+        notify_send.assert_not_called()
+        perform_check.assert_not_called()
+
+    @patch.object(Check, 'perform_check')
+    @patch.object(notify, 'send')
+    def test_is_working_no_recovery_notification(self, notify_send, perform_check):
+        ckey = self._create_credentials_with_key(port=self.ssh_server.port)
+        dc = self._create_device_connection(credentials=ckey, is_working=True)
+        d = self.device_model.objects.first()
+        d.monitoring.update_status('ok')
+        dc.refresh_from_db()
+        self._delete_non_ping_checks()
+        failure_reason = '[Errno None] Unable to connect to port 5555 on 127.0.0.1'
+        self.assertTrue(dc.is_working)
+        dc.failure_reason = failure_reason
+        dc.is_working = False
+        dc.save()
+        # Recovery is made
+        dc.failure_reason = ''
+        dc.is_working = True
+        dc.save()
+        notify_send.assert_not_called()
+        perform_check.assert_not_called()

--- a/openwisp_monitoring/device/utils.py
+++ b/openwisp_monitoring/device/utils.py
@@ -1,6 +1,3 @@
-from django.apps import apps
-from swapper import is_swapped, split
-
 from ..db import timeseries_db
 from . import settings as app_settings
 
@@ -17,13 +14,3 @@ def manage_short_retention_policy():
     """
     duration = app_settings.SHORT_RETENTION_POLICY
     timeseries_db.create_or_alter_retention_policy(SHORT_RP, duration)
-
-
-def load_model_patched(app_label, model, require_ready=True):
-    """
-    TODO: remove if https://github.com/wq/django-swappable-models/pull/23 gets merged
-    """
-    swapped = is_swapped(app_label, model)
-    if swapped:
-        app_label, model = split(swapped)
-    return apps.get_model(app_label, model, require_ready=require_ready)

--- a/openwisp_monitoring/utils.py
+++ b/openwisp_monitoring/utils.py
@@ -1,0 +1,18 @@
+from django.apps import apps
+from django.db import transaction
+from swapper import is_swapped, split
+
+
+def transaction_on_commit(func):
+    with transaction.atomic():
+        transaction.on_commit(func)
+
+
+def load_model_patched(app_label, model, require_ready=True):
+    """
+    TODO: remove if https://github.com/wq/django-swappable-models/pull/23 gets merged
+    """
+    swapped = is_swapped(app_label, model)
+    if swapped:
+        app_label, model = split(swapped)
+    return apps.get_model(app_label, model, require_ready=require_ready)

--- a/tests/openwisp2/sample_device_monitoring/models.py
+++ b/tests/openwisp2/sample_device_monitoring/models.py
@@ -6,7 +6,7 @@ from openwisp_monitoring.device.base.models import (
     AbstractDeviceData,
     AbstractDeviceMonitoring,
 )
-from openwisp_monitoring.device.utils import load_model_patched
+from openwisp_monitoring.utils import load_model_patched
 
 BaseDevice = load_model_patched('config', 'Device', require_ready=False)
 

--- a/tests/openwisp2/sample_device_monitoring/tests.py
+++ b/tests/openwisp2/sample_device_monitoring/tests.py
@@ -18,6 +18,9 @@ from openwisp_monitoring.device.tests.test_recovery import (
 from openwisp_monitoring.device.tests.test_settings import (
     TestSettings as BaseTestSettings,
 )
+from openwisp_monitoring.device.tests.test_transactions import (
+    TestTransactions as BaseTestTransactions,
+)
 
 
 class TestRecovery(BaseTestRecovery):
@@ -34,6 +37,10 @@ class TestDeviceMonitoring(BaseTestDeviceMonitoring):
         dm = d.monitoring
         self.assertEqual(dm.details, 'devicemonitoring')
         self.assertEqual(str(dm), 'devicemonitoring')
+
+
+class TestTransactions(BaseTestTransactions):
+    pass
 
 
 class TestSettings(BaseTestSettings):
@@ -61,3 +68,4 @@ del BaseTestSettings
 del BaseTestDeviceApi
 del BaseTestAdmin
 del BaseTestDeviceNotifications
+del BaseTestTransactions


### PR DESCRIPTION
Many tasks were being called without transaction.on_commit,
which does not guarantee the tasks will be executed after
changes have been committed to the database, which in turn
leads to inconsistent results.