### PR TITLE
[feature] Added support for multiple iperf3 servers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1090,8 +1090,22 @@ Example:
                'udp': {'bitrate': '20M'},
                'tcp': {'bitrate': '0'},
            },
-       }
+       },
+       # another org
+       'b9734710-db30-46b0-a2fc-01f01046fe4f': {
+           # available iperf servers
+           'host': ['iperf.openwisp2.io', '192.168.5.3'],
+           'client_options': {
+               'port': 5207,
+               'udp': {'bitrate': '50M'},
+               'tcp': {'bitrate': '20M'},
+           },
+       },
    }
+
+**Note:** If an organisation has more than one iperf server configured, then it enables
+the iperf checks to run on different devices at the same time. If the current available server
+is busy running a check, then it will keep other checks back in queue until the previous check finishes.
 
 The celery-beat configuration for the iperf check needs to be added too:
 
@@ -1461,6 +1475,19 @@ For example, if you want to change only the **port number** of
 This setting allows you to set whether
 `iperf check RSA public key <#configure-iperf-check-for-authentication>`_
 will be deleted after successful completion of the check or not.
+
+``OPENWISP_MONITORING_IPERF_CHECK_LOCK_EXPIRE``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------+-------------------------------+
+| **type**:    | ``int``                       |
++--------------+-------------------------------+
+| **default**: | ``600``                       |
++--------------+-------------------------------+
+
+This setting allows you to set a cache lock expiration time for the iperf check when
+running on multiple servers. Make sure it is always greater than the total iperf check
+time, i.e. greater than the TCP + UDP test time. By default, it is set to **600 seconds (10 mins)**.
 
 ``OPENWISP_MONITORING_AUTO_CHARTS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -1103,7 +1103,7 @@ Example:
        },
    }
 
-**Note:** If an organisation has more than one iperf server configured, then it enables
+**Note:** If an organization has more than one iperf server configured, then it enables
 the iperf checks to run concurrently on different devices. If all of the available servers
 are busy, then it will add the check back in the queue.
 

--- a/README.rst
+++ b/README.rst
@@ -1104,8 +1104,8 @@ Example:
    }
 
 **Note:** If an organisation has more than one iperf server configured, then it enables
-the iperf checks to run on different devices at the same time. If the current available server
-is busy running a check, then it will keep other checks back in queue until the previous check finishes.
+the iperf checks to run concurrently on different devices. If all of the available servers
+are busy, then it will add the check back in the queue.
 
 The celery-beat configuration for the iperf check needs to be added too:
 

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -94,11 +94,11 @@ class AbstractCheck(TimeStampedEditableModel):
         check_class = self.check_class
         return check_class(check=self, params=self.params)
 
-    def perform_check(self, store=True):
+    def perform_check(self, store=True, **kwargs):
         """
         initiates check instance and calls its check method
         """
-        return self.check_instance.check(store=True)
+        return self.check_instance.check(store=True, **kwargs)
 
 
 def auto_ping_receiver(sender, instance, created, **kwargs):

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -94,11 +94,16 @@ class AbstractCheck(TimeStampedEditableModel):
         check_class = self.check_class
         return check_class(check=self, params=self.params)
 
-    def perform_check(self, store=True, **kwargs):
+    def perform_check(self, store=True):
         """
         initiates check instance and calls its check method
         """
-        return self.check_instance.check(store=True, **kwargs)
+        return self.check_instance.check(store=True)
+
+    def perform_check_delayed(self, duration=0):
+        from ..tasks import perform_check
+
+        perform_check.apply_async(args=[self.id], countdown=duration)
 
 
 def auto_ping_receiver(sender, instance, created, **kwargs):

--- a/openwisp_monitoring/check/classes/iperf.py
+++ b/openwisp_monitoring/check/classes/iperf.py
@@ -113,7 +113,9 @@ class Iperf(BaseCheck):
     def _validate_iperf_config(self, org):
         # if iperf config is present and validate it's params
         if app_settings.IPERF_CHECK_CONFIG:
-            self.validate_params(params=app_settings.IPERF_CHECK_CONFIG[str(org.id)])
+            self.validate_params(
+                params=app_settings.IPERF_CHECK_CONFIG.get(str(org.id))
+            )
 
     def check(self, store=True):
         lock_acquired = False
