### PR TITLE
[fix] Use REDIS_HOST in CHANNEL_LAYERS in test app

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -183,7 +183,7 @@ else:
     CHANNEL_LAYERS = {
         'default': {
             'BACKEND': 'channels_redis.core.RedisChannelLayer',
-            'CONFIG': {'hosts': ['redis://localhost/7']},
+            'CONFIG': {'hosts': [f'redis://{redis_host}/7']},
         }
     }
 


### PR DESCRIPTION
CHANNEL_LAYERS was not using REDIS_HOST env var