### PR TITLE
[change] Changed default alert settings for disk, cpu, memory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -674,7 +674,7 @@ For example, if you want to change only the default alert settings of
 
     OPENWISP_MONITORING_METRICS = {
         'memory': {
-            'alert_settings': {'threshold': 75, 'tolerance': 5}
+            'alert_settings': {'threshold': 75, 'tolerance': 10}
         },
     }
 

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -213,7 +213,7 @@ DEFAULT_METRICS = {
                 'query': chart_query['disk'],
             }
         },
-        'alert_settings': {'operator': '>', 'threshold': 80, 'tolerance': 0},
+        'alert_settings': {'operator': '>', 'threshold': 90, 'tolerance': 0},
         'notification': {
             'problem': {
                 'verbose_name': 'Disk usage PROBLEM',
@@ -268,7 +268,7 @@ DEFAULT_METRICS = {
                 'query': chart_query['memory'],
             }
         },
-        'alert_settings': {'operator': '>', 'threshold': 95, 'tolerance': 0},
+        'alert_settings': {'operator': '>', 'threshold': 95, 'tolerance': 5},
         'notification': {
             'problem': {
                 'verbose_name': 'Memory usage PROBLEM',
@@ -318,7 +318,7 @@ DEFAULT_METRICS = {
                 'query': chart_query['cpu'],
             }
         },
-        'alert_settings': {'operator': '>', 'threshold': 90, 'tolerance': 0},
+        'alert_settings': {'operator': '>', 'threshold': 90, 'tolerance': 5},
         'notification': {
             'problem': {
                 'verbose_name': 'CPU usage PROBLEM',


### PR DESCRIPTION
Added a default 5 minutes tolerance to CPU and memory.
Increased disk threshold value from 80% to 90% since some device models
have limited flash and would trigger the alert in many cases.

Will be testing this in the coming days.

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)
