### PR TITLE
[feature] Added setting to configure default retention policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -951,7 +951,7 @@ Settings
 | **default**: | ``26280h0m0s`` (3 years) |
 +--------------+--------------------------+
 
-The default retention policy that applies to all the data.
+The default retention policy that applies to the timeseries data.
 
 ``OPENWISP_MONITORING_SHORT_RETENTION_POLICY``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -942,6 +942,17 @@ if there's anything that is not working as intended.
 Settings
 --------
 
+``OPENWISP_MONITORING_DEFAULT_RETENTION_POLICY``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------+--------------------------+
+| **type**:    | ``str``                  |
++--------------+--------------------------+
+| **default**: | ``26280h0m0s`` (3 years) |
++--------------+--------------------------+
+
+The default retention policy that applies to all the data.
+
 ``OPENWISP_MONITORING_SHORT_RETENTION_POLICY``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -11,8 +11,16 @@ from influxdb.exceptions import InfluxDBClientError, InfluxDBServerError
 from pytz import timezone as tz
 from swapper import load_model
 
-from openwisp_monitoring.device.settings import SHORT_RETENTION_POLICY
-from openwisp_monitoring.device.utils import SHORT_RP, manage_short_retention_policy
+from openwisp_monitoring.device.settings import (
+    DEFAULT_RETENTION_POLICY,
+    SHORT_RETENTION_POLICY,
+)
+from openwisp_monitoring.device.utils import (
+    DEFAULT_RP,
+    SHORT_RP,
+    manage_default_retention_policy,
+    manage_short_retention_policy,
+)
 from openwisp_monitoring.monitoring.tests import TestMonitoringMixin
 from openwisp_monitoring.settings import MONITORING_TIMESERIES_RETRY_OPTIONS
 from openwisp_utils.tests import capture_stderr
@@ -183,12 +191,15 @@ class TestDatabaseClient(TestMonitoringMixin, TestCase):
 
     def test_retention_policy(self):
         manage_short_retention_policy()
+        manage_default_retention_policy()
         rp = timeseries_db.get_list_retention_policies()
         self.assertEqual(len(rp), 2)
+        self.assertEqual(rp[0]['name'], DEFAULT_RP)
+        self.assertEqual(rp[0]['default'], True)
+        self.assertEqual(rp[0]['duration'], DEFAULT_RETENTION_POLICY)
         self.assertEqual(rp[1]['name'], SHORT_RP)
         self.assertEqual(rp[1]['default'], False)
-        duration = SHORT_RETENTION_POLICY
-        self.assertEqual(rp[1]['duration'], duration)
+        self.assertEqual(rp[1]['duration'], SHORT_RETENTION_POLICY)
 
     def test_query_set(self):
         c = self._create_chart(configuration='histogram')

--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -24,7 +24,11 @@ from ..settings import MONITORING_API_BASEURL, MONITORING_API_URLCONF
 from ..utils import transaction_on_commit
 from . import settings as app_settings
 from .signals import device_metrics_received, health_status_changed
-from .utils import get_device_cache_key, manage_short_retention_policy
+from .utils import (
+    get_device_cache_key,
+    manage_default_retention_policy,
+    manage_short_retention_policy,
+)
 
 
 class DeviceMonitoringConfig(AppConfig):
@@ -33,6 +37,7 @@ class DeviceMonitoringConfig(AppConfig):
     verbose_name = _('Device Monitoring')
 
     def ready(self):
+        manage_default_retention_policy()
         manage_short_retention_policy()
         self.connect_is_working_changed()
         self.connect_device_signals()

--- a/openwisp_monitoring/device/settings.py
+++ b/openwisp_monitoring/device/settings.py
@@ -43,6 +43,7 @@ def get_health_status_labels():
 
 
 SHORT_RETENTION_POLICY = get_settings_value('SHORT_RETENTION_POLICY', '24h0m0s')
+DEFAULT_RETENTION_POLICY = get_settings_value('DEFAULT_RETENTION_POLICY', '26280h0m0s')
 CRITICAL_DEVICE_METRICS = get_critical_device_metrics()
 HEALTH_STATUS_LABELS = get_health_status_labels()
 AUTO_CLEAR_MANAGEMENT_IP = get_settings_value('AUTO_CLEAR_MANAGEMENT_IP', True)

--- a/openwisp_monitoring/device/utils.py
+++ b/openwisp_monitoring/device/utils.py
@@ -2,6 +2,7 @@ from ..db import timeseries_db
 from . import settings as app_settings
 
 SHORT_RP = 'short'
+DEFAULT_RP = 'autogen'
 
 
 def get_device_cache_key(device, context='react-to-updates'):
@@ -14,3 +15,11 @@ def manage_short_retention_policy():
     """
     duration = app_settings.SHORT_RETENTION_POLICY
     timeseries_db.create_or_alter_retention_policy(SHORT_RP, duration)
+
+
+def manage_default_retention_policy():
+    """
+    creates or updates the "default" retention policy
+    """
+    duration = app_settings.DEFAULT_RETENTION_POLICY
+    timeseries_db.create_or_alter_retention_policy(DEFAULT_RP, duration)


### PR DESCRIPTION
Added setting to configure default retention policy for the
timeseries database.

Related to https://github.com/openwisp/ansible-ow-influxdb/issues/12

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)
