### PR TITLE
[change] Removed charts which have empty data #349

### DIFF
--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -92,6 +92,8 @@ class DeviceMetricView(GenericAPIView):
             # prepare chart dict
             try:
                 chart_dict = chart.read(time=time, x_axys=x_axys, timezone=timezone)
+                if not chart_dict['traces']:
+                    continue
                 chart_dict['description'] = chart.description
                 chart_dict['title'] = chart.title.format(metric=chart.metric)
                 chart_dict['type'] = chart.type

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -341,7 +341,7 @@ class TestDeviceApi(AuthenticationMixin, DeviceMonitoringTestCase):
         self.assertEqual(rows[-2].strip().split(','), ['http2', '100'])
         self.assertEqual(rows[-1].strip().split(','), ['ssh', '0'])
 
-    def test_get_device_empty_metric(self):
+    def test_get_device_metrics_empty(self):
         d = self._create_device(organization=self._create_org())
         m = self._create_object_metric(name='test_metric', content_object=d)
         c = Chart(metric=m, configuration='dummy')  # empty chart
@@ -350,7 +350,7 @@ class TestDeviceApi(AuthenticationMixin, DeviceMonitoringTestCase):
         self.assertEqual(Chart.objects.count(), 1)
         response = self.client.get(self._url(d.pk.hex, d.key))
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data['charts'])
+        self.assertEqual(response.data['charts'], [])
 
     def test_get_device_metrics_400_bad_timezone(self):
         dd = self.create_test_data(no_resources=True)

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -341,6 +341,17 @@ class TestDeviceApi(AuthenticationMixin, DeviceMonitoringTestCase):
         self.assertEqual(rows[-2].strip().split(','), ['http2', '100'])
         self.assertEqual(rows[-1].strip().split(','), ['ssh', '0'])
 
+    def test_get_device_empty_metric(self):
+        d = self._create_device(organization=self._create_org())
+        m = self._create_object_metric(name='test_metric', content_object=d)
+        c = Chart(metric=m, configuration='dummy')  # empty chart
+        c.full_clean()
+        c.save()
+        self.assertEqual(Chart.objects.count(), 1)
+        response = self.client.get(self._url(d.pk.hex, d.key))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data['charts'])
+
     def test_get_device_metrics_400_bad_timezone(self):
         dd = self.create_test_data(no_resources=True)
         d = self.device_model.objects.get(pk=dd.pk)


### PR DESCRIPTION
- If data in charts is empty, then we can remove it from `API` response `(api/v1/monitoring/device/)` and it no longer visible on UI.
- For charts having empty data, we can check value of its `traces`.

### Before (If charts have empty data) : 

![Screenshot from 2022-05-05 01-14-44](https://user-images.githubusercontent.com/56113566/166820349-988af06e-ce23-4e00-8404-97f332e0be93.png)

![Screenshot from 2022-05-05 01-59-57](https://user-images.githubusercontent.com/56113566/166820699-b222ce4b-83dc-45e9-b471-80f97c06c30c.png)

### After (showing only those charts having data) :

![Screenshot from 2022-05-05 02-03-35](https://user-images.githubusercontent.com/56113566/166821273-ff2aac55-400d-4ba7-800c-e1e95ac23c40.png)

Closes #349

Checks:

- [x] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
