### PR TITLE
[fix] Fixed WifiSession dashboard pie chart 

### DIFF
--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -324,6 +324,7 @@ class DeviceMonitoringConfig(AppConfig):
                         'aggregate': {
                             'active__sum': Sum('active'),
                         },
+                        'organization_field': 'device__organization_id',
                     },
                     'filters': {
                         'key': 'stop_time__isnull',

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -528,3 +528,17 @@ class TestWifiSessionAdmin(
         response = self.client.post(path, {'post': 'yes'}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Device.objects.count(), 0)
+
+    def test_dashboard_wifi_session_chart(self):
+        org1 = self._create_org(name='org1', slug='org1')
+        org1_device = self._create_device(organization=org1)
+        self._create_wifi_session(device=org1_device)
+        org2 = self._create_org(name='org2', slug='org2')
+        administrator = self._create_administrator([org2])
+        self.client.force_login(administrator)
+        response = self.client.get(reverse('admin:index'))
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.context['dashboard_charts'][13]['query_params'],
+            {'labels': [], 'values': []},
+        )

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/tarball/master
+openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/tarball/62c6dfac559e914e8186de4aa80c56b03012ba38
 redis~=3.5.3
 django-redis~=4.12.1
 mock-ssh-server~=0.9.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/tarball/62c6dfac559e914e8186de4aa80c56b03012ba38
+openwisp-utils[qa] @ https://github.com/openwisp/openwisp-utils/tarball/5a8f1dea187586d85c77b46e6e3fd725f557e3c6
 redis~=3.5.3
 django-redis~=4.12.1
 mock-ssh-server~=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ django-cache-memoize~=0.1.0
 django-nested-admin~=3.4.0
 netaddr~=0.8
 python-dateutil>=2.7,<3.0
-openwisp-utils[rest] @ https://github.com/openwisp/openwisp-utils/tarball/62c6dfac559e914e8186de4aa80c56b03012ba38
+openwisp-utils[rest] @ https://github.com/openwisp/openwisp-utils/tarball/5a8f1dea187586d85c77b46e6e3fd725f557e3c6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ django-cache-memoize~=0.1.0
 django-nested-admin~=3.4.0
 netaddr~=0.8
 python-dateutil>=2.7,<3.0
-openwisp-utils[rest] @ https://github.com/openwisp/openwisp-utils/tarball/master
+openwisp-utils[rest] @ https://github.com/openwisp/openwisp-utils/tarball/62c6dfac559e914e8186de4aa80c56b03012ba38


### PR DESCRIPTION
The WifiSession pie chart on the dashboard was not filtering the
queryset by the related device's organization.

**Blockers**

- [x] https://github.com/openwisp/openwisp-utils/pull/313

Checks:

- [x] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
