### PR TITLE
[ci] Bind pip to 20.2.4 to avoid new dependency resolution algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
 
 before_install:
   - docker run -d --name influxdb -e INFLUXDB_DB=openwisp2 -p 8086:8086 influxdb:alpine
-  - pip install -U pip wheel setuptools
+  - pip install -U "pip==20.2.4" wheel setuptools
   - pip install -U -r requirements-test.txt
   - pip install -U $DJANGO
 


### PR DESCRIPTION
Temporary workaround to gain more time.