### PR TITLE
[fix] Skip retry for writing metrics beyond retention policy

### DIFF
--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -124,6 +124,14 @@ class DatabaseClient(object):
             )
         except Exception as exception:
             logger.warning(f'got exception while writing to tsdb: {exception}')
+            if isinstance(exception, self.client_error):
+                exception_code = getattr(exception, 'code', None)
+                exception_message = getattr(exception, 'content')
+                if (
+                    exception_code == 400
+                    and 'points beyond retention policy dropped' in exception_message
+                ):
+                    return
             raise TimeseriesWriteException
 
     def read(self, key, fields, tags, **kwargs):

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.utils.timezone import now
 from freezegun import freeze_time
 from influxdb import InfluxDBClient
-from influxdb.exceptions import InfluxDBServerError
+from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from pytz import timezone as tz
 from swapper import load_model
 
@@ -268,6 +268,32 @@ class TestDatabaseClient(TestMonitoringMixin, TestCase):
         m = self._create_general_metric(name='Test metric')
         with self.assertRaises(Retry):
             m.write(1)
+
+    @patch.object(
+        InfluxDBClient,
+        'write',
+        side_effect=InfluxDBClientError(
+            content='{"error":"partial write: points beyond retention policy dropped=1"}',
+            code=400,
+        ),
+    )
+    @capture_stderr()
+    def test_write_skip_retry_for_retention_ploicy(self, mock_write):
+        try:
+            timeseries_db.write('test_write', {'value': 1})
+        except TimeseriesWriteException:
+            self.fail(
+                'TimeseriesWriteException should not be raised when data '
+                'points crosses retention policy'
+            )
+        m = self._create_general_metric(name='Test metric')
+        try:
+            m.write(1)
+        except Retry:
+            self.fail(
+                'Writing metric should not be retried when data '
+                'points crosses retention policy'
+            )
 
     @patch.object(
         InfluxDBClient, 'write', side_effect=InfluxDBServerError('Server error')

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -278,7 +278,7 @@ class TestDatabaseClient(TestMonitoringMixin, TestCase):
         ),
     )
     @capture_stderr()
-    def test_write_skip_retry_for_retention_ploicy(self, mock_write):
+    def test_write_skip_retry_for_retention_policy(self, mock_write):
         try:
             timeseries_db.write('test_write', {'value': 1})
         except TimeseriesWriteException:


### PR DESCRIPTION
Bug:
The celery worker kept on retrying writing data to InfluxDB even
when the data points crossed rentention policy of InfluxDB. The
celery worker continued retrying such task indefinitely which
accumulated such tasks.

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
