### PR TITLE
[fix] Fixed migrate_timeseries stalling due to retention policy #401

### DIFF
--- a/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
+++ b/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
@@ -66,6 +66,13 @@ def retry_until_success(func, *args, **kwargs):
             InfluxDBServerError,
             timeseries_db.client_error,
         ) as error:
+            if 'points beyond retention policy dropped' in str(error):
+                # When writing data to the InfluxDB, if the measurement
+                # points are older than the retention policy the
+                # InfluxDB returns a HTTP 400 response. Retrying this
+                # operation will again result in HTTP 400, hence
+                # this error is assumed as success.
+                return True
             sleep_time *= 2
             time.sleep(sleep_time)
             logger.warning(


### PR DESCRIPTION
When writing data to the InfluxDB if the measurement
points are older than the retention policy, the
InfluxDB returns a HTTP 400 response. Retrying this
operation will again result in HTTP 400, hence
this error is assumed as success.

Fixes #401

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [ ] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
