### PR TITLE
[change] ConfigApplied triggered on config_status_changed instead of config_modified

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -431,6 +431,11 @@ is running and applying configuration changes in a timely manner.
 You may choose to disable auto creation of this check by using the
 setting `OPENWISP_MONITORING_AUTO_DEVICE_CONFIG_CHECK <#OPENWISP_MONITORING_AUTO_DEVICE_CONFIG_CHECK>`_.
 
+This check runs periodically, but it is also triggered whenever the
+configuration status of a device changes, this ensures the check reacts
+quickly to events happening in the network and informs the user promptly
+if there's anything that is not working as intended.
+
 Settings
 --------
 

--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -5,7 +5,7 @@ from django.db.models.signals import post_delete, post_save
 from django.utils.translation import gettext_lazy as _
 from swapper import load_model
 
-from openwisp_controller.config.signals import checksum_requested, config_modified
+from openwisp_controller.config.signals import checksum_requested, config_status_changed
 from openwisp_controller.connection import settings as connection_settings
 from openwisp_controller.connection.signals import is_working_changed
 
@@ -25,7 +25,7 @@ class DeviceMonitoringConfig(AppConfig):
         manage_short_retention_policy()
         self.connect_is_working_changed()
         self.connect_device_signals()
-        self.connect_config_modified()
+        self.connect_config_status_changed()
         self.device_recovery_detection()
         self.set_update_config_model()
 
@@ -144,18 +144,18 @@ class DeviceMonitoringConfig(AppConfig):
                 device_monitoring.update_status(status)
 
     @classmethod
-    def connect_config_modified(cls):
+    def connect_config_status_changed(cls):
         Config = load_model('config', 'Config')
 
         if check_settings.AUTO_CONFIG_CHECK:
-            config_modified.connect(
-                cls.config_modified_receiver,
+            config_status_changed.connect(
+                cls.config_status_changed_receiver,
                 sender=Config,
-                dispatch_uid='config_modified',
+                dispatch_uid='monitoring.config_status_changed_receiver',
             )
 
     @classmethod
-    def config_modified_receiver(cls, sender, instance, **kwargs):
+    def config_status_changed_receiver(cls, sender, instance, **kwargs):
         from ..check.tasks import perform_check
 
         DeviceData = load_model('device_monitoring', 'DeviceData')

--- a/openwisp_monitoring/device/tests/test_transactions.py
+++ b/openwisp_monitoring/device/tests/test_transactions.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from openwisp_notifications.signals import notify
 from swapper import load_model
 
-from openwisp_controller.config.signals import config_modified
+from openwisp_controller.config.signals import config_status_changed
 from openwisp_controller.connection.tests.base import CreateConnectionsMixin
 from openwisp_utils.tests import catch_signal
 
@@ -26,11 +26,11 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
         self.assertEqual(Check.objects.count(), 1)
 
     @patch('openwisp_monitoring.check.tasks.perform_check.delay')
-    def test_config_modified_receiver(self, mock_method):
+    def test_config_status_changed_receiver(self, mock_method):
         c = self._create_config(status='applied', organization=self._create_org())
         c.config = {'general': {'description': 'test'}}
         c.full_clean()
-        with catch_signal(config_modified) as handler:
+        with catch_signal(config_status_changed) as handler:
             c.save()
             handler.assert_called_once()
         self.assertEqual(c.status, 'modified')


### PR DESCRIPTION
It does not make sense to trigger this check when the config is modified,
because the result will be always that config.status == 'modified'.
Moreover, due to the recent changes in openwisp-controller,
this action can now be executed also when a config has been just created
and m2m templates are added to it.

Rather than changing the code to check whether the signal is being
sent from m2m changes or not, it is a lot more useful to just
switch to the config_status_changed signal, which will trigger
the check also when the configuration is flagged as applied by
the system, making the check a lot more proactive.

Checks:

- [x] I have manually tested the proposed changes
- [x] I have updated the documentation (e.g. README.rst)
- [x] I have written new test cases to avoid regressions (if necessary)