### PR TITLE
[ci] Temporarily bind to influxdb:1.8.4-alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         ports:
           - 6379:6379
       influxdb:
-        image: influxdb:alpine
+        image: influxdb:1.8.4-alpine
         options: >-
           --name "influxdb"
         ports:


### PR DESCRIPTION
The build is failing and I think it's because a new version of influxdb (2.0) has been released to the docker images and this new version has a stricter default configuration regarding authentication.