### PR TITLE
[fix] Fix random SynchronousOnlyOperation in celery tasks #249

### DIFF
--- a/openwisp_monitoring/check/tasks.py
+++ b/openwisp_monitoring/check/tasks.py
@@ -7,6 +7,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from swapper import load_model
 
+from ..utils import fix_async
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,11 +43,11 @@ def perform_check(uuid):
     and calls ``check.perform_check()``
     """
     try:
-        check = get_check_model().objects.get(pk=uuid)
+        check = fix_async(lambda: get_check_model().objects.get(pk=uuid))
     except ObjectDoesNotExist:
         logger.warning(f'The check with uuid {uuid} has been deleted')
         return
-    result = check.perform_check()
+    result = fix_async(lambda: check.perform_check())
     if settings.DEBUG:  # pragma: nocover
         print(json.dumps(result, indent=4, sort_keys=True))
 


### PR DESCRIPTION
When using gevent as a concurrency pool for celery,
SynchronousOnlyOperation exception may be run,
but not always, only in a minority of cases,
so this patch tries to run the code normally and
only if the exception is raised it will re-run the
code through asgiref.sync.sync_to_async.

Fixes #249

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [ ] I have manually tested the proposed changes - I am testing this
- [ ] ~~I have written new test cases to avoid regressions (if necessary)~~ N/A
- [ ] ~~I have updated the documentation (e.g. README.rst)~~ N/A
