### PR TITLE
1.0.1 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+Version 1.0.1 [2022-07-01]
+--------------------------
+
+Bugfixes
+~~~~~~~~
+
+- Removed hardcoded static URLs which created
+  issues when static files are served using an
+  external service (e.g. S3 storage buckets)
+- Fixed `"migrate_timeseries" command stalling
+  when measurements exceeds retention policy
+  <https://github.com/openwisp/openwisp-monitoring/issues/401>`_
+
 Version 1.0.0 [2022-05-05]
 --------------------------
 

--- a/openwisp_monitoring/__init__.py
+++ b/openwisp_monitoring/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 0, 0, 'final')
+VERSION = (1, 0, 1, 'final')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
# Bugfixes

-   Removed hardcoded static URLs which created issues when static files
    are served using an external service (e.g. S3 storage buckets)
-   Fixed ["migrate_timeseries" command stalling when measurements
    exceeds retention policy][]

  ["migrate_timeseries" command stalling when measurements exceeds retention policy]:
    https://github.com/openwisp/openwisp-monitoring/issues/401