### PR TITLE
[ux] Show size in (KB, MB or GB) adaptively in charts #87

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -918,6 +918,29 @@ configuration status of a device changes, this ensures the check reacts
 quickly to events happening in the network and informs the user promptly
 if there's anything that is not working as intended.
 
+Adaptive Filtering in Charts
+----------------------------
+
+This behavior helps us to show the data and unit of the chart in a more readable way, the units are shown in `B`, `KB`, `MB` and `GB` respectively, and datapoints have same unit to maintain consistency in the chart. The chart automatically sets it's unit according to a specific range of values of data. 
+For the quick glance the Y-Axis Legend has same unit as the datapoints which makes it easier to understand the unit of points in the chart. 
+The summarycircles have different units and are shown in `B`, `KB`, `MB` and `GB` to overview chart summary in a more readable way.
+
+For Example:
+~~~~~~~~~~~~
+
+.. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/chartsize.png
+   :align: center
+
+configuration
+~~~~~~~~~~~~~
+.. code-block:: python
+    
+    'traffic': {
+                'unit': '{adaptive_bytes}',
+                },
+
+This is enabled for the traffic charts where the data is in `B`, `KB`, `MB` and `GB` respectively.
+
 Settings
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -918,15 +918,11 @@ configuration status of a device changes, this ensures the check reacts
 quickly to events happening in the network and informs the user promptly
 if there's anything that is not working as intended.
 
-Adaptive Filtering in Charts
-----------------------------
+Byte Adaptive Measuring in Charts
+---------------------------------
 
-This behavior helps us to show the data and unit of the chart in a more readable way, the units are shown in `B`, `KB`, `MB` and `GB` respectively, and datapoints have same unit to maintain consistency in the chart. The chart automatically sets it's unit according to a specific range of values of data. 
-For the quick glance the Y-Axis Legend has same unit as the datapoints which makes it easier to understand the unit of points in the chart. 
-The summarycircles have different units and are shown in `B`, `KB`, `MB` and `GB` to overview chart summary in a more readable way.
-
-For Example:
-~~~~~~~~~~~~
+This behavior helps us to show the data and unit of the chart in a more readable way, the units are shown in `B`, `KB`, `MB` and `GB` respectively, and datapoints have same unit to maintain consistency in the chart, summarycircles have different units and are shown in `B`, `KB`, `MB` and `GB` to overview chart summary in a more readable way.
+The chart automatically sets it's unit according to a specific range of values of data, for the quick glance the Y-Axis Legend has same unit as the datapoints which makes it easier to understand the unit of points in the chart.
 
 .. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/chartsize.png
    :align: center
@@ -936,7 +932,7 @@ configuration
 .. code-block:: python
     
     'traffic': {
-                'unit': '{adaptive_bytes}',
+                'unit': 'adaptive_bytes',
                 },
 
 This is enabled for the traffic charts where the data is in `B`, `KB`, `MB` and `GB` respectively.

--- a/README.rst
+++ b/README.rst
@@ -937,12 +937,13 @@ which makes it easier to understand the unit of points in the chart.
 configuration
 ~~~~~~~~~~~~~
 .. code-block:: python
-    
-    'traffic': {
-                    'unit': 'adaptive_bytes',
-                },
 
-This is enabled for the traffic charts where the data is in `B`, `KB`, `MB` and `GB` respectively.
+    'traffic': {
+        # other configurations for this chart
+        'unit': 'adaptive_bytes',
+    },
+
+The default traffic chart uses this feature to automatically adapt units for the traffic data.
 
 Settings
 --------
@@ -1384,17 +1385,19 @@ This setting allows to define additional charts or to override
 the default chart configuration defined in
 ``openwisp_monitoring.monitoring.configuration.DEFAULT_CHARTS``.
 
