### PR TITLE
[change] Support tolerance in both directions #234

### DIFF
--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -303,3 +303,16 @@ class TestModels(TestMonitoringMixin, TestCase):
             m.write(71, time=timezone.now() - timedelta(minutes=7))
             self.assertTrue(m.is_healthy)
             self.assertEqual(Notification.objects.count(), 2)
+
+    def test_time_crossed(self):
+        m = self._create_general_metric(name='load')
+        a = self._create_alert_settings(
+            metric=m, custom_operator='>', custom_threshold=90, custom_tolerance=5
+        )
+
+        now = timezone.now()
+        self.assertFalse(a._time_crossed(now))
+        self.assertFalse(a._time_crossed(now - timedelta(minutes=1)))
+        self.assertFalse(a._time_crossed(now - timedelta(minutes=4)))
+        self.assertTrue(a._time_crossed(now - timedelta(minutes=5)))
+        self.assertTrue(a._time_crossed(now - timedelta(minutes=6)))


### PR DESCRIPTION
- if a metric is flapping during the tolerated interval, the system will not trigger status changes
- if a metric is not flapping, the system will trigger a status change, whether recovery or not

Before this change, recoveries did not respect the tolerance, causing the generation of many alerts on flapping metrics.

Closes #234

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
