### PR TITLE
[deps] Add support for Django 3.1 #225

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ python:
   - "3.7"
 
 env:
-  - DJANGO="django>=2.2,<3.0"
-  - DJANGO="django>=3.0,<3.1"
+  - DJANGO="django~=2.2"
+  - DJANGO="django~=3.0"
+  - DJANGO="django~=3.1"
 
 addons:
   apt:
@@ -34,8 +35,8 @@ branches:
 before_install:
   - docker run -d --name influxdb -e INFLUXDB_DB=openwisp2 -p 8086:8086 influxdb:alpine
   - pip install -U pip wheel setuptools
-  - pip install $DJANGO
   - pip install -U -r requirements-test.txt
+  - pip install -U $DJANGO
 
 install:
   - pip install -e .

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -450,10 +450,9 @@ class AbstractChart(TimeStampedEditableModel):
             # unit needs to be passed for chart_inline
             data = self.read(time=time)
             data.update({'unit': self.unit})
-            return json.dumps(data, **kwargs)
-        except KeyError:
-            # TODO: this should be improved
-            pass
+            return json.dumps(data, **kwargs, default=str)
+        except KeyError as e:
+            logger.warning(f'Got KeyError in Chart.json method: {e}')
 
     @staticmethod
     def _round(value, decimal_places):


### PR DESCRIPTION
Closes #225

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [ ] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)

Work in Progress
* :warning: I found a potential bug while testing the front-end.
Traffic metric's metric admin is crashing when opened up :(
Below code is causing the issue (exception message is "it is not JSON serializable"), I couldn't figure out on a quick glance since all other metric admins are opening up and `ipdb` showed path followed and data serialized is almost similar. Will dig deeper.
https://github.com/openwisp/openwisp-monitoring/blob/7c66bada52b00237a986ed626b6c72c864d58c11/openwisp_monitoring/monitoring/base/models.py#L448-L453
* Django 3.1 also brings in left-pane in admin which I think shall be taken care of by **openwisp-utils==0.6.3**
* One more thing, observed a deprecation warning for `openwisp-controller`
![Screenshot from 2020-09-02 18-18-11](https://user-images.githubusercontent.com/54471024/91990687-a7b3d000-ed4f-11ea-8146-f5e9aca038d6.png)
