### PR TITLE
[fix] Fixed traffic charts showing wrong traffic total #415

### DIFF
--- a/openwisp_monitoring/db/backends/influxdb/queries.py
+++ b/openwisp_monitoring/db/backends/influxdb/queries.py
@@ -39,8 +39,7 @@ chart_query = {
     'traffic': {
         'influxdb': (
             "SELECT SUM(tx_bytes) / 1000000000 AS upload, "
-            "SUM(rx_bytes) / 1000000000 AS download, "
-            "((SUM(tx_bytes) + SUM(rx_bytes)) / 1000000000) AS total FROM {key} "
+            "SUM(rx_bytes) / 1000000000 AS download FROM {key} "
             "WHERE time >= '{time}' AND content_type = '{content_type}' "
             "AND object_id = '{object_id}' AND ifname = '{ifname}' "
             "GROUP BY time(1d)"
@@ -49,8 +48,7 @@ chart_query = {
     'general_traffic': {
         'influxdb': (
             "SELECT SUM(tx_bytes) / 1000000000 AS upload, "
-            "SUM(rx_bytes) / 1000000000 AS download, "
-            "((SUM(tx_bytes) + SUM(rx_bytes)) / 1000000000) AS total FROM {key} "
+            "SUM(rx_bytes) / 1000000000 AS download FROM {key} "
             "WHERE time >= '{time}' {organization_id} {location_id} "
             "{floorplan_id} {ifname} "
             "GROUP BY time(1d)"

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -198,10 +198,8 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         data = c.read()
         # expected download wlan0
         self.assertEqual(data['traces'][0][1][-1], 1.2)
-        # expected total wlan0
-        self.assertEqual(data['traces'][1][1][-1], 1.8)
         # expected upload wlan0
-        self.assertEqual(data['traces'][2][1][-1], 0.6)
+        self.assertEqual(data['traces'][1][1][-1], 0.6)
         # wlan1 traffic
         m = self.metric_queryset.get(name='wlan1 traffic', object_id=dd.pk)
         points = m.read(limit=10, order='-time', extra_fields=['tx_bytes'])
@@ -216,10 +214,8 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         data = c.read()
         # expected download wlan1
         self.assertEqual(data['traces'][0][1][-1], 3.0)
-        # expected total wlan1
-        self.assertEqual(data['traces'][1][1][-1], 4.5)
         # expected upload wlan1
-        self.assertEqual(data['traces'][2][1][-1], 1.5)
+        self.assertEqual(data['traces'][1][1][-1], 1.5)
 
     def test_200_no_date_supplied(self):
         o = self._create_org()
@@ -339,10 +335,8 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
                 'wifi_clients - WiFi clients: wlan0',
                 'wifi_clients - WiFi clients: wlan1',
                 'download - Traffic: wlan0',
-                'total - Traffic: wlan0',
                 'upload - Traffic: wlan0',
                 'download - Traffic: wlan1',
-                'total - Traffic: wlan1',
                 'upload - Traffic: wlan1',
                 'memory_usage - Memory Usage',
                 'CPU_load - CPU Load',
@@ -357,10 +351,8 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
                 '1',
                 '2',
                 '0.4',
-                '0.5',
                 '0.1',
                 '2.0',
-                '3.0',
                 '1.0',
                 '9.73',
                 '0.0',

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -1,4 +1,3 @@
-import decimal
 import json
 import logging
 from collections import OrderedDict
@@ -38,7 +37,6 @@ from ..tasks import timeseries_write
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
-adaptive_chart_decimal_context = decimal.Context(prec=3, rounding=decimal.ROUND_DOWN)
 
 
 class AbstractMetric(TimeStampedEditableModel):
@@ -643,9 +641,7 @@ class AbstractChart(TimeStampedEditableModel):
         rounds value if it makes sense
         """
         if adaptive:
-            return float(
-                decimal.Decimal(str(value), context=adaptive_chart_decimal_context)
-            )
+            return float('%.3f' % value)
         control = 1.0 / 10**decimal_places
         if value < control:
             decimal_places += 2

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -643,7 +643,9 @@ class AbstractChart(TimeStampedEditableModel):
         rounds value if it makes sense
         """
         if adaptive:
-            return decimal.Decimal(value, context=adaptive_chart_decimal_context)
+            return float(
+                decimal.Decimal(str(value), context=adaptive_chart_decimal_context)
+            )
         control = 1.0 / 10**decimal_places
         if value < control:
             decimal_places += 2

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -38,7 +38,7 @@ from ..tasks import timeseries_write
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
-adaptive_chart_decimal_context = decimal.Context(prec=4, rounding=decimal.ROUND_DOWN)
+adaptive_chart_decimal_context = decimal.Context(prec=3, rounding=decimal.ROUND_DOWN)
 
 
 class AbstractMetric(TimeStampedEditableModel):

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -586,7 +586,14 @@ class AbstractChart(TimeStampedEditableModel):
                 if key == 'time':
                     continue
                 traces.setdefault(key, [])
-                if decimal_places and isinstance(value, (int, float)):
+                if (
+                    # The adaptive feature does unit conversion and approximation
+                    # in the frontend, hence rounding off is skipped here.
+                    # TODO: Update this code to check for 'adaptive_prefix'
+                    not self.config_dict.get('unit', '').startswith('adaptive')
+                    and decimal_places
+                    and isinstance(value, (int, float))
+                ):
                     value = self._round(value, decimal_places)
                 traces[key].append(value)
             time = datetime.fromtimestamp(point['time'], tz=tz(timezone)).strftime(

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -227,6 +227,7 @@ DEFAULT_METRICS = {
         'charts': {
             'general_traffic': {
                 'type': 'stackedbar+lines',
+                'calculate_total': True,
                 'trace_type': {
                     'download': 'stackedbar',
                     'upload': 'stackedbar',

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -189,6 +189,7 @@ DEFAULT_METRICS = {
         'charts': {
             'traffic': {
                 'type': 'stackedbar+lines',
+                'calculate_total': True,
                 'trace_type': {
                     'download': 'stackedbar',
                     'upload': 'stackedbar',

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart.js
@@ -155,6 +155,18 @@
             }
             return {color: color, desc: desc};
         }
+        if (data.calculate_total === true) {
+            var total = data.traces[0][1].slice();
+            for (i = 1; i < data.traces.length; ++i) {
+                for (var j = 0; j < data.traces[i][1].length; ++j) {
+                    total[j] += data.traces[i][1][j];
+                }
+            }
+            data.traces.push(["total", total]);
+            data.summary.total = Object.values(data.summary).reduce(function (a, b) {
+                return a + b;
+            }, 0);
+        }
         // loop over traces to put them on the chart
         for (var i=0; i<data.traces.length; i++) {
             key = data.traces[i][0];

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -440,7 +440,6 @@ class TestDashboardTimeseriesView(
                     'time',
                     'wifi_clients - General WiFi Clients',
                     'download - General Traffic',
-                    'total - General Traffic',
                     'upload - General Traffic',
                 ],
             )
@@ -469,7 +468,7 @@ class TestDashboardTimeseriesView(
             last_line = _test_csv_response(response)
             self.assertEqual(
                 last_line,
-                [last_line[0], '3', '3.0', '', ''],
+                [last_line[0], '3', '3.0', ''],
             )
 
         self.client.force_login(org2_administrator)
@@ -478,7 +477,7 @@ class TestDashboardTimeseriesView(
             last_line = _test_csv_response(response)
             self.assertEqual(
                 last_line,
-                [last_line[0], '2', '2.0', '', ''],
+                [last_line[0], '2', '2.0', ''],
             )
 
         self.client.force_login(operator)

--- a/openwisp_monitoring/monitoring/tests/test_charts.py
+++ b/openwisp_monitoring/monitoring/tests/test_charts.py
@@ -313,3 +313,20 @@ class TestCharts(TestMonitoringMixin, TestCase):
             self.assertDictEqual(
                 DEFAULT_DASHBOARD_TRAFFIC_CHART, {'__all__': ['wan', 'eth1', 'eth0_2']}
             )
+
+    def test_adaptive_chart_approximation(self):
+        org = self._get_org()
+        metric = self._create_object_metric(
+            name='traffic',
+            configuration='general_traffic',
+            field_name='rx_bytes',
+            main_tags={'ifname': 'eth0'},
+            extra_tags={'organization_id': str(org.id)},
+        )
+
+        chart = self._create_chart(
+            metric=metric, configuration='traffic', test_data=False
+        )
+        metric.write(2365411)
+        traces = chart.read()['traces']
+        self.assertEqual(traces[0][1][-1], 0.002365411)

--- a/openwisp_monitoring/monitoring/tests/test_charts.py
+++ b/openwisp_monitoring/monitoring/tests/test_charts.py
@@ -176,6 +176,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
                 'unit': c.unit,
                 'trace_type': c.trace_type,
                 'trace_order': c.trace_order,
+                'calculate_total': False,
                 'colors': c.colors,
             }
         )
@@ -313,20 +314,3 @@ class TestCharts(TestMonitoringMixin, TestCase):
             self.assertDictEqual(
                 DEFAULT_DASHBOARD_TRAFFIC_CHART, {'__all__': ['wan', 'eth1', 'eth0_2']}
             )
-
-    def test_adaptive_chart_approximation(self):
-        org = self._get_org()
-        metric = self._create_object_metric(
-            name='traffic',
-            configuration='general_traffic',
-            field_name='rx_bytes',
-            main_tags={'ifname': 'eth0'},
-            extra_tags={'organization_id': str(org.id)},
-        )
-
-        chart = self._create_chart(
-            metric=metric, configuration='traffic', test_data=False
-        )
-        metric.write(2365411)
-        traces = chart.read()['traces']
-        self.assertEqual(traces[0][1][-1], 0.002)

--- a/openwisp_monitoring/monitoring/tests/test_charts.py
+++ b/openwisp_monitoring/monitoring/tests/test_charts.py
@@ -329,4 +329,4 @@ class TestCharts(TestMonitoringMixin, TestCase):
         )
         metric.write(2365411)
         traces = chart.read()['traces']
-        self.assertEqual(traces[0][1][-1], 0.002365411)
+        self.assertEqual(traces[0][1][-1], 0.002)

--- a/openwisp_monitoring/views.py
+++ b/openwisp_monitoring/views.py
@@ -93,6 +93,8 @@ class MonitoringApiViewMixin:
                     chart_dict['trace_type'] = chart.trace_type
                 if chart.trace_order:
                     chart_dict['trace_order'] = chart.trace_order
+                if chart.calculate_total:
+                    chart_dict['calculate_total'] = chart.calculate_total
             except InvalidChartConfigException:
                 logger.exception(f'Skipped chart for metric {chart.metric}')
                 continue


### PR DESCRIPTION
The traffic charts were showing the wrong total because of the
approximation (round-off) done in the backend to decrease the
the precision of values to two decimal places.

Since the adaptive feature already does this approximation
in the frontend, the rounding off is skipped from the backend.

Closes #415

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