-For example, if you want to change the traffic chart to show
-MB (megabytes) instead of GB (Gigabytes) you can use:
+For example, the units in the traffic charts automatically 
+adapt according to the traffic data and is set to ``adaptive_bytes``
+by default.
 
 .. code-block:: python
 
     OPENWISP_MONITORING_CHARTS = {
         'traffic': {
-            'unit': ' MB',
+            'unit': 'adaptive_bytes',
             'description': (
                 'Network traffic, download and upload, measured on '
-                'the interface "{metric.key}", measured in GB.'
+                'the interface "{metric.key}", and automatically '
+                'adapt units for the traffic data.'
             ),
             'query': {
                 'influxdb': (

--- a/README.rst
+++ b/README.rst
@@ -921,18 +921,25 @@ if there's anything that is not working as intended.
 Byte Adaptive Measuring in Charts
 ---------------------------------
 
-This behavior helps us to show the data and unit of the chart in a more readable way, the units are shown in `B`, `KB`, `MB` and `GB` respectively, and datapoints have same unit to maintain consistency in the chart, summarycircles have different units and are shown in `B`, `KB`, `MB` and `GB` to overview chart summary in a more readable way.
-The chart automatically sets it's unit according to a specific range of values of data, for the quick glance the Y-Axis Legend has same unit as the datapoints which makes it easier to understand the unit of points in the chart.
-
 .. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/chartsize.png
    :align: center
+
+This behavior helps us to show the data and unit of the chart in a more readable way,
+the units are shown in `B`, `KB`, `MB` and `GB` respectively, and datapoints have
+same unit to maintain consistency in the chart, summarycircles have different units
+and are shown in `B`, `KB`, `MB` and `GB` to overview chart summary in a more 
+readable way.
+
+The chart automatically sets it's unit according to a specific range of values of data,
+for the quick glance the Y-Axis Legend has same unit as the datapoints 
+which makes it easier to understand the unit of points in the chart.
 
 configuration
 ~~~~~~~~~~~~~
 .. code-block:: python
     
     'traffic': {
-                'unit': 'adaptive_bytes',
+                    'unit': 'adaptive_bytes',
                 },
 
 This is enabled for the traffic charts where the data is in `B`, `KB`, `MB` and `GB` respectively.

--- a/README.rst
+++ b/README.rst
@@ -925,9 +925,9 @@ Byte Adaptive Measuring in Charts
    :align: center
 
 This behavior helps us to show the data and unit of the chart in a more readable way,
-the units are shown in `B`, `KB`, `MB` and `GB` respectively, and datapoints have
+the units are shown in `B`, `KB`, `MB`, `GB` and `TB` respectively, and datapoints have
 same unit to maintain consistency in the chart, summarycircles have different units
-and are shown in `B`, `KB`, `MB` and `GB` to overview chart summary in a more 
+and are shown in `B`, `KB`, `MB`, `GB` and `TB` to overview chart summary in a more 
 readable way.
 
 The chart automatically sets it's unit according to a specific range of values of data,
@@ -1394,7 +1394,7 @@ MB (megabytes) instead of GB (Gigabytes) you can use:
             'unit': ' MB',
             'description': (
                 'Network traffic, download and upload, measured on '
-                'the interface "{metric.key}", measured in MB.'
+                'the interface "{metric.key}", measured in GB.'
             ),
             'query': {
                 'influxdb': (

--- a/README.rst
+++ b/README.rst
@@ -818,6 +818,26 @@ You can configure the interfaces included in the **General traffic chart** using
 the `"OPENWISP_MONITORING_DASHBOARD_TRAFFIC_CHART"
 <#openwisp_monitoring_dashboard_traffic_chart>`_ setting.
 
+Adaptive byte charts
+--------------------
+
+.. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/1.1/adaptive-chart.png
+   :align: center
+
+When configuring charts, it is possible to flag their unit
+as ``adaptive_bytes``, this allows to make the charts more readable because
+the units are shown in either `B`, `KB`, `MB`, `GB` and `TB` depending on
+the size of each point, the summary values and Y axis are also resized.
+
+Example taken from the default configuration of the traffic chart:
+
+.. code-block:: python
+
+    'traffic': {
+        # other configurations for this chart
+        'unit': 'adaptive_bytes',
+    },
+
 Monitoring WiFi Sessions
 ------------------------
 
@@ -917,33 +937,6 @@ This check runs periodically, but it is also triggered whenever the
 configuration status of a device changes, this ensures the check reacts
 quickly to events happening in the network and informs the user promptly
 if there's anything that is not working as intended.
-
-Byte Adaptive Measuring in Charts
----------------------------------
-
-.. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/chartsize.png
-   :align: center
-
-This behavior helps us to show the data and unit of the chart in a more readable way,
-the units are shown in `B`, `KB`, `MB`, `GB` and `TB` respectively, and datapoints have
-same unit to maintain consistency in the chart, summarycircles have different units
-and are shown in `B`, `KB`, `MB`, `GB` and `TB` to overview chart summary in a more 
-readable way.
-
-The chart automatically sets it's unit according to a specific range of values of data,
-for the quick glance the Y-Axis Legend has same unit as the datapoints 
-which makes it easier to understand the unit of points in the chart.
-
-configuration
-~~~~~~~~~~~~~
-.. code-block:: python
-
-    'traffic': {
-        # other configurations for this chart
-        'unit': 'adaptive_bytes',
-    },
-
-The default traffic chart uses this feature to automatically adapt units for the traffic data.
 
 Settings
 --------
@@ -1385,7 +1378,7 @@ This setting allows to define additional charts or to override
 the default chart configuration defined in
 ``openwisp_monitoring.monitoring.configuration.DEFAULT_CHARTS``.
 
-For example, the units in the traffic charts automatically 
+For example, the units in the traffic charts automatically
 adapt according to the traffic data and is set to ``adaptive_bytes``
 by default.
 

--- a/README.rst
+++ b/README.rst
@@ -1379,28 +1379,16 @@ This setting allows to define additional charts or to override
 the default chart configuration defined in
 ``openwisp_monitoring.monitoring.configuration.DEFAULT_CHARTS``.
 
-For example, the units in the traffic charts automatically
-adapt according to the traffic data and is set to ``adaptive_bytes``
-by default.
+In the following example, we modify the description of the traffic chart:
 
 .. code-block:: python
 
     OPENWISP_MONITORING_CHARTS = {
         'traffic': {
-            'unit': 'adaptive_bytes',
             'description': (
                 'Network traffic, download and upload, measured on '
-                'the interface "{metric.key}", and automatically '
-                'adapt units for the traffic data.'
+                'the interface "{metric.key}", custom message here.'
             ),
-            'query': {
-                'influxdb': (
-                    "SELECT SUM(tx_bytes) / 1000000 AS upload, "
-                    "SUM(rx_bytes) / 1000000 AS download FROM {key} "
-                    "WHERE time >= '{time}' AND content_type = '{content_type}' "
-                    "AND object_id = '{object_id}' GROUP BY time(1d)"
-                )
-            },
         }
     }
 
@@ -1435,7 +1423,7 @@ In case you just want to change the colors used in a chart here's how to do it:
 
     OPENWISP_MONITORING_CHARTS = {
         'traffic': {
-            'colors': ['#000000', '#cccccc']
+            'colors': ['#000000', '#cccccc', '#111111']
         }
     }
 

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -199,8 +199,7 @@ DEFAULT_METRICS = {
                 'label': _('Traffic'),
                 'description': _(
                     'Network traffic (total, download and upload) '
-                    'of the interface "{ifname}", and automatically '
-                    'adapt units for the traffic data.'
+                    'of the interface "{ifname}".'
                 ),
                 'summary_labels': [
                     _('Total traffic'),
@@ -236,9 +235,7 @@ DEFAULT_METRICS = {
                 'title': _('General Traffic'),
                 'label': _('General Traffic'),
                 'description': _(
-                    'Network traffic of the whole network'
-                    ' (total, download, upload), and automatically '
-                    'adapt units for the traffic data.'
+                    'Network traffic of the whole network ' '(total, download, upload).'
                 ),
                 'summary_labels': [
                     _('Total traffic'),

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -243,7 +243,7 @@ DEFAULT_METRICS = {
                     _('Total download traffic'),
                     _('Total upload traffic'),
                 ],
-                'unit': _(' GB'),
+                'unit': 'adaptive_bytes',
                 'order': 240,
                 'query': chart_query['general_traffic'],
                 'query_default_param': {

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -206,7 +206,9 @@ DEFAULT_METRICS = {
                     _('Total download traffic'),
                     _('Total upload traffic'),
                 ],
-                'unit': _(' GB'),
+                'conversion': {
+                    'filter': '{unit}',
+                },
                 'order': 240,
                 'query': chart_query['traffic'],
                 'colors': [

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -235,7 +235,7 @@ DEFAULT_METRICS = {
                 'title': _('General Traffic'),
                 'label': _('General Traffic'),
                 'description': _(
-                    'Network traffic of the whole network ' '(total, download, upload).'
+                    'Network traffic of the whole network (total, download, upload).'
                 ),
                 'summary_labels': [
                     _('Total traffic'),

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -206,7 +206,7 @@ DEFAULT_METRICS = {
                     _('Total download traffic'),
                     _('Total upload traffic'),
                 ],
-                'unit': '{adaptive_bytes}',
+                'unit': 'adaptive_bytes',
                 'order': 240,
                 'query': chart_query['traffic'],
                 'colors': [

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -206,9 +206,7 @@ DEFAULT_METRICS = {
                     _('Total download traffic'),
                     _('Total upload traffic'),
                 ],
-                'conversion': {
-                    'filter': '{unit}',
-                },
+                'unit': '{adaptive_bytes}',
                 'order': 240,
                 'query': chart_query['traffic'],
                 'colors': [

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -199,7 +199,8 @@ DEFAULT_METRICS = {
                 'label': _('Traffic'),
                 'description': _(
                     'Network traffic (total, download and upload) '
-                    'of the interface "{ifname}", measured in GB.'
+                    'of the interface "{ifname}", and automatically '
+                    'adapt units for the traffic data.'
                 ),
                 'summary_labels': [
                     _('Total traffic'),
@@ -236,7 +237,8 @@ DEFAULT_METRICS = {
                 'label': _('General Traffic'),
                 'description': _(
                     'Network traffic of the whole network'
-                    ' (total, download, upload) measured in GB.'
+                    ' (total, download, upload), and automatically '
+                    'adapt units for the traffic data.'
                 ),
                 'summary_labels': [
                     _('Total traffic'),

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -206,20 +206,23 @@
                 }
             }
             var average = sum / count;
+            var multiplier;
             if (average < 0.01){
                 for(i=0; i<total_traffic_charts.length; i++){
-                    charts[0].y[i] *= 1000000;
-                    charts[1].y[i] *= 1000000;
-                    charts[2].y[i] *= 1000000;
+                    multiplier = 1000000;
+                    charts[0].y[i] = Math.round(charts[0].y[i] * multiplier, 2);
+                    charts[1].y[i] = Math.round(charts[1].y[i] * multiplier, 2);
+                    charts[2].y[i] = Math.round(charts[2].y[i] * multiplier, 2);
                 }
                 layout.yaxis.title = ' KB';
                 unit = ' KB';
             }
             else if (average < 1){
                 for(i=0; i<total_traffic_charts.length; i++){
-                    charts[0].y[i] *= 1000;
-                    charts[1].y[i] *= 1000;
-                    charts[2].y[i] *= 1000;
+                    multiplier = 1000;
+                    charts[0].y[i] = Math.round(charts[0].y[i] * multiplier, 2);
+                    charts[1].y[i] = Math.round(charts[1].y[i] * multiplier, 2);
+                    charts[2].y[i] = Math.round(charts[2].y[i] * multiplier, 2);
                 }
                 layout.yaxis.title = ' MB';
                 unit = ' MB';

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -17,55 +17,97 @@
         return newArr;
     }
 
-    function adaptiveFilterPoints(charts, layout, unit, data) {
-        var newArr = charts[0].y, sum = 0, count = 0, multiplier = 1, adaptValue;
+    function adaptiveFilterPoints(charts) {
 
+        var convertToAdaptiveBytes = function(charts, type, i, multiplier, unit) {
+            charts[type].y[i] = Math.round((charts[type].y[i] * multiplier)*100)/100;
+            charts[type].hovertemplate[i] = charts[type].y[i] + ' ' + unit;
+        };
+
+        for(var i=0; i<charts[0].y.length; i++)
+        {
+            if(charts[0].y[i] == 0)
+            {
+                convertToAdaptiveBytes(charts, 0, i, 1, 'B');
+            }
+            else if(charts[0].y[i] < 0.01)
+            {
+                convertToAdaptiveBytes(charts, 0, i, 1000000, 'KB');
+            }
+            else if(charts[0].y[i] < 1)
+            {
+                convertToAdaptiveBytes(charts, 0, i, 1000, 'MB');
+            }
+            else
+            {
+                convertToAdaptiveBytes(charts, 0, i, 1, 'GB');
+            }
+        }
+
+        for(i=0; i<charts[1].y.length; i++)
+        {
+            if(charts[1].y[i] == 0)
+            {
+                convertToAdaptiveBytes(charts, 1, i, 1, 'B');
+            }
+            else if(charts[1].y[i] < 0.01)
+            {
+                convertToAdaptiveBytes(charts, 1, i, 1000000, 'KB');
+            }
+            else if(charts[1].y[i] < 1)
+            {
+                convertToAdaptiveBytes(charts, 1, i, 1000, 'MB');
+            }
+            else
+            {
+                convertToAdaptiveBytes(charts, 1, i, 1, 'GB');
+            }
+        }
+
+        for(i=0; i<charts[2].y.length; i++)
+        {
+            if(charts[2].y[i] == 0)
+            {
+                convertToAdaptiveBytes(charts, 2, i, 1, 'B');
+            }
+            else if(charts[2].y[i] < 0.01)
+            {
+                convertToAdaptiveBytes(charts, 2, i, 1000000, 'KB');
+            }
+            else if(charts[2].y[i] < 1)
+            {
+                convertToAdaptiveBytes(charts, 2, i, 1000, 'MB');
+            }
+            else
+            {
+                convertToAdaptiveBytes(charts, 2, i, 1, 'GB');
+            }
+        }
+    }
+
+    function adaptiveFilterLayout(charts, layout) {
+        var newArr = charts[0].y, sum = 0, count = 0;
         for(var i=0; i<newArr.length; i++) {
             sum += newArr[i];
         }
         for(i=0; i<newArr.length; i++) {
-            if(newArr[i] !== 0) {
+            if(newArr[i] != 0) {
                 count++;
             }
         }
-
         var average = sum / count;
-        adaptValue = function(value, multiplier) {
-            return Math.round((value * multiplier) * 100) / 100;
-        };
-
-        if (average < 0.01) {
-            for(i=0; i<newArr.length; i++) {
-                multiplier = 1000000;
-                charts[0].y[i] = adaptValue(charts[0].y[i], multiplier);
-                charts[1].y[i] = adaptValue(charts[1].y[i], multiplier);
-                charts[2].y[i] = adaptValue(charts[2].y[i], multiplier);
-            }
+        if(average == 0) {
+            layout.yaxis.title = 'B';
+        }
+        else if (average < 0.01) {
             layout.yaxis.title = 'KB';
-            unit = 'KB';
         }
         else if (average < 1) {
-            for(i=0; i<newArr.length; i++) {
-                multiplier = 1000;
-                charts[0].y[i] = adaptValue(charts[0].y[i], multiplier);
-                charts[1].y[i] = adaptValue(charts[1].y[i], multiplier);
-                charts[2].y[i] = adaptValue(charts[2].y[i], multiplier);
-            }
             layout.yaxis.title = 'MB';
-            unit = 'MB';
         }
         else {
             layout.yaxis.title = 'GB';
-            unit = 'GB';
         }
-
-        for(i=0; i<newArr.length; i++) {
-            charts[0].hovertemplate[i] = charts[0].y[i] + ' ' + unit;
-            charts[1].hovertemplate[i] = charts[1].y[i] + ' ' + unit;
-            charts[2].hovertemplate[i] = charts[2].y[i] + ' ' + unit;
-        }
-
-        data.unit = unit;
     }
 
     function adaptiveFilterSummary(i, percircles, value, data) {
@@ -268,7 +310,8 @@
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
 
         if(unit == 'adaptive_bytes') {
-            adaptiveFilterPoints(charts, layout, unit, data);
+            adaptiveFilterLayout(charts, layout);
+            adaptiveFilterPoints(charts);
         }
 
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -17,73 +17,45 @@
         return newArr;
     }
 
-    function adaptiveFilterPoints(charts, yRawVal) {
-
-        var convertToAdaptiveBytes = function(charts, type, i, multiplier, unit) {
-            charts[type].y[i] = Math.round((charts[type].y[i] * multiplier) * 100) / 100;
-            charts[type].hovertemplate[i] = charts[type].y[i] + ' ' + unit;
+    function getAdaptiveScale(value, multiplier, unit) {
+        if (value == 0) {
+            multiplier = 1;
+            unit = 'B';
+        } else if (value < 0.001) {
+            multiplier = 1000000;
+            unit = 'KB';
+        } else if (value < 1) {
+            multiplier = 1000;
+            unit = 'MB';
+        } else if (value < 1000) {
+            multiplier = 1;
+            unit = 'GB';
+        } else if (value >=1000) {
+            multiplier = 0.001;
+            unit = 'TB';
+        }
+        return {
+            multiplier: multiplier,
+            unit: unit
         };
+    }
 
-        for (var i=0; i<charts[0].y.length; i++) {
-            if (yRawVal[i] == null) {
-                charts[0].hovertemplate[i] = 'N/A' + '<extra></extra>';
-            }
-            else if (charts[0].y[i] == 0) {
-                convertToAdaptiveBytes(charts, 0, i, 1, 'B');
-            }
-            else if (charts[0].y[i] < 0.001) {
-                convertToAdaptiveBytes(charts, 0, i, 1000000, 'KB');
-            }
-            else if (charts[0].y[i] < 1) {
-                convertToAdaptiveBytes(charts, 0, i, 1000, 'MB');
-            }
-            else if (charts[0].y[i] < 1000) {
-                convertToAdaptiveBytes(charts, 0, i, 1, 'GB');
-            }
-            else {
-                convertToAdaptiveBytes(charts, 0, i, 0.001, 'TB');
-            }
-        }
+    function getAdaptiveBytes(value, multiplier) {
+        return Math.round((value * multiplier) * 100) / 100;
+    }
 
-        for (i=0; i<charts[1].y.length; i++) {
-            if (yRawVal[i] == null) {
-                charts[1].hovertemplate[i] = 'N/A' + '<extra></extra>';
-            }
-            else if (charts[1].y[i] == 0) {
-                convertToAdaptiveBytes(charts, 1, i, 1, 'B');
-            }
-            else if (charts[1].y[i] < 0.001) {
-                convertToAdaptiveBytes(charts, 1, i, 1000000, 'KB');
-            }
-            else if (charts[1].y[i] < 1) {
-                convertToAdaptiveBytes(charts, 1, i, 1000, 'MB');
-            }
-            else if (charts[1].y[i] < 1000) {
-                convertToAdaptiveBytes(charts, 1, i, 1, 'GB');
-            }
-            else {
-                convertToAdaptiveBytes(charts, 1, i, 0.001, 'TB');
-            }
-        }
-
-        for (i=0; i<charts[2].y.length; i++) {
-            if (yRawVal[i] == null) {
-                charts[2].hovertemplate[i] = 'N/A' + '<extra></extra>';
-            }
-            else if (charts[2].y[i] == 0) {
-                convertToAdaptiveBytes(charts, 2, i, 1, 'B');
-            }
-            else if (charts[2].y[i] < 0.001) {
-                convertToAdaptiveBytes(charts, 2, i, 1000000, 'KB');
-            }
-            else if (charts[2].y[i] < 1) {
-                convertToAdaptiveBytes(charts, 2, i, 1000, 'MB');
-            }
-            else if (charts[2].y[i] < 1000) {
-                convertToAdaptiveBytes(charts, 2, i, 1, 'GB');
-            }
-            else {
-                convertToAdaptiveBytes(charts, 2, i, 0.001, 'TB');
+    function adaptiveFilterPoints(charts, yRawVal) {
+        for (var i=0; i<charts.length; i++) {
+            for (var j=0; j<charts[i].y.length; j++) {
+                if (yRawVal[j] == null) {
+                    charts[i].hovertemplate[j] = 'N/A' + '<extra></extra>';
+                    continue;
+                }
+                var scales = getAdaptiveScale(charts[i].y[j], 1, '');
+                var multiplier = scales.multiplier;
+                var unit = scales.unit;
+                charts[i].y[j] = getAdaptiveBytes(charts[i].y[j], multiplier);
+                charts[i].hovertemplate[j] = charts[i].y[j] + ' ' + unit;
             }
         }
     }
@@ -99,43 +71,17 @@
             }
         }
         var average = sum / count;
-        if (average < 0.001) {
-            layout.yaxis.title = 'KB';
-        }
-        else if (average < 1) {
-            layout.yaxis.title = 'MB';
-        }
-        else if (average < 1000) {
-            layout.yaxis.title = 'GB';
-        }
-        else if (average > 1000) {
-            layout.yaxis.title = 'TB';
-        }
-        else {
-            layout.yaxis.title = 'B';
-        }
+        var scales = getAdaptiveScale(average, 1, '');
+        var unit = scales.unit;
+        layout.yaxis.title = unit;
     }
 
     function adaptiveFilterSummary(i, percircles, value) {
-        var convertToAdaptiveBytesSummary = function(i, percircles, multiplier, value, unit ) {
-            percircles[i].text = Math.round((value * multiplier) * 100) / 100 + ' ' + unit;
-        };
-
-        if (value == 0) {
-            convertToAdaptiveBytesSummary(i, percircles, 1, value, 'B');
-        }
-        else if (value < 0.001) {
-            convertToAdaptiveBytesSummary(i, percircles, 1000000, value, 'KB');
-        }
-        else if (value < 1) {
-            convertToAdaptiveBytesSummary(i, percircles, 1000, value, 'MB');
-        }
-        else if (value < 1000) {
-            convertToAdaptiveBytesSummary(i, percircles, 1, value, 'GB');
-        }
-        else {
-            convertToAdaptiveBytesSummary(i, percircles, 0.001, value, 'TB');
-        }
+        var scales = getAdaptiveScale(value, 1, '');
+        var multiplier = scales.multiplier;
+        var unit = scales.unit;
+        value = getAdaptiveBytes(value, multiplier);
+        percircles[i].text = value + ' ' + unit;
     }
 
     window.createChart = function (data, x, id, title, type, quickLink) {
@@ -318,7 +264,7 @@
 
         if (unit == 'adaptive_bytes') {
             var yRawVal;
-            for( i =0; i<charts.length; i++){
+            for (i=0; i<charts.length; i++) {
                 yRawVal = data.traces[i][1];
             }
             adaptiveFilterLayout(charts, layout);

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -206,6 +206,7 @@
                     charts[1].y[i] *= 1000000;
                     charts[2].y[i] *= 1000000;
                 }
+                layout.yaxis.title = ' KB';
                 unit = ' KB';
             }
             else if (average < 1){
@@ -214,9 +215,11 @@
                     charts[1].y[i] *= 1000;
                     charts[2].y[i] *= 1000;
                 }
+                layout.yaxis.title = ' MB';
                 unit = ' MB';
             }
             else {
+                layout.yaxis.title = ' GB';
                 unit = ' GB';
             }
 
@@ -299,13 +302,24 @@
                     percircleOptions.progressBarColor = data.colors[data.trace_order.indexOf(key)];
                 }
                 percircles.push(percircleOptions);
+                if(data.trace_order !== undefined) {
+                    if(value < 0.01){
+                        value *= 1000000;
+                        data.unit = ' KB';
+                        percircles[i].text = value + data.unit;
+                    }
+                    else if(value < 1){
+                        value *= 1000;
+                        data.unit = ' MB';
+                        percircles[i].text = value + data.unit;
+                    }
+                    else{
+                        data.unit = ' GB';
+                        percircles[i].text = value + data.unit;
+                    }
             }
+        }
             percircles = sortByTraceOrder(data.trace_order, percircles, '_key');
-            if(data.trace_order !== undefined) {
-                for(i=0; i<percircles.length; i++){
-                    percircles[i].text = percircles[i].text.replace(data.unit, ' GB');
-                }
-            }
             for (i=0; i<percircles.length; ++i) {
                 percircleContainer.append(
                     '<div class="small circle" title="' + percircles[i].htmlTitle + '"></div>'

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -44,7 +44,7 @@
         return Math.round((value * multiplier) * 100) / 100;
     }
 
-    function adaptiveFilterPoints(charts, yRawVal) {
+    function adaptiveFilterPoints(charts, yRawVal, layout) {
         for (var i=0; i<charts.length; i++) {
             for (var j=0; j<charts[i].y.length; j++) {
                 if (yRawVal[j] == null) {
@@ -54,14 +54,19 @@
                 var scales = getAdaptiveScale(charts[i].y[j], 1, '');
                 var multiplier = scales.multiplier;
                 var unit = scales.unit;
-                charts[i].y[j] = getAdaptiveBytes(charts[i].y[j], multiplier);
-                charts[i].hovertemplate[j] = charts[i].y[j] + ' ' + unit;
+                if (unit == layout.yaxis.title) {
+                    charts[i].y[j] = getAdaptiveBytes(charts[i].y[j], multiplier);
+                    charts[i].hovertemplate[j] = charts[i].y[j] + ' ' + unit;
+                }
+                else {
+                    charts[i].hovertemplate[j] = (charts[i].y[j] * multiplier) + ' ' + unit;
+                }
             }
         }
     }
 
     function adaptiveFilterLayout(charts, layout) {
-        var y = charts[0].y, sum = 0, count = 0;
+        var y = charts[0].y, sum = 0, count = 0, average, scales, unit;
         for (var i=0; i<y.length; i++) {
             sum += y[i];
         }
@@ -70,9 +75,9 @@
                 count++;
             }
         }
-        var average = sum / count;
-        var scales = getAdaptiveScale(average, 1, '');
-        var unit = scales.unit;
+        average = sum / count;
+        scales = getAdaptiveScale(average, 1, '');
+        unit = scales.unit;
         layout.yaxis.title = unit;
     }
 
@@ -268,7 +273,7 @@
                 yRawVal = data.traces[i][1];
             }
             adaptiveFilterLayout(charts, layout);
-            adaptiveFilterPoints(charts, yRawVal);
+            adaptiveFilterPoints(charts, yRawVal, layout);
         }
 
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -17,7 +17,7 @@
         return newArr;
     }
 
-    function adaptiveFilterPoints(charts, layout, adaptiveBytes, data) {
+    function adaptiveFilterPoints(charts, layout, unit, data) {
         var newArr = charts[0].y, sum = 0, count = 0, multiplier = 1;
 
         for(var i=0; i<newArr.length; i++) {
@@ -37,8 +37,8 @@
                 charts[1].y[i] = Math.round((charts[1].y[i] * multiplier) * 100) / 100;
                 charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100) / 100;
             }
-            layout.yaxis.title = ' KB';
-            adaptiveBytes = ' KB';
+            layout.yaxis.title = 'KB';
+            unit = 'KB';
         }
         else if (average < 1) {
             for(i=0; i<newArr.length; i++) {
@@ -47,41 +47,41 @@
                 charts[1].y[i] = Math.round((charts[1].y[i] * multiplier) * 100) / 100;
                 charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100) / 100;
             }
-            layout.yaxis.title = ' MB';
-            adaptiveBytes = ' MB';
+            layout.yaxis.title = 'MB';
+            unit = 'MB';
         }
         else {
-            layout.yaxis.title = ' GB';
-            adaptiveBytes = ' GB';
+            layout.yaxis.title = 'GB';
+            unit = 'GB';
         }
 
         for(i=0; i<newArr.length; i++) {
-            charts[0].hovertemplate[i] = charts[0].y[i] + adaptiveBytes;
-            charts[1].hovertemplate[i] = charts[1].y[i] + adaptiveBytes;
-            charts[2].hovertemplate[i] = charts[2].y[i] + adaptiveBytes;
+            charts[0].hovertemplate[i] = charts[0].y[i] + ' ' + unit;
+            charts[1].hovertemplate[i] = charts[1].y[i] + ' ' + unit;
+            charts[2].hovertemplate[i] = charts[2].y[i] + ' ' + unit;
         }
 
-        data.unit = adaptiveBytes;
+        data.unit = unit;
     }
 
     function adaptiveFilterSummary(i, percircles, value, data) {
         if(value == 0) {
-            data.unit = ' B';
-            percircles[i].text = value + data.unit;
+            data.unit = 'B';
+            percircles[i].text = value + ' ' + data.unit;
         }
         else if(value < 0.01) {
             value *= 1000000;
-            data.unit = ' KB';
-            percircles[i].text = value + data.unit;
+            data.unit = 'KB';
+            percircles[i].text = value + ' ' + data.unit;
         }
         else if(value < 1) {
             value *= 1000;
-            data.unit = ' MB';
-            percircles[i].text = value + data.unit;
+            data.unit = 'MB';
+            percircles[i].text = value + ' ' + data.unit;
         }
         else {
-            data.unit = ' GB';
-            percircles[i].text = value + data.unit;
+            data.unit = 'GB';
+            percircles[i].text = value + ' ' + data.unit;
         }
     }
 
@@ -263,9 +263,8 @@
         }
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
 
-        var adaptiveBytes = unit, adaptive_bytes = adaptiveBytes;
-        if(adaptive_bytes) {
-            adaptiveFilterPoints(charts, layout, adaptiveBytes, data);
+        if(unit == 'adaptive_bytes') {
+            adaptiveFilterPoints(charts, layout, unit, data);
         }
 
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }
@@ -340,7 +339,8 @@
                     percircleOptions.progressBarColor = data.colors[data.trace_order.indexOf(key)];
                 }
                 percircles.push(percircleOptions);
-                if(adaptive_bytes) {
+
+                if(unit == 'adaptive_bytes') {
                     adaptiveFilterSummary(i, percircles, value, data);
                 }
             }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -17,7 +17,7 @@
         return newArr;
     }
 
-    function adaptiveFilterPoints(charts) {
+    function adaptiveFilterPoints(charts, yrawVal) {
 
         var convertToAdaptiveBytes = function(charts, type, i, multiplier, unit) {
             charts[type].y[i] = Math.round((charts[type].y[i] * multiplier) * 100) / 100;
@@ -25,7 +25,10 @@
         };
 
         for (var i=0; i<charts[0].y.length; i++) {
-            if (charts[0].y[i] == 0) {
+            if (yrawVal[i] == null) {
+                charts[0].hovertemplate[i] = 'N/A' + '<extra></extra>';
+            }
+            else if (charts[0].y[i] == 0) {
                 convertToAdaptiveBytes(charts, 0, i, 1, 'B');
             }
             else if (charts[0].y[i] < 0.001) {
@@ -40,7 +43,10 @@
         }
 
         for (i=0; i<charts[1].y.length; i++) {
-            if (charts[1].y[i] == 0) {
+            if (yrawVal[i] == null) {
+                charts[1].hovertemplate[i] = 'N/A' + '<extra></extra>';
+            }
+            else if (charts[1].y[i] == 0) {
                 convertToAdaptiveBytes(charts, 1, i, 1, 'B');
             }
             else if (charts[1].y[i] < 0.001) {
@@ -55,7 +61,10 @@
         }
 
         for (i=0; i<charts[2].y.length; i++) {
-            if (charts[2].y[i] == 0) {
+            if (yrawVal[i] == null) {
+                charts[2].hovertemplate[i] = 'N/A' + '<extra></extra>';
+            }
+            else if (charts[2].y[i] == 0) {
                 convertToAdaptiveBytes(charts, 2, i, 1, 'B');
             }
             else if (charts[2].y[i] < 0.001) {
@@ -95,24 +104,23 @@
         }
     }
 
-    function adaptiveFilterSummary(i, percircles, value, data) {
+    function adaptiveFilterSummary(i, percircles, value) {
+
+        var convertToAdaptiveBytesSummary = function(i, percircles, multiplier, value, unit ) {
+            percircles[i].text = Math.round((value * multiplier) * 100) / 100 + ' ' + unit;
+        };
+
         if (value == 0) {
-            data.unit = 'B';
-            percircles[i].text = value + ' ' + data.unit;
+            convertToAdaptiveBytesSummary(i, percircles, 1, value, 'B');
         }
         else if (value < 0.001) {
-            value *= 1000000;
-            data.unit = 'KB';
-            percircles[i].text = value + ' ' + data.unit;
+            convertToAdaptiveBytesSummary(i, percircles, 1000000, value, 'KB');
         }
         else if (value < 1) {
-            value *= 1000;
-            data.unit = 'MB';
-            percircles[i].text = value + ' ' + data.unit;
+            convertToAdaptiveBytesSummary(i, percircles, 1000, value, 'MB');
         }
         else {
-            data.unit = 'GB';
-            percircles[i].text = value + ' ' + data.unit;
+            convertToAdaptiveBytesSummary(i, percircles, 1, value, 'GB');
         }
     }
 
@@ -295,8 +303,12 @@
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
 
         if (unit == 'adaptive_bytes') {
+            var yrawVal;
+            for( i =0; i<charts.length; i++){
+                yrawVal = data.traces[i][1];
+            }
             adaptiveFilterLayout(charts, layout);
-            adaptiveFilterPoints(charts);
+            adaptiveFilterPoints(charts, yrawVal);
         }
 
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }
@@ -373,7 +385,7 @@
                 percircles.push(percircleOptions);
 
                 if (unit == 'adaptive_bytes') {
-                    adaptiveFilterSummary(i, percircles, value, data);
+                    adaptiveFilterSummary(i, percircles, value);
                 }
             }
             percircles = sortByTraceOrder(data.trace_order, percircles, '_key');

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -16,20 +16,20 @@
         }
         return newArr;
     }
-    function adaptiveFilterPoints(charts, layout, adaptive_bytes, data) {
-        var newArr = charts[0].y;
-        var sum = 0;
+
+    function adaptiveFilterPoints(charts, layout, adaptiveBytes, data) {
+        var newArr = charts[0].y, sum = 0, count = 0, multiplier = 1;
+
         for(var i=0; i<newArr.length; i++) {
             sum += newArr[i];
         }
-        var count = 0;
         for(i=0; i<newArr.length; i++) {
             if(newArr[i] !== 0) {
                 count++;
             }
         }
+
         var average = sum / count;
-        var multiplier;
         if (average < 0.01) {
             for(i=0; i<newArr.length; i++) {
                 multiplier = 1000000;
@@ -38,7 +38,7 @@
                 charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100) / 100;
             }
             layout.yaxis.title = ' KB';
-            adaptive_bytes = ' KB';
+            adaptiveBytes = ' KB';
         }
         else if (average < 1) {
             for(i=0; i<newArr.length; i++) {
@@ -48,20 +48,22 @@
                 charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100) / 100;
             }
             layout.yaxis.title = ' MB';
-            adaptive_bytes = ' MB';
+            adaptiveBytes = ' MB';
         }
         else {
             layout.yaxis.title = ' GB';
-            adaptive_bytes = ' GB';
+            adaptiveBytes = ' GB';
         }
 
         for(i=0; i<newArr.length; i++) {
-            charts[0].hovertemplate[i] = charts[0].y[i] + adaptive_bytes;
-            charts[1].hovertemplate[i] = charts[1].y[i] + adaptive_bytes;
-            charts[2].hovertemplate[i] = charts[2].y[i] + adaptive_bytes;
+            charts[0].hovertemplate[i] = charts[0].y[i] + adaptiveBytes;
+            charts[1].hovertemplate[i] = charts[1].y[i] + adaptiveBytes;
+            charts[2].hovertemplate[i] = charts[2].y[i] + adaptiveBytes;
         }
-        data.unit = adaptive_bytes;
+
+        data.unit = adaptiveBytes;
     }
+
     function adaptiveFilterSummary(i, percircles, value, data) {
         if(value == 0) {
             data.unit = ' B';
@@ -82,6 +84,7 @@
             percircles[i].text = value + data.unit;
         }
     }
+
     window.createChart = function (data, x, id, title, type, quickLink) {
         if (data === false) {
             alert(gettext('error while receiving data from server'));
@@ -259,9 +262,12 @@
             charts.push(options);
         }
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
-        if(type === 'stackedbar+lines') {
-            adaptiveFilterPoints(charts, layout, unit, data);
+
+        var adaptiveBytes = unit, adaptive_bytes = adaptiveBytes;
+        if(adaptive_bytes) {
+            adaptiveFilterPoints(charts, layout, adaptiveBytes, data);
         }
+
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }
 
         Plotly.newPlot(plotlyContainer, charts, layout, {responsive: true});
@@ -334,7 +340,7 @@
                     percircleOptions.progressBarColor = data.colors[data.trace_order.indexOf(key)];
                 }
                 percircles.push(percircleOptions);
-                if(type === 'stackedbar+lines') {
+                if(adaptive_bytes) {
                     adaptiveFilterSummary(i, percircles, value, data);
                 }
             }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -69,7 +69,8 @@
                 var hoverScales = getAdaptiveScale(shownVal, 1, '');
                 var hoverMultiplier = hoverScales.multiplier;
                 var hoverUnit = hoverScales.unit;
-                charts[j].hovertemplate[i] = (shownVal * hoverMultiplier) + ' ' + hoverUnit;
+                shownVal = getAdaptiveBytes(shownVal, hoverMultiplier);
+                charts[j].hovertemplate[i] = shownVal + ' ' + hoverUnit;
             }
         }
         layout.yaxis.title = unit;

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -196,12 +196,12 @@
         if(data.trace_order !== undefined)  {
             var total_traffic_charts = charts[0].y;
             var sum = 0;
-            for(var i=0; i<total_traffic_charts.length; i++){
+            for(i=0; i<total_traffic_charts.length; i++){
                 sum += total_traffic_charts[i];
             }
             var average = sum / total_traffic_charts.length;
             if (average < 0.01){
-                for(var i=0; i<total_traffic_charts.length; i++){
+                for(i=0; i<total_traffic_charts.length; i++){
                     charts[0].y[i] *= 1000000;
                     charts[1].y[i] *= 1000000;
                     charts[2].y[i] *= 1000000;
@@ -209,7 +209,7 @@
                 unit = 'KB';
             }
             else if (average < 1){
-                for(var i=0; i<total_traffic_charts.length; i++){
+                for(i=0; i<total_traffic_charts.length; i++){
                     charts[0].y[i] *= 1000;
                     charts[1].y[i] *= 1000;
                     charts[2].y[i] *= 1000;
@@ -220,7 +220,7 @@
                 unit = 'GB';
             }
 
-            for(var i=0; i<total_traffic_charts.length; i++){
+            for(i=0; i<total_traffic_charts.length; i++){
                 charts[0].hovertemplate[i] = charts[0].y[i] + unit;
                 charts[1].hovertemplate[i] = charts[1].y[i] + unit;
                 charts[2].hovertemplate[i] = charts[2].y[i] + unit;

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -44,40 +44,34 @@
         return Math.round((value * multiplier) * 100) / 100;
     }
 
-    function adaptiveFilterPoints(charts, yRawVal, layout) {
-        for (var i=0; i<charts.length; i++) {
-            for (var j=0; j<charts[i].y.length; j++) {
-                if (yRawVal[j] == null) {
-                    charts[i].hovertemplate[j] = 'N/A' + '<extra></extra>';
-                    continue;
-                }
-                var scales = getAdaptiveScale(charts[i].y[j], 1, '');
-                var multiplier = scales.multiplier;
-                var unit = scales.unit;
-                if (unit == layout.yaxis.title) {
-                    charts[i].y[j] = getAdaptiveBytes(charts[i].y[j], multiplier);
-                    charts[i].hovertemplate[j] = charts[i].y[j] + ' ' + unit;
-                }
-                else {
-                    charts[i].hovertemplate[j] = (charts[i].y[j] * multiplier) + ' ' + unit;
-                }
-            }
-        }
-    }
-
-    function adaptiveFilterLayout(charts, layout) {
-        var y = charts[0].y, sum = 0, count = 0, average, scales, unit;
+    function adaptiveFilterPoints(charts, layout, yRawVal) {
+        var y = charts[0].y, sum = 0, count = 0, shownVal, average;
         for (var i=0; i<y.length; i++) {
             sum += y[i];
         }
-        for (i=0; i<y.length; i++) {
+        for (var j=0; j<y.length; j++) {
             if (y[i] != 0) {
                 count++;
             }
         }
         average = sum / count;
-        scales = getAdaptiveScale(average, 1, '');
-        unit = scales.unit;
+        var scales = getAdaptiveScale(average, 1, '');
+        var multiplier = scales.multiplier;
+        var unit = scales.unit;
+        for (i=0; i<y.length; i++) {
+            for (j=0; j<charts.length; j++) {
+                if (yRawVal[i] == null) {
+                    charts[j].hovertemplate[i] = 'N/A' + '<extra></extra>';
+                    continue;
+                }
+                shownVal = charts[j].y[i];
+                charts[j].y[i] = getAdaptiveBytes(charts[j].y[i], multiplier);
+                var hoverScales = getAdaptiveScale(shownVal, 1, '');
+                var hoverMultiplier = hoverScales.multiplier;
+                var hoverUnit = hoverScales.unit;
+                charts[j].hovertemplate[i] = (shownVal * hoverMultiplier) + ' ' + hoverUnit;
+            }
+        }
         layout.yaxis.title = unit;
     }
 
@@ -272,8 +266,7 @@
             for (i=0; i<charts.length; i++) {
                 yRawVal = data.traces[i][1];
             }
-            adaptiveFilterLayout(charts, layout);
-            adaptiveFilterPoints(charts, yRawVal, layout);
+            adaptiveFilterPoints(charts, layout, yRawVal);
         }
 
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -206,7 +206,7 @@
                     charts[1].y[i] *= 1000000;
                     charts[2].y[i] *= 1000000;
                 }
-                unit = 'KB';
+                unit = ' KB';
             }
             else if (average < 1){
                 for(i=0; i<total_traffic_charts.length; i++){
@@ -214,10 +214,10 @@
                     charts[1].y[i] *= 1000;
                     charts[2].y[i] *= 1000;
                 }
-                unit = 'MB';
+                unit = ' MB';
             }
             else {
-                unit = 'GB';
+                unit = ' GB';
             }
 
             for(i=0; i<total_traffic_charts.length; i++){
@@ -303,7 +303,7 @@
             percircles = sortByTraceOrder(data.trace_order, percircles, '_key');
             if(data.trace_order !== undefined) {
                 for(i=0; i<percircles.length; i++){
-                    percircles[i].text = percircles[i].text.replace(data.unit, 'GB');
+                    percircles[i].text = percircles[i].text.replace(data.unit, ' GB');
                 }
             }
             for (i=0; i<percircles.length; ++i) {

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -58,7 +58,7 @@
             else if (charts[1].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 1, i, 1000, 'MB');
             }
-            else if(charts[1].y[i] < 1000) {
+            else if (charts[1].y[i] < 1000) {
                 convertToAdaptiveBytes(charts, 1, i, 1, 'GB');
             }
             else {
@@ -79,7 +79,7 @@
             else if (charts[2].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 2, i, 1000, 'MB');
             }
-            else if(charts[2].y[i] < 1000) {
+            else if (charts[2].y[i] < 1000) {
                 convertToAdaptiveBytes(charts, 2, i, 1, 'GB');
             }
             else {
@@ -99,20 +99,20 @@
             }
         }
         var average = sum / count;
-        if (average == 0) {
-            layout.yaxis.title = 'B';
-        }
-        else if (average < 0.001) {
+        if (average < 0.001) {
             layout.yaxis.title = 'KB';
         }
         else if (average < 1) {
             layout.yaxis.title = 'MB';
         }
-        else if(average < 1000) {
+        else if (average < 1000) {
             layout.yaxis.title = 'GB';
         }
-        else {
+        else if (average > 1000) {
             layout.yaxis.title = 'TB';
+        }
+        else {
+            layout.yaxis.title = 'B';
         }
     }
 
@@ -130,7 +130,7 @@
         else if (value < 1) {
             convertToAdaptiveBytesSummary(i, percircles, 1000, value, 'MB');
         }
-        else if(value < 1000) {
+        else if (value < 1000) {
             convertToAdaptiveBytesSummary(i, percircles, 1, value, 'GB');
         }
         else {

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -30,7 +30,7 @@
         } else if (value < 1000) {
             multiplier = 1;
             unit = 'GB';
-        } else if (value >=1000) {
+        } else if (value >= 1000) {
             multiplier = 0.001;
             unit = 'TB';
         }
@@ -46,20 +46,18 @@
 
     function adaptiveFilterPoints(charts, layout, yRawVal) {
         var y = charts[0].y, sum = 0, count = 0, shownVal, average;
-        for (var i=0; i<y.length; i++) {
+        for (var i=0; i < y.length; i++) {
             sum += y[i];
-        }
-        for (var j=0; j<y.length; j++) {
-            if (y[i] != 0) {
+            if (y[i]) {
                 count++;
             }
         }
         average = sum / count;
         var scales = getAdaptiveScale(average, 1, '');
-        var multiplier = scales.multiplier;
-        var unit = scales.unit;
-        for (i=0; i<y.length; i++) {
-            for (j=0; j<charts.length; j++) {
+        var multiplier = scales.multiplier,
+            unit = scales.unit;
+        for (i=0; i < y.length; i++) {
+            for (var j=0; j < charts.length; j++) {
                 if (yRawVal[i] == null) {
                     charts[j].hovertemplate[i] = 'N/A' + '<extra></extra>';
                     continue;
@@ -67,8 +65,8 @@
                 shownVal = charts[j].y[i];
                 charts[j].y[i] = getAdaptiveBytes(charts[j].y[i], multiplier);
                 var hoverScales = getAdaptiveScale(shownVal, 1, '');
-                var hoverMultiplier = hoverScales.multiplier;
-                var hoverUnit = hoverScales.unit;
+                var hoverMultiplier = hoverScales.multiplier,
+                    hoverUnit = hoverScales.unit;
                 shownVal = getAdaptiveBytes(shownVal, hoverMultiplier);
                 charts[j].hovertemplate[i] = shownVal + ' ' + hoverUnit;
             }
@@ -77,9 +75,9 @@
     }
 
     function adaptiveFilterSummary(i, percircles, value) {
-        var scales = getAdaptiveScale(value, 1, '');
-        var multiplier = scales.multiplier;
-        var unit = scales.unit;
+        var scales = getAdaptiveScale(value, 1, ''),
+            multiplier = scales.multiplier,
+            unit = scales.unit;
         value = getAdaptiveBytes(value, multiplier);
         percircles[i].text = value + ' ' + unit;
     }
@@ -264,7 +262,7 @@
 
         if (unit == 'adaptive_bytes') {
             var yRawVal;
-            for (i=0; i<charts.length; i++) {
+            for (i=0; i < charts.length; i++) {
                 yRawVal = data.traces[i][1];
             }
             adaptiveFilterPoints(charts, layout, yRawVal);

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -20,66 +20,51 @@
     function adaptiveFilterPoints(charts) {
 
         var convertToAdaptiveBytes = function(charts, type, i, multiplier, unit) {
-            charts[type].y[i] = Math.round((charts[type].y[i] * multiplier)*100)/100;
+            charts[type].y[i] = Math.round((charts[type].y[i] * multiplier) * 100) / 100;
             charts[type].hovertemplate[i] = charts[type].y[i] + ' ' + unit;
         };
 
-        for(var i=0; i<charts[0].y.length; i++)
-        {
-            if(charts[0].y[i] == 0)
-            {
+        for (var i=0; i<charts[0].y.length; i++) {
+            if (charts[0].y[i] == 0) {
                 convertToAdaptiveBytes(charts, 0, i, 1, 'B');
             }
-            else if(charts[0].y[i] < 0.01)
-            {
+            else if (charts[0].y[i] < 0.001) {
                 convertToAdaptiveBytes(charts, 0, i, 1000000, 'KB');
             }
-            else if(charts[0].y[i] < 1)
-            {
+            else if (charts[0].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 0, i, 1000, 'MB');
             }
-            else
-            {
+            else {
                 convertToAdaptiveBytes(charts, 0, i, 1, 'GB');
             }
         }
 
-        for(i=0; i<charts[1].y.length; i++)
-        {
-            if(charts[1].y[i] == 0)
-            {
+        for (i=0; i<charts[1].y.length; i++) {
+            if (charts[1].y[i] == 0) {
                 convertToAdaptiveBytes(charts, 1, i, 1, 'B');
             }
-            else if(charts[1].y[i] < 0.01)
-            {
+            else if (charts[1].y[i] < 0.001) {
                 convertToAdaptiveBytes(charts, 1, i, 1000000, 'KB');
             }
-            else if(charts[1].y[i] < 1)
-            {
+            else if (charts[1].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 1, i, 1000, 'MB');
             }
-            else
-            {
+            else {
                 convertToAdaptiveBytes(charts, 1, i, 1, 'GB');
             }
         }
 
-        for(i=0; i<charts[2].y.length; i++)
-        {
-            if(charts[2].y[i] == 0)
-            {
+        for (i=0; i<charts[2].y.length; i++) {
+            if (charts[2].y[i] == 0) {
                 convertToAdaptiveBytes(charts, 2, i, 1, 'B');
             }
-            else if(charts[2].y[i] < 0.01)
-            {
+            else if (charts[2].y[i] < 0.001) {
                 convertToAdaptiveBytes(charts, 2, i, 1000000, 'KB');
             }
-            else if(charts[2].y[i] < 1)
-            {
+            else if (charts[2].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 2, i, 1000, 'MB');
             }
-            else
-            {
+            else {
                 convertToAdaptiveBytes(charts, 2, i, 1, 'GB');
             }
         }
@@ -87,19 +72,19 @@
 
     function adaptiveFilterLayout(charts, layout) {
         var newArr = charts[0].y, sum = 0, count = 0;
-        for(var i=0; i<newArr.length; i++) {
+        for (var i=0; i<newArr.length; i++) {
             sum += newArr[i];
         }
-        for(i=0; i<newArr.length; i++) {
-            if(newArr[i] != 0) {
+        for (i=0; i<newArr.length; i++) {
+            if (newArr[i] != 0) {
                 count++;
             }
         }
         var average = sum / count;
-        if(average == 0) {
+        if (average == 0) {
             layout.yaxis.title = 'B';
         }
-        else if (average < 0.01) {
+        else if (average < 0.001) {
             layout.yaxis.title = 'KB';
         }
         else if (average < 1) {
@@ -111,16 +96,16 @@
     }
 
     function adaptiveFilterSummary(i, percircles, value, data) {
-        if(value == 0) {
+        if (value == 0) {
             data.unit = 'B';
             percircles[i].text = value + ' ' + data.unit;
         }
-        else if(value < 0.01) {
+        else if (value < 0.001) {
             value *= 1000000;
             data.unit = 'KB';
             percircles[i].text = value + ' ' + data.unit;
         }
-        else if(value < 1) {
+        else if (value < 1) {
             value *= 1000;
             data.unit = 'MB';
             percircles[i].text = value + ' ' + data.unit;
@@ -309,7 +294,7 @@
         }
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
 
-        if(unit == 'adaptive_bytes') {
+        if (unit == 'adaptive_bytes') {
             adaptiveFilterLayout(charts, layout);
             adaptiveFilterPoints(charts);
         }
@@ -387,7 +372,7 @@
                 }
                 percircles.push(percircleOptions);
 
-                if(unit == 'adaptive_bytes') {
+                if (unit == 'adaptive_bytes') {
                     adaptiveFilterSummary(i, percircles, value, data);
                 }
             }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -17,7 +17,7 @@
         return newArr;
     }
 
-    function adaptiveFilterPoints(charts, yrawVal) {
+    function adaptiveFilterPoints(charts, yRawVal) {
 
         var convertToAdaptiveBytes = function(charts, type, i, multiplier, unit) {
             charts[type].y[i] = Math.round((charts[type].y[i] * multiplier) * 100) / 100;
@@ -25,7 +25,7 @@
         };
 
         for (var i=0; i<charts[0].y.length; i++) {
-            if (yrawVal[i] == null) {
+            if (yRawVal[i] == null) {
                 charts[0].hovertemplate[i] = 'N/A' + '<extra></extra>';
             }
             else if (charts[0].y[i] == 0) {
@@ -37,13 +37,16 @@
             else if (charts[0].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 0, i, 1000, 'MB');
             }
-            else {
+            else if (charts[0].y[i] < 1000) {
                 convertToAdaptiveBytes(charts, 0, i, 1, 'GB');
+            }
+            else {
+                convertToAdaptiveBytes(charts, 0, i, 0.001, 'TB');
             }
         }
 
         for (i=0; i<charts[1].y.length; i++) {
-            if (yrawVal[i] == null) {
+            if (yRawVal[i] == null) {
                 charts[1].hovertemplate[i] = 'N/A' + '<extra></extra>';
             }
             else if (charts[1].y[i] == 0) {
@@ -55,13 +58,16 @@
             else if (charts[1].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 1, i, 1000, 'MB');
             }
-            else {
+            else if(charts[1].y[i] < 1000) {
                 convertToAdaptiveBytes(charts, 1, i, 1, 'GB');
+            }
+            else {
+                convertToAdaptiveBytes(charts, 1, i, 0.001, 'TB');
             }
         }
 
         for (i=0; i<charts[2].y.length; i++) {
-            if (yrawVal[i] == null) {
+            if (yRawVal[i] == null) {
                 charts[2].hovertemplate[i] = 'N/A' + '<extra></extra>';
             }
             else if (charts[2].y[i] == 0) {
@@ -73,19 +79,22 @@
             else if (charts[2].y[i] < 1) {
                 convertToAdaptiveBytes(charts, 2, i, 1000, 'MB');
             }
-            else {
+            else if(charts[2].y[i] < 1000) {
                 convertToAdaptiveBytes(charts, 2, i, 1, 'GB');
+            }
+            else {
+                convertToAdaptiveBytes(charts, 2, i, 0.001, 'TB');
             }
         }
     }
 
     function adaptiveFilterLayout(charts, layout) {
-        var newArr = charts[0].y, sum = 0, count = 0;
-        for (var i=0; i<newArr.length; i++) {
-            sum += newArr[i];
+        var y = charts[0].y, sum = 0, count = 0;
+        for (var i=0; i<y.length; i++) {
+            sum += y[i];
         }
-        for (i=0; i<newArr.length; i++) {
-            if (newArr[i] != 0) {
+        for (i=0; i<y.length; i++) {
+            if (y[i] != 0) {
                 count++;
             }
         }
@@ -99,13 +108,15 @@
         else if (average < 1) {
             layout.yaxis.title = 'MB';
         }
-        else {
+        else if(average < 1000) {
             layout.yaxis.title = 'GB';
+        }
+        else {
+            layout.yaxis.title = 'TB';
         }
     }
 
     function adaptiveFilterSummary(i, percircles, value) {
-
         var convertToAdaptiveBytesSummary = function(i, percircles, multiplier, value, unit ) {
             percircles[i].text = Math.round((value * multiplier) * 100) / 100 + ' ' + unit;
         };
@@ -119,8 +130,11 @@
         else if (value < 1) {
             convertToAdaptiveBytesSummary(i, percircles, 1000, value, 'MB');
         }
-        else {
+        else if(value < 1000) {
             convertToAdaptiveBytesSummary(i, percircles, 1, value, 'GB');
+        }
+        else {
+            convertToAdaptiveBytesSummary(i, percircles, 0.001, value, 'TB');
         }
     }
 
@@ -303,12 +317,12 @@
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
 
         if (unit == 'adaptive_bytes') {
-            var yrawVal;
+            var yRawVal;
             for( i =0; i<charts.length; i++){
-                yrawVal = data.traces[i][1];
+                yRawVal = data.traces[i][1];
             }
             adaptiveFilterLayout(charts, layout);
-            adaptiveFilterPoints(charts, yrawVal);
+            adaptiveFilterPoints(charts, yRawVal);
         }
 
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -301,6 +301,11 @@
                 percircles.push(percircleOptions);
             }
             percircles = sortByTraceOrder(data.trace_order, percircles, '_key');
+            if(data.trace_order !== undefined) {
+                for(i=0; i<percircles.length; i++){
+                    percircles[i].text = percircles[i].text.replace(data.unit, 'GB');
+                }
+            }
             for (i=0; i<percircles.length; ++i) {
                 percircleContainer.append(
                     '<div class="small circle" title="' + percircles[i].htmlTitle + '"></div>'

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -193,15 +193,15 @@
             charts.push(options);
         }
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
-        if(data.trace_order!==undefined)  {
-            let total_traffic_charts = charts[0].y;
-            let sum = 0;
-            for(let i=0;i<total_traffic_charts.length;i++){
+        if(data.trace_order !== undefined)  {
+            var total_traffic_charts = charts[0].y;
+            var sum = 0;
+            for(var i=0; i<total_traffic_charts.length; i++){
                 sum += total_traffic_charts[i];
             }
-            let average = sum / total_traffic_charts.length;
+            var average = sum / total_traffic_charts.length;
             if (average < 0.01){
-                for(let i=0;i<total_traffic_charts.length;i++){
+                for(var i=0; i<total_traffic_charts.length; i++){
                     charts[0].y[i] *= 1000000;
                     charts[1].y[i] *= 1000000;
                     charts[2].y[i] *= 1000000;
@@ -209,7 +209,7 @@
                 unit = 'KB';
             }
             else if (average < 1){
-                for(let i=0;i<total_traffic_charts.length;i++){
+                for(var i=0; i<total_traffic_charts.length; i++){
                     charts[0].y[i] *= 1000;
                     charts[1].y[i] *= 1000;
                     charts[2].y[i] *= 1000;
@@ -220,10 +220,10 @@
                 unit = 'GB';
             }
 
-            for(let i=0;i<total_traffic_charts.length;i++){
-                charts[0].hovertemplate[i] = charts[0].y[i] + unit ;
-                charts[1].hovertemplate[i] = charts[1].y[i] + unit ;
-                charts[2].hovertemplate[i] = charts[2].y[i] + unit ;
+            for(var i=0; i<total_traffic_charts.length; i++){
+                charts[0].hovertemplate[i] = charts[0].y[i] + unit;
+                charts[1].hovertemplate[i] = charts[1].y[i] + unit;
+                charts[2].hovertemplate[i] = charts[2].y[i] + unit;
             }
             data.unit = unit;
         }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -18,7 +18,7 @@
     }
 
     function adaptiveFilterPoints(charts, layout, unit, data) {
-        var newArr = charts[0].y, sum = 0, count = 0, multiplier = 1;
+        var newArr = charts[0].y, sum = 0, count = 0, multiplier = 1, adaptValue;
 
         for(var i=0; i<newArr.length; i++) {
             sum += newArr[i];
@@ -30,12 +30,16 @@
         }
 
         var average = sum / count;
+        adaptValue = function(value, multiplier) {
+            return Math.round((value * multiplier) * 100) / 100;
+        };
+
         if (average < 0.01) {
             for(i=0; i<newArr.length; i++) {
                 multiplier = 1000000;
-                charts[0].y[i] = Math.round((charts[0].y[i] * multiplier) * 100) / 100;
-                charts[1].y[i] = Math.round((charts[1].y[i] * multiplier) * 100) / 100;
-                charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100) / 100;
+                charts[0].y[i] = adaptValue(charts[0].y[i], multiplier);
+                charts[1].y[i] = adaptValue(charts[1].y[i], multiplier);
+                charts[2].y[i] = adaptValue(charts[2].y[i], multiplier);
             }
             layout.yaxis.title = 'KB';
             unit = 'KB';
@@ -43,9 +47,9 @@
         else if (average < 1) {
             for(i=0; i<newArr.length; i++) {
                 multiplier = 1000;
-                charts[0].y[i] = Math.round((charts[0].y[i] * multiplier) * 100) / 100;
-                charts[1].y[i] = Math.round((charts[1].y[i] * multiplier) * 100) / 100;
-                charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100) / 100;
+                charts[0].y[i] = adaptValue(charts[0].y[i], multiplier);
+                charts[1].y[i] = adaptValue(charts[1].y[i], multiplier);
+                charts[2].y[i] = adaptValue(charts[2].y[i], multiplier);
             }
             layout.yaxis.title = 'MB';
             unit = 'MB';

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -193,6 +193,40 @@
             charts.push(options);
         }
         charts = sortByTraceOrder(data.trace_order, charts, '_key');
+        if(data.trace_order!==undefined)  {
+            let total_traffic_charts = charts[0].y;
+            let sum = 0;
+            for(let i=0;i<total_traffic_charts.length;i++){
+                sum += total_traffic_charts[i];
+            }
+            let average = sum / total_traffic_charts.length;
+            if (average < 0.01){
+                for(let i=0;i<total_traffic_charts.length;i++){
+                    charts[0].y[i] *= 1000000;
+                    charts[1].y[i] *= 1000000;
+                    charts[2].y[i] *= 1000000;
+                }
+                unit = 'KB';
+            }
+            else if (average < 1){
+                for(let i=0;i<total_traffic_charts.length;i++){
+                    charts[0].y[i] *= 1000;
+                    charts[1].y[i] *= 1000;
+                    charts[2].y[i] *= 1000;
+                }
+                unit = 'MB';
+            }
+            else {
+                unit = 'GB';
+            }
+
+            for(let i=0;i<total_traffic_charts.length;i++){
+                charts[0].hovertemplate[i] = charts[0].y[i] + unit ;
+                charts[1].hovertemplate[i] = charts[1].y[i] + unit ;
+                charts[2].hovertemplate[i] = charts[2].y[i] + unit ;
+            }
+            data.unit = unit;
+        }
         if (fixedY) { layout.yaxis = {range: [0, fixedYMax]}; }
 
         Plotly.newPlot(plotlyContainer, charts, layout, {responsive: true});

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -199,7 +199,13 @@
             for(i=0; i<total_traffic_charts.length; i++){
                 sum += total_traffic_charts[i];
             }
-            var average = sum / total_traffic_charts.length;
+            var count = 0;
+            for(i=0; i<total_traffic_charts.length; i++){
+                if(total_traffic_charts[i] !== 0){
+                    count++;
+                }
+            }
+            var average = sum / count;
             if (average < 0.01){
                 for(i=0; i<total_traffic_charts.length; i++){
                     charts[0].y[i] *= 1000000;

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -210,9 +210,9 @@
             if (average < 0.01){
                 for(i=0; i<total_traffic_charts.length; i++){
                     multiplier = 1000000;
-                    charts[0].y[i] = Math.round(charts[0].y[i] * multiplier, 2);
-                    charts[1].y[i] = Math.round(charts[1].y[i] * multiplier, 2);
-                    charts[2].y[i] = Math.round(charts[2].y[i] * multiplier, 2);
+                    charts[0].y[i] = Math.round((charts[0].y[i] * multiplier) * 100)/100;
+                    charts[1].y[i] = Math.round((charts[1].y[i] * multiplier) * 100)/100;
+                    charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100)/100;
                 }
                 layout.yaxis.title = ' KB';
                 unit = ' KB';
@@ -220,9 +220,9 @@
             else if (average < 1){
                 for(i=0; i<total_traffic_charts.length; i++){
                     multiplier = 1000;
-                    charts[0].y[i] = Math.round(charts[0].y[i] * multiplier, 2);
-                    charts[1].y[i] = Math.round(charts[1].y[i] * multiplier, 2);
-                    charts[2].y[i] = Math.round(charts[2].y[i] * multiplier, 2);
+                    charts[0].y[i] = Math.round((charts[0].y[i] * multiplier) * 100)/100;
+                    charts[1].y[i] = Math.round((charts[1].y[i] * multiplier) * 100)/100;
+                    charts[2].y[i] = Math.round((charts[2].y[i] * multiplier) * 100)/100;
                 }
                 layout.yaxis.title = ' MB';
                 unit = ' MB';
@@ -312,6 +312,10 @@
                 }
                 percircles.push(percircleOptions);
                 if(data.trace_order !== undefined) {
+                    if(value == 0){
+                        data.unit = ' B';
+                        percircles[i].text = value + data.unit;
+                    }
                     if(value < 0.01){
                         value *= 1000000;
                         data.unit = ' KB';

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -214,8 +214,7 @@ class TestDashboardTimeseriesView(
             self.assertEqual(chart['colorscale'], None)
             self.assertEqual(
                 chart['description'],
-                'Network traffic of the whole network (total, download, upload), and automatically '
-                'adapt units for the traffic data.',
+                'Network traffic of the whole network (total, download, upload).',
             )
 
         path = reverse('monitoring_general:api_dashboard_timeseries')

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -205,7 +205,7 @@ class TestDashboardTimeseriesView(
         def _test_chart_properties(chart):
             self.assertEqual(chart['title'], 'General Traffic')
             self.assertEqual(chart['type'], 'stackedbar+lines')
-            self.assertEqual(chart['unit'], ' GB')
+            self.assertEqual(chart['unit'], 'adaptive_bytes')
             self.assertEqual(
                 chart['summary_labels'],
                 ['Total traffic', 'Total download traffic', 'Total upload traffic'],

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -214,7 +214,8 @@ class TestDashboardTimeseriesView(
             self.assertEqual(chart['colorscale'], None)
             self.assertEqual(
                 chart['description'],
-                'Network traffic of the whole network (total, download, upload) measured in GB.',
+                'Network traffic of the whole network (total, download, upload), and automatically '
+                'adapt units for the traffic data.',
             )
 
         path = reverse('monitoring_general:api_dashboard_timeseries')


### PR DESCRIPTION
Fixes #87

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->
   Before        |  After
:-------------------------:|:-------------------------:
![Screenshot from 2022-06-19 17-45-56](https://user-images.githubusercontent.com/77020164/174481050-73a16930-a307-4e5b-9be7-e48d7edca569.png) | ![Screenshot from 2022-06-19 17-42-21](https://user-images.githubusercontent.com/77020164/174481059-2416a245-03a0-4461-92be-61a7b737ef47.png)

**After**

1. ![Screenshot (70)](https://user-images.githubusercontent.com/77020164/175225197-85c7348c-3177-4a12-bb1e-2cb1cd9237c7.png)

2. ![Screenshot (71)](https://user-images.githubusercontent.com/77020164/175228171-06ef3d7f-3fcf-4434-b516-82a690e99a0c.png)



**Changes**:
* All the data points have their data converted as per the range, and a particular chart has one specific unit.
* The percircles have their data converted and have different units as per the range.
* The side y-axis has a unit as same as what data points have.


**Demo**:

https://user-images.githubusercontent.com/77020164/175221352-22b969b6-05c2-499c-aac5-32bedc8369b4.mp4



Checks:

- [ ] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