@@ -281,7 +283,7 @@ class Iperf(BaseCheck):
                 return check_params
 
         if iperf_config:
-            iperf_config = iperf_config[org_id]
+            iperf_config = iperf_config.get(org_id)
             iperf_config_param = self._deep_get(iperf_config, conf_key)
             if iperf_config_param:
                 return iperf_config_param

--- a/openwisp_monitoring/check/classes/iperf.py
+++ b/openwisp_monitoring/check/classes/iperf.py
@@ -145,7 +145,7 @@ class Iperf(BaseCheck):
             if lock_acquired:
                 break
         else:
-            logger.warning(
+            logger.info(
                 (
                     f'At the moment, all available iperf servers of organization "{org}" '
                     f'are busy running checks, putting "{self.check_instance}" back in the queue..'

--- a/openwisp_monitoring/check/classes/iperf.py
+++ b/openwisp_monitoring/check/classes/iperf.py
@@ -110,12 +110,6 @@ class Iperf(BaseCheck):
             raise ValidationError({'params': message}) from e
 
     def check(self, store=True, **kwargs):
-        iperf_config = app_settings.IPERF_CHECK_CONFIG
-        org = self.related_object.organization
-        org_id = str(org.id)
-        if iperf_config:
-            self.validate_params(params=iperf_config[org_id])
-
         port = self._get_param(
             'client_options.port', 'client_options.properties.port.default'
         )

--- a/openwisp_monitoring/check/classes/iperf.py
+++ b/openwisp_monitoring/check/classes/iperf.py
@@ -147,7 +147,6 @@ class Iperf(BaseCheck):
 
         server, lock_acquired = self._get_iperf_servers()
         server_lock_id = f'ow_monitoring_iperf_check_{server}'
-        print(f'Server : {server}, Device : {self.related_object}')
         command_tcp = f'iperf3 -c {server} -p {port} -t {time} -b {tcp_bitrate} -J'
         command_udp = f'iperf3 -c {server} -p {port} -t {time} -b {udp_bitrate} -u -J'
 
@@ -225,7 +224,7 @@ class Iperf(BaseCheck):
         for server in servers:
             server_lock_id = f'ow_monitoring_iperf_check_{server}'
             lock_acquired = redis_client.set(
-                server_lock_id, 'server_locked', ex=2 * 25, nx=True
+                server_lock_id, 'server_locked', ex=25, nx=True
             )
             if lock_acquired:
                 return server, lock_acquired

--- a/openwisp_monitoring/check/settings.py
+++ b/openwisp_monitoring/check/settings.py
@@ -15,7 +15,7 @@ PING_CHECK_CONFIG = get_settings_value('PING_CHECK_CONFIG', {})
 AUTO_IPERF = get_settings_value('AUTO_IPERF', False)
 IPERF_CHECK_CONFIG = get_settings_value('IPERF_CHECK_CONFIG', {})
 IPERF_CHECK_LOCK_EXPIRE = get_settings_value(
-    'IPERF_CHECK_LOCK_EXPIRE', 5 * 60
-)  # 5 mins (arbitrarily selected)
+    'IPERF_CHECK_LOCK_EXPIRE', 10 * 60
+)  # 10 minutes arbitrarily chosen (must be longer than TCP + UDP test time)
 IPERF_CHECK_DELETE_RSA_KEY = get_settings_value('IPERF_CHECK_DELETE_RSA_KEY', True)
 CHECKS_LIST = get_settings_value('CHECK_LIST', list(dict(CHECK_CLASSES).keys()))

--- a/openwisp_monitoring/check/settings.py
+++ b/openwisp_monitoring/check/settings.py
@@ -14,5 +14,8 @@ MANAGEMENT_IP_ONLY = get_settings_value('MANAGEMENT_IP_ONLY', True)
 PING_CHECK_CONFIG = get_settings_value('PING_CHECK_CONFIG', {})
 AUTO_IPERF = get_settings_value('AUTO_IPERF', False)
 IPERF_CHECK_CONFIG = get_settings_value('IPERF_CHECK_CONFIG', {})
+IPERF_CHECK_LOCK_EXPIRE = get_settings_value(
+    'IPERF_CHECK_LOCK_EXPIRE', 5 * 60
+)  # 5 mins (arbitrarily selected)
 IPERF_CHECK_DELETE_RSA_KEY = get_settings_value('IPERF_CHECK_DELETE_RSA_KEY', True)
 CHECKS_LIST = get_settings_value('CHECK_LIST', list(dict(CHECK_CLASSES).keys()))

--- a/openwisp_monitoring/check/tasks.py
+++ b/openwisp_monitoring/check/tasks.py
@@ -1,15 +1,22 @@
 import json
 import logging
+from time import monotonic
 
 from celery import shared_task
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
+from redis import StrictRedis
 from swapper import load_model
 
 from .settings import CHECKS_LIST
 
 logger = logging.getLogger(__name__)
+# We need to be careful while utilising this time variable.
+# lock expires in 25 secs, just greater than the TCP + UDP test time
+CACHE_LOCK_EXPIRE = 25
+# Todo: Update redis host
+redis_client = StrictRedis('localhost', 6379, charset="utf-8", decode_responses=True)
 
 
 def get_check_model():
@@ -60,7 +67,30 @@ def perform_check(uuid):
     except ObjectDoesNotExist:
         logger.warning(f'The check with uuid {uuid} has been deleted')
         return
-    result = check.perform_check()
+    if check.check_type not in ['openwisp_monitoring.check.classes.Iperf']:
+        result = check.perform_check()
+    else:
+        check_lock_id = 'ow_monitoring_iperf_check_lock'
+        # Timeout with a small diff, so we'll leave the lock delete
+        # to the cache if it's close to being auto-removed/expired
+        timeout_at = monotonic() + CACHE_LOCK_EXPIRE - 1.5
+
+        # Try to acquire a lock, or put task back on queue
+        lock_acquired = redis_client.set(check_lock_id, 'locked', nx=True)
+        if not lock_acquired:
+            logger.warning(
+                f'The Iperf server is already occupied by a device, so putting {check} back in queue'
+            )
+            # We need to be careful while utilising this time variable
+            # just greater than the TCP + UDP test time
+            perform_check.apply_async(args=[uuid], countdown=25)
+            return
+        try:
+            result = check.perform_check()
+        finally:
+            # Release the lock
+            if monotonic() < timeout_at:
+                redis_client.delete(check_lock_id)
     if settings.DEBUG:  # pragma: nocover
         print(json.dumps(result, indent=4, sort_keys=True))
 

--- a/openwisp_monitoring/check/tasks.py
+++ b/openwisp_monitoring/check/tasks.py
@@ -17,7 +17,7 @@ def get_check_model():
     return load_model('check', 'Check')
 
 
-def _run_iperf_check_on_multiple_servers(uuid, check):  # pragma: no cover
+def _run_iperf_check_on_multiple_servers(uuid, check):
     """
     This will ensure that we only run iperf checks on those servers
     which are currently available for that organisation at that time,
@@ -30,7 +30,7 @@ def _run_iperf_check_on_multiple_servers(uuid, check):  # pragma: no cover
     org = check.content_object.organization
     iperf_check = check.check_instance
     # if iperf config is present and validate it's params
-    if IPERF_CHECK_CONFIG:
+    if IPERF_CHECK_CONFIG:  # pragma: nocover
         iperf_check.validate_params(params=IPERF_CHECK_CONFIG[str(org.id)])
     available_iperf_servers = iperf_check._get_param('host', 'host.default')
     iperf_check_time = iperf_check._get_param(
@@ -48,7 +48,6 @@ def _run_iperf_check_on_multiple_servers(uuid, check):  # pragma: no cover
     for server in available_iperf_servers:
         server_lock_key = f'ow_monitoring_{org}_iperf_check_{server}'
         # Set available_iperf_server to the org device
-        # this cache key value will be used within iperf_check
         lock_acquired = cache.set(
             server_lock_key,
             str(check.content_object),
@@ -122,9 +121,7 @@ def perform_check(uuid):
     except ObjectDoesNotExist:
         logger.warning(f'The check with uuid {uuid} has been deleted')
         return
-    if check.check_type in [
-        'openwisp_monitoring.check.classes.Iperf'
-    ]:  # pragma: no cover
+    if check.check_type in ['openwisp_monitoring.check.classes.Iperf']:
         result = _run_iperf_check_on_multiple_servers(uuid, check)
     else:
         result = check.perform_check()

--- a/openwisp_monitoring/check/tests/test_iperf.py
+++ b/openwisp_monitoring/check/tests/test_iperf.py
@@ -123,7 +123,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com']
+        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_no_params(
@@ -154,7 +154,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com']
+        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_params(
@@ -221,7 +221,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com']
+        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_config(
@@ -339,7 +339,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com']
+        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check(self, mock_warn, mock_get_iperf_servers, mock_exec_command):
@@ -522,7 +522,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com']
+        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_auth_config(

--- a/openwisp_monitoring/check/tests/test_iperf.py
+++ b/openwisp_monitoring/check/tests/test_iperf.py
@@ -123,7 +123,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
+        Iperf, '_get_iperf_servers', return_value='iperf.openwisptestserver.com'
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_no_params(
@@ -154,7 +154,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
+        Iperf, '_get_iperf_servers', return_value='iperf.openwisptestserver.com'
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_params(
@@ -221,7 +221,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
+        Iperf, '_get_iperf_servers', return_value='iperf.openwisptestserver.com'
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_config(
@@ -339,7 +339,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
+        Iperf, '_get_iperf_servers', return_value='iperf.openwisptestserver.com'
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check(self, mock_warn, mock_get_iperf_servers, mock_exec_command):
@@ -522,7 +522,7 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Iperf, '_exec_command')
     @patch.object(
-        Iperf, '_get_iperf_servers', return_value=['iperf.openwisptestserver.com', True]
+        Iperf, '_get_iperf_servers', return_value='iperf.openwisptestserver.com'
     )
     @patch.object(iperf_logger, 'warning')
     def test_iperf_check_auth_config(

--- a/openwisp_monitoring/check/tests/test_iperf.py
+++ b/openwisp_monitoring/check/tests/test_iperf.py
@@ -605,11 +605,13 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
 
     @patch.object(Ssh, 'exec_command')
     @patch.object(iperf_logger, 'warning')
+    @patch.object(iperf_logger, 'info')
     @patch.object(cache, 'add')
     def test_iperf_check_task_with_multiple_server_config(self, *args):
         mock_add = args[0]
-        mock_warn = args[1]
-        mock_exec_command = args[2]
+        mock_info = args[1]
+        mock_warn = args[2]
+        mock_exec_command = args[3]
         org = self.device.organization
         iperf_multiple_server_config = {
             self.org_id: {'host': self._IPERF_TEST_MULTIPLE_SERVERS}
@@ -706,14 +708,13 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
                 mock_add.side_effect = [False, False, True]
                 mock_exec_command.side_effect = [(RESULT_TCP, 0), (RESULT_UDP, 0)]
                 self._perform_iperf_check()
-                mock_warn.assert_called_with(
+                mock_info.has_called_with(
                     (
                         f'At the moment, all available iperf servers of organization "{org}" '
                         f'are busy running checks, putting "{check}" back in the queue..'
                     )
                 )
-
-                self.assertEqual(mock_warn.call_count, 1)
+                self.assertEqual(mock_info.call_count, 4)
                 self.assertEqual(mock_add.call_count, 3)
                 self.assertEqual(mock_exec_command.call_count, 2)
                 mock_exec_command.assert_has_calls(

--- a/openwisp_monitoring/check/tests/test_iperf.py
+++ b/openwisp_monitoring/check/tests/test_iperf.py
@@ -369,8 +369,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
                 self.assertEqual(mock_warn.call_count, 2)
                 self.assertEqual(mock_exec_command.call_count, 2)
                 mock_warn.assert_has_calls(EXPECTED_WARN_CALLS)
-                mock_warn.reset_mock()
-                mock_exec_command.reset_mock()
+            mock_warn.reset_mock()
+            mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf3 is not installed on the device'):
             mock_exec_command.side_effect = [(error, 127)]
@@ -380,8 +380,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
             )
             self.assertEqual(mock_warn.call_count, 1)
             self.assertEqual(mock_exec_command.call_count, 1)
-            mock_warn.reset_mock()
-            mock_exec_command.reset_mock()
+        mock_warn.reset_mock()
+        mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf check passes in both TCP & UDP'):
             mock_exec_command.side_effect = [(RESULT_TCP, 0), (RESULT_UDP, 0)]
@@ -432,8 +432,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
             self.assertEqual(mock_warn.call_count, 0)
             self.assertEqual(mock_exec_command.call_count, 2)
             mock_exec_command.assert_has_calls(self._EXPECTED_COMMAND_CALLS)
-            mock_warn.reset_mock()
-            mock_exec_command.reset_mock()
+        mock_warn.reset_mock()
+        mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf check fails in both TCP & UDP'):
             mock_exec_command.side_effect = [(RESULT_FAIL, 1), (RESULT_FAIL, 1)]
@@ -445,8 +445,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
             self.assertEqual(mock_exec_command.call_count, 2)
             mock_warn.assert_has_calls(self._EXPECTED_WARN_CALLS)
             mock_exec_command.assert_has_calls(self._EXPECTED_COMMAND_CALLS)
-            mock_warn.reset_mock()
-            mock_exec_command.reset_mock()
+        mock_warn.reset_mock()
+        mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf check TCP pass UDP fail'):
             mock_exec_command.side_effect = [(RESULT_TCP, 0), (RESULT_FAIL, 1)]
@@ -479,8 +479,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
             self.assertEqual(mock_exec_command.call_count, 2)
             mock_warn.assert_has_calls(self._EXPECTED_WARN_CALLS[1:])
             mock_exec_command.assert_has_calls(self._EXPECTED_COMMAND_CALLS)
-            mock_warn.reset_mock()
-            mock_exec_command.reset_mock()
+        mock_warn.reset_mock()
+        mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf check TCP fail UDP pass'):
             mock_exec_command.side_effect = [(RESULT_FAIL, 1), (RESULT_UDP, 0)]
@@ -565,8 +565,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
                 self.assertEqual(mock_warn.call_count, 0)
                 self.assertEqual(mock_exec_command.call_count, 2)
                 mock_exec_command.assert_has_calls(self._EXPECTED_COMMAND_CALLS)
-                mock_warn.reset_mock()
-                mock_exec_command.reset_mock()
+            mock_warn.reset_mock()
+            mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf check with wrong password'):
             with patch.object(
@@ -584,8 +584,8 @@ class TestIperf(CreateConnectionsMixin, TestDeviceMonitoringMixin, TransactionTe
                 self.assertEqual(mock_exec_command.call_count, 2)
                 mock_warn.assert_has_calls(self._EXPECTED_WARN_CALLS)
                 mock_exec_command.assert_has_calls(self._EXPECTED_COMMAND_CALLS)
-                mock_warn.reset_mock()
-                mock_exec_command.reset_mock()
+            mock_warn.reset_mock()
+            mock_exec_command.reset_mock()
 
         with self.subTest('Test iperf check with wrong username'):
             with patch.object(


### PR DESCRIPTION
### `Iperf check` on multiple server

https://user-images.githubusercontent.com/56113566/187673896-1e358f5e-98bc-4afb-b3c4-21ef2750fb39.mp4

![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)

#### If the server is already occupied by the `device`, then put other `iperf_checks` back in the queue

![Screenshot from 2022-09-02 17-50-46](https://user-images.githubusercontent.com/56113566/188141962-54f99094-d594-4653-8e47-34b40159f55f.png)

### Iperf check `cache keys`

![Screenshot from 2022-09-05 14-09-03](https://user-images.githubusercontent.com/56113566/188406682-cd64ea45-876f-4a2d-9f8d-0399673861c8.png)

#### Cache keys before running checks

![Screenshot from 2022-09-05 14-02-42](https://user-images.githubusercontent.com/56113566/188406328-a167d229-9a01-4a94-9718-a8b888c9d12c.png)

#### Cache keys in between running checks

![Screenshot from 2022-09-05 14-03-06](https://user-images.githubusercontent.com/56113566/188406358-63274898-dead-491e-ab15-37e9ff17cd95.png)

#### Cache keys after completion of checks

![Screenshot from 2022-09-05 14-03-24](https://user-images.githubusercontent.com/56113566/188406379-d6bb9bd4-08db-4557-a190-058c5ae03146.png)

 
Closes #391

![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/rainbow.png)
Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)

Closes #439 