### PR TITLE
[feature] Added zooming graphs to provide a detailed view #27

### DIFF
--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -1005,39 +1005,31 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             self.assertIn(expected, chart_group)
 
         with self.subTest('Test custom grouping between 1 to 2 days'):
-            custom_date_query = (
-                '&time=2d&start=2022-10-02%2000:00:00&end=2022-10-04%2023:59:59'
-            )
+            custom_date_query = '&start=2022-10-02%2000:00:00&end=2022-10-04%2023:59:59'
             url = f'{self._url(d.pk, d.key)}{custom_date_query}'
             _assert_chart_group(url, 200, ('2d', '10m'))
 
         with self.subTest('Test custom grouping between 3 to 6 days'):
-            custom_date_query = (
-                '&time=4d&start=2022-10-02%2000:00:00&end=2022-10-06%2023:59:59'
-            )
+            custom_date_query = '&start=2022-10-02%2000:00:00&end=2022-10-06%2023:59:59'
             url = f'{self._url(d.pk, d.key)}{custom_date_query}'
             _assert_chart_group(url, 200, ('4d', '25m'))
 
         with self.subTest('Test custom grouping between 8 to 27 days'):
-            custom_date_query = (
-                '&time=12d&start=2022-09-29%2000:00:00&end=2022-10-11%2015:50:56'
-            )
+            custom_date_query = '&start=2022-09-29%2000:00:00&end=2022-10-11%2015:50:56'
             url = f'{self._url(d.pk, d.key)}{custom_date_query}'
             _assert_chart_group(url, 200, ('12d', '2h'))
 
         with self.subTest('Test custom grouping between 28 to 364 days'):
-            custom_date_query = (
-                '&time=99d&start=2022-07-04%2000:00:00&end=2022-10-11%2015:50:56'
-            )
+            custom_date_query = '&start=2022-07-04%2000:00:00&end=2022-10-11%2015:50:56'
             url = f'{self._url(d.pk, d.key)}{custom_date_query}'
             _assert_chart_group(url, 200, ('99d', '1d'))
 
         with self.subTest('Test invalid custom dates'):
             invalid_custom_dates = (
-                '&time=99d&start=2022-07-04&end=2022-10-11',
-                '&time=15d&start=September&end=October',
-                '&time=23d&start=2022-07-04&end=10-11-2022%2015:50:56',
-                '&time=33d&start=09-08-2022%2000:00:00&end=10-11-2022%2016:39:29',
+                '&start=2022-07-04&end=2022-10-11',
+                '&start=September&end=October',
+                '&start=2022-07-04&end=10-11-2022%2015:50:56',
+                '&start=09-08-2022%2000:00:00&end=10-11-2022%2016:39:29',
             )
             for invalid_date in invalid_custom_dates:
                 url = f'{self._url(d.pk, d.key)}{invalid_date}'
@@ -1050,7 +1042,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             'Test device metrics when start date is greater than end date'
         ):
             start_greater_than_end = (
-                '&time=10d&start=2022-09-23%2000:00:00&end=2022-09-13%2023:59:59'
+                '&start=2022-09-23%2000:00:00&end=2022-09-13%2023:59:59'
             )
             url = f'{self._url(d.pk, d.key)}{start_greater_than_end}'
             r = self.client.get(url)
@@ -1064,7 +1056,9 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         ):
             start_greater = (now + timedelta(days=5)).strftime('%Y-%m-%d')
             end_greater = (now + timedelta(days=9)).strftime('%Y-%m-%d')
-            start_greater_than_now = f'&time=4d&start={start_greater}%2000:00:00&end={end_greater}%2023:59:59'
+            start_greater_than_now = (
+                f'&start={start_greater}%2000:00:00&end={end_greater}%2023:59:59'
+            )
             url = f'{self._url(d.pk, d.key)}{start_greater_than_now}'
             r = self.client.get(url)
             self.assertEqual(r.status_code, 400)
@@ -1078,7 +1072,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             start_lesser = (now - timedelta(days=2)).strftime('%Y-%m-%d')
             end_greater = (now + timedelta(days=5)).strftime('%Y-%m-%d')
             end_greater_than_now = (
-                f'&time=7d&start={start_lesser}%2000:00:00&end={end_greater}%2023:59:59'
+                f'&start={start_lesser}%2000:00:00&end={end_greater}%2023:59:59'
             )
             url = f'{self._url(d.pk, d.key)}{end_greater_than_now}'
             r = self.client.get(url)
@@ -1092,7 +1086,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             'Test device metrics when date range is greater than 365 days'
         ):
             greater_than_365_days = (
-                '&time=366d&start=2021-11-11%2000:00:00&end=2022-11-12%2023:59:59'
+                '&start=2021-11-11%2000:00:00&end=2022-11-12%2023:59:59'
             )
             url = f'{self._url(d.pk, d.key)}{greater_than_365_days}'
             r = self.client.get(url)
@@ -1112,7 +1106,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             self._create_chart(metric=m, configuration='histogram')
             m.write(None, extra_values={'http2': 90, 'ssh': 100, 'udp': 80, 'spdy': 70})
             custom_date_query = (
-                f'&time=2d&start={start_date}%2000:00:00&end={end_date}%2000:00:00'
+                f'&start={start_date}%2000:00:00&end={end_date}%2000:00:00'
             )
             url = f'{self._url(d.pk, d.key)}{custom_date_query}&csv=1'
             response = self.client.get(url)

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -1030,7 +1030,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
                 '&time=99d&start=2022-07-04%2000:00:00&end=2022-10-11%2015:50:56'
             )
             url = f'{self._url(d.pk, d.key)}{custom_date_query}'
-            _assert_chart_group(url, 200, ('99d', '4d'))
+            _assert_chart_group(url, 200, ('99d', '1d'))
 
         with self.subTest('Test invalid custom dates'):
             invalid_custom_dates = (
@@ -1085,6 +1085,20 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             self.assertEqual(r.status_code, 400)
             self.assertIn(
                 "end_date cannot be greater than today's date",
+                r.data,
+            )
+
+        with self.subTest(
+            'Test device metrics when date range is greater than 365 days'
+        ):
+            greater_than_365_days = (
+                '&time=366d&start=2021-11-11%2000:00:00&end=2022-11-12%2023:59:59'
+            )
+            url = f'{self._url(d.pk, d.key)}{greater_than_365_days}'
+            r = self.client.get(url)
+            self.assertEqual(r.status_code, 400)
+            self.assertIn(
+                "The date range shouldn't be greater than 365 days",
                 r.data,
             )
 

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -426,7 +426,7 @@ class AbstractChart(TimeStampedEditableModel):
     configuration = models.CharField(
         max_length=16, null=True, choices=CHART_CONFIGURATION_CHOICES
     )
-    GROUP_MAP = {'1d': '10m', '3d': '20m', '7d': '1h', '30d': '24h', '365d': '24h'}
+    GROUP_MAP = {'1d': '10m', '3d': '20m', '7d': '1h', '30d': '24h', '365d': '7d'}
     DEFAULT_TIME = '7d'
 
     class Meta:
@@ -570,9 +570,12 @@ class AbstractChart(TimeStampedEditableModel):
         # custom grouping between 8 to 27 days
         elif days > 7 and days < 28:
             group = str(round(days / 7)) + 'h'
-        # custom grouping between 28 to 364 days
-        elif days >= 28 and days < 365:
-            group = str(round(days / 28)) + 'd'
+        # custom grouping between 1 month to 7 month
+        elif days >= 30 and days <= 210:
+            group = '1d'
+        # custom grouping between 7 month to 1 year
+        elif days > 210 and days <= 365:
+            group = '7d'
         custom_group_map.update({time: group})
         return custom_group_map
 

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -244,15 +244,11 @@ django.jQuery(function ($) {
       var startLabel = localStorage.getItem(startDayKey) || moment().format('MMMM D, YYYY');
       var endLabel = localStorage.getItem(endDayKey) || moment().format('MMMM D, YYYY');
       
-      // Disable zoom charts scrolling on page refresh
+      // Disable the zoom chart and scrolling when we refresh the page
       localStorage.setItem(isChartZoomScroll, false);
-      if (localStorage.getItem(isChartZoomed) === 'true') {
-        range = localStorage.getItem(zoomtimeRangeKey);
-        endLabel = localStorage.getItem(zoomEndDayKey);
-        startLabel = localStorage.getItem(zoomStartDayKey);
-      }
-  
-      if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(isChartZoomed) === 'false') {
+      localStorage.setItem(isChartZoomed, false);
+
+      if (localStorage.getItem(isCustomDateRange) === 'true') {
         // Add label to daterangepicker widget
         addDateRangePickerLabel(startLabel, endLabel);
         // Set last selected custom date after page reload

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -286,8 +286,7 @@ django.jQuery(function ($) {
       clearInterval(window.owChartRefresh);
       window.owChartRefresh = setInterval(loadFetchedCharts,
         1000 * 60 * 2.5,
-        pickerDays,
-        false
+        pickerDays
       );
     });
     // bind export button
@@ -314,6 +313,7 @@ django.jQuery(function ($) {
         success: function (data) {
           if (data.charts.length) {
             createCharts(data);
+            triggerZoomCharts('js-plotly-plot');
           }
         },
         error: function () {

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -144,7 +144,8 @@ django.jQuery(function ($) {
             endDate = localStorage.getItem(zoomEndDateTimeKey);
             startDate = localStorage.getItem(zoomStartDateTimeKey);
           }
-          url = `${baseUrl}${time}&start=${startDate}&end=${endDate}`;
+          var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          url = `${apiUrl}?key=${originalKey}&timezone=${timezone}&start=${startDate}&end=${endDate}`;
         }
         $.ajax(url, {
           dataType: 'json',
@@ -291,7 +292,8 @@ django.jQuery(function ($) {
         endDate = localStorage.getItem(zoomEndDateTimeKey);
         startDate = localStorage.getItem(zoomStartDateTimeKey);
       }
-      location.href = `${baseUrl}${time}&start=${startDate}&end=${endDate}&csv=1`;
+      var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      location.href = `${apiUrl}?key=${originalKey}&timezone=${timezone}&start=${startDate}&end=${endDate}&csv=1`;
       }
     });
   });

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -261,9 +261,14 @@ django.jQuery(function ($) {
       var time = localStorage.getItem(timeRangeKey);
       location.href = baseUrl + time + '&csv=1';
       // If custom pass pickerEndDate and pickerStartDate to csv url
-      if (localStorage.getItem(isCustomDateRange) === 'true') {
+      if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(pickerChosenLabelKey) === 'Custom Range') {
       var startDate = localStorage.getItem(startDateTimeKey);
       var endDate = localStorage.getItem(endDateTimeKey);
+      if (localStorage.getItem(isChartZoomed) === 'true') {
+        time = localStorage.getItem(zoomtimeRangeKey);
+        endDate = localStorage.getItem(zoomEndDateTimeKey);
+        startDate = localStorage.getItem(zoomStartDateTimeKey);
+      }
       location.href = `${baseUrl}${time}&start=${startDate}&end=${endDate}&csv=1`;
       }
     });

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -73,7 +73,7 @@ django.jQuery(function ($) {
               clearInterval(window.owChartRefresh);
               window.owChartRefresh = setInterval(loadCharts,
                 1000 * 60 * 2.5,
-                pickerDays,
+                daysBeforeZoom,
                 false
               );
               return;
@@ -126,8 +126,8 @@ django.jQuery(function ($) {
           var startDate = localStorage.getItem(startDateTimeKey);
           var endDate = localStorage.getItem(endDateTimeKey);
           if (localStorage.getItem(isChartZoomed) === 'true') {
-            startDate = localStorage.getItem(zoomStartDateTimeKey);
             endDate = localStorage.getItem(zoomEndDateTimeKey);
+            startDate = localStorage.getItem(zoomStartDateTimeKey);
           }
           url = `${baseUrl}${time}&start=${startDate}&end=${endDate}`;
         }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -1,11 +1,17 @@
 'use strict';
-const isCustomDateRange = 'ow2-chart-custom-daterange'; // true/false
 const isChartZoomed = 'ow2-chart-custom-zoom'; // true/false
+const isCustomDateRange = 'ow2-chart-custom-daterange'; // true/false
 const timeRangeKey = 'ow2-chart-time-range'; // 30d
 const startDayKey = 'ow2-chart-start-day'; // September 3, 2022
 const endDayKey = 'ow2-chart-end-day'; // October 3, 2022
 const startDateTimeKey = 'ow2-chart-start-datetime'; // 2022-09-03 00:00:00
 const endDateTimeKey = 'ow2-chart-end-datetime'; // 2022-09-03 00:00:00
+const pickerChosenLabelKey = 'ow2-chart-picker-label'; // 2022-09-03 00:00:00
+const zoomtimeRangeKey = 'ow2-chart-zoom-time-range'; // 30d
+const zoomStartDayKey = 'ow2-chart-zoom-start-day'; // September 3, 2022
+const zoomEndDayKey = 'ow2-chart-zoom-end-day'; // October 3, 2022
+const zoomStartDateTimeKey = 'ow2-chart-zoom-start-datetime'; // 2022-09-03 00:00:00
+const zoomEndDateTimeKey = 'ow2-chart-zoom-end-datetime'; // 2022-09-03 00:00:00
 
 django.jQuery(function ($) {
   $(document).ready(function () {
@@ -37,40 +43,71 @@ django.jQuery(function ($) {
       }, initDateRangePickerWidget);
       initDateRangePickerWidget(start, end);
 
-    function handleChartZoomChange(chartsId) {
+    function handleChartZoomChange(chartsContainers) {
       // Handle chart zooming with custom dates
-      var zoomChart = document.getElementById(chartsId);
-      zoomChart.on('plotly_relayout',
-        function (eventdata) {
-          var pickerEnd = moment(eventdata['xaxis.range[1]']);
-          var pickerStart = moment(eventdata['xaxis.range[0]']);
-          var pickerDays = pickerEnd.diff(pickerStart, 'days') + 'd';
-          if (pickerDays === '0d') {
-            pickerDays = '1d';
-          }
-          // Set custom date range values
-          localStorage.setItem(startDateTimeKey, pickerStart.format('YYYY-MM-DD HH:mm:ss'));
-          localStorage.setItem(endDateTimeKey, pickerEnd.format('YYYY-MM-DD HH:mm:ss'));
-          localStorage.setItem(startDayKey, pickerStart.format('MMMM D, YYYY'));
-          localStorage.setItem(endDayKey, pickerEnd.format('MMMM D, YYYY'));
-          localStorage.setItem(isCustomDateRange, true);
-          localStorage.setItem(timeRangeKey, pickerDays);
-          localStorage.setItem(isChartZoomed, true);
-          // Set custom date range labels & select custom date ranges for the widget
-          $('#daterangepicker-widget span').html(pickerStart.format('MMMM D, YYYY') + ' - ' + pickerEnd.format('MMMM D, YYYY'));
-          $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(pickerStart.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
-          $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(pickerEnd.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
-          // Now, load the charts with custom date ranges
-          loadCharts(pickerDays, true);
-          // refresh every 2.5 minutes
-          // clearInterval(window.owChartRefresh);
-          window.owChartRefresh = setInterval(loadCharts,
-            1000 * 60 * 2.5,
-            pickerDays,
-            false
-          );
+      var zoomCharts = document.getElementsByClassName(chartsContainers);
+      for (var zoomChart of zoomCharts) {
+        if (!zoomChart) {
+          localStorage.setItem(isChartZoomed, false);
+          localStorage.setItem(isCustomDateRange, false);
+          return;
         }
-      );
+        zoomChart.on('plotly_relayout',
+          function (eventdata) { // jshint ignore:line
+            var eventEnd = eventdata['xaxis.range[1]'];
+            var eventStart = eventdata['xaxis.range[0]'];
+            if (!eventEnd || !eventStart) {
+              localStorage.setItem(isChartZoomed, false);
+              localStorage.setItem(isCustomDateRange, false);
+              var daysBeforeZoom = localStorage.getItem(timeRangeKey);
+              // Set custom date range labels & select custom date ranges for the widget
+              var initialStartLabel = localStorage.getItem(startDayKey) || moment().format('MMMM D, YYYY');
+              var initialEndLabel = localStorage.getItem(endDayKey) || moment().format('MMMM D, YYYY');
+              var initialstartDate = moment(initialStartLabel, 'MMMM D, YYYY');
+              var initialEndDate = moment(initialEndLabel, 'MMMM D, YYYY');
+              $('#daterangepicker-widget span').html(initialstartDate.format('MMMM D, YYYY') + ' - ' + initialEndDate.format('MMMM D, YYYY'));
+              $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(initialstartDate.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+              $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(initialEndDate.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+              loadCharts(daysBeforeZoom, true);
+              // refresh every 2.5 minutes
+              clearInterval(window.owChartRefresh);
+              window.owChartRefresh = setInterval(loadCharts,
+                1000 * 60 * 2.5,
+                pickerDays,
+                false
+              );
+              return;
+            }
+            var pickerEnd = moment(eventEnd);
+            var pickerStart = moment(eventStart);
+            var pickerDays = pickerEnd.diff(pickerStart, 'days') + 'd';
+            if (pickerDays === '0d') {
+              pickerDays = '1d';
+            }
+            // Set custom date range values
+            localStorage.setItem(zoomStartDateTimeKey, pickerStart.format('YYYY-MM-DD HH:mm:ss'));
+            localStorage.setItem(zoomEndDateTimeKey, pickerEnd.format('YYYY-MM-DD HH:mm:ss'));
+            localStorage.setItem(zoomStartDayKey, pickerStart.format('MMMM D, YYYY'));
+            localStorage.setItem(zoomEndDayKey, pickerEnd.format('MMMM D, YYYY'));
+            localStorage.setItem(isChartZoomed, true);
+            localStorage.setItem(isCustomDateRange, true);
+            localStorage.setItem(zoomtimeRangeKey, pickerDays);
+            // Set custom date range labels & select custom date ranges for the widget
+            $('#daterangepicker-widget span').html(pickerStart.format('MMMM D, YYYY') + ' - ' + pickerEnd.format('MMMM D, YYYY'));
+            $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(pickerStart.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+            $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(pickerEnd.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+            // Now, load the charts with custom date ranges
+            loadCharts(pickerDays, true);
+            // refresh every 2.5 minutes
+            clearInterval(window.owChartRefresh);
+            window.owChartRefresh = setInterval(loadCharts,
+              1000 * 60 * 2.5,
+              pickerDays,
+              false
+            );
+          }
+        );
+      }
     }
 
     var chartQuickLinks, chartContents = $('#ow-chart-contents'),
@@ -85,9 +122,13 @@ django.jQuery(function ($) {
       loadCharts = function (time, showLoading) {
         var url = baseUrl + time;
         // pass pickerEndDate and pickerStartDate to url
-        if (localStorage.getItem(isCustomDateRange) === 'true') {
+        if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(pickerChosenLabelKey) === 'Custom Range') {
           var startDate = localStorage.getItem(startDateTimeKey);
           var endDate = localStorage.getItem(endDateTimeKey);
+          if (localStorage.getItem(isChartZoomed) === 'true') {
+            startDate = localStorage.getItem(zoomStartDateTimeKey);
+            endDate = localStorage.getItem(zoomEndDateTimeKey);
+          }
           url = `${baseUrl}${time}&start=${startDate}&end=${endDate}`;
         }
         $.ajax(url, {
@@ -115,17 +156,17 @@ django.jQuery(function ($) {
               if (!chartDiv.length) {
                 chartContents.append(
                   '<div id="' + htmlId + '" class="ow-chart">' +
-                  '<div id="js-plotly-zoom" class="js-plotly-plot"></div></div>'
+                  '<div class="js-plotly-plot"></div></div>'
                 );
               }
               createChart(chart, data.x, htmlId, chart.title, chart.type, chartQuickLink);
-              handleChartZoomChange('js-plotly-zoom');
             });
           },
           error: function () {
             alert('Something went wrong while loading the charts');
           },
           complete: function () {
+            handleChartZoomChange('js-plotly-plot');
             localLoadingOverlay.fadeOut(200, function() {
               if (showLoading) {
                 globalLoadingOverlay.fadeOut(200);
@@ -145,17 +186,21 @@ django.jQuery(function ($) {
       var range = localStorage.getItem(timeRangeKey) || defaultTimeRange;
       var startLabel = localStorage.getItem(startDayKey) || moment().format('MMMM D, YYYY');
       var endLabel = localStorage.getItem(endDayKey) || moment().format('MMMM D, YYYY');
-
+      if (localStorage.getItem(isChartZoomed) === 'true') {
+        range = localStorage.getItem(zoomtimeRangeKey);
+        endLabel = localStorage.getItem(zoomEndDayKey);
+        startLabel = localStorage.getItem(zoomStartDayKey);
+      }
       // Add label to daterangepicker widget
       $('#daterangepicker-widget span').html(startLabel + ' - ' + endLabel);
-      if (localStorage.getItem(isCustomDateRange) === 'true') {
+      if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(isChartZoomed) === 'false' ) {
         // Set last selected custom date after page reload
         var startDate = moment(startLabel, 'MMMM D, YYYY');
         var endDate = moment(endLabel, 'MMMM D, YYYY');
         $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(startDate).format('MM/DD/YYYY'));
         $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(endDate).format('MM/DD/YYYY'));
         // Then loads charts with custom ranges selected
-        loadCharts(localStorage.getItem(timeRangeKey), true);
+        loadCharts(range, true);
       }
       else {
         // Set last selected default dates after page reload
@@ -177,6 +222,7 @@ django.jQuery(function ($) {
       pickerDays = pickerEnd.diff(pickerStart, 'days') + 'd';
 
       // set date values required for daterangepicker labels
+      localStorage.setItem(pickerChosenLabelKey, pickerChosenLabel);
       localStorage.setItem(startDateTimeKey, picker.startDate.format('YYYY-MM-DD HH:mm:ss'));
       localStorage.setItem(endDateTimeKey, picker.endDate.format('YYYY-MM-DD HH:mm:ss'));
       localStorage.setItem(startDayKey, pickerStart.format('MMMM D, YYYY'));
@@ -184,6 +230,7 @@ django.jQuery(function ($) {
 
       // daterangepicker with custom time ranges
       if (pickerChosenLabel === "Custom Range") {
+        localStorage.setItem(isChartZoomed, false);
         localStorage.setItem(isCustomDateRange, true);
         localStorage.setItem(timeRangeKey, pickerDays);
         loadCharts(pickerDays, true);
@@ -197,6 +244,7 @@ django.jQuery(function ($) {
 
       // daterangepicker with default time ranges
       else {
+        localStorage.setItem(isChartZoomed, false);
         localStorage.setItem(isCustomDateRange, false);
         localStorage.setItem(timeRangeKey, pickerDays);
         loadCharts(pickerDays, true);

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -46,6 +46,11 @@ django.jQuery(function ($) {
       }, initDateRangePickerWidget);
       initDateRangePickerWidget(start, end);
 
+    function setDateRangePickerWidgetLabel(pickerStartDate, pickerEndDate) {
+      $('#daterangepicker-widget span').html(pickerStartDate.format('MMMM D, YYYY') + ' - ' + pickerEndDate.format('MMMM D, YYYY'));
+      $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(pickerStartDate.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+      $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(pickerEndDate.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+    }
     function isMonitoringChartsLocation() {
       // If active monitoring charts location is not #ow-chart-container and not admin
       return window.location.hash === '#ow-chart-container' ||  window.location.pathname === '/admin/';
@@ -91,11 +96,10 @@ django.jQuery(function ($) {
               // Set custom date range labels & select custom date ranges for the widget
               var initialStartLabel = localStorage.getItem(startDayKey) || moment().format('MMMM D, YYYY');
               var initialEndLabel = localStorage.getItem(endDayKey) || moment().format('MMMM D, YYYY');
-              var initialstartDate = moment(initialStartLabel, 'MMMM D, YYYY');
+              var initialStartDate = moment(initialStartLabel, 'MMMM D, YYYY');
               var initialEndDate = moment(initialEndLabel, 'MMMM D, YYYY');
-              $('#daterangepicker-widget span').html(initialstartDate.format('MMMM D, YYYY') + ' - ' + initialEndDate.format('MMMM D, YYYY'));
-              $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(initialstartDate.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
-              $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(initialEndDate.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+              // Set date range picker widget labels
+              setDateRangePickerWidgetLabel(initialStartDate, initialEndDate);
               // On zoom out, load all charts to their initial zoom level
               loadCharts(daysBeforeZoom, true);
               // refresh every 2.5 minutes
@@ -108,25 +112,23 @@ django.jQuery(function ($) {
               return;
             }
             // When the chart zoomed in,
-            var pickerEnd = moment(eventEnd);
-            var pickerStart = moment(eventStart);
-            var pickerDays = pickerEnd.diff(pickerStart, 'days') + 'd';
+            var pickerEndDate = moment(eventEnd);
+            var pickerStartDate = moment(eventStart);
+            var pickerDays = pickerEndDate.diff(pickerStartDate, 'days') + 'd';
             if (pickerDays === '0d') {
               pickerDays = '1d';
             }
             // Set custom date range values
-            localStorage.setItem(zoomStartDateTimeKey, pickerStart.format('YYYY-MM-DD HH:mm:ss'));
-            localStorage.setItem(zoomEndDateTimeKey, pickerEnd.format('YYYY-MM-DD HH:mm:ss'));
-            localStorage.setItem(zoomStartDayKey, pickerStart.format('MMMM D, YYYY'));
-            localStorage.setItem(zoomEndDayKey, pickerEnd.format('MMMM D, YYYY'));
+            localStorage.setItem(zoomStartDateTimeKey, pickerStartDate.format('YYYY-MM-DD HH:mm:ss'));
+            localStorage.setItem(zoomEndDateTimeKey, pickerEndDate.format('YYYY-MM-DD HH:mm:ss'));
+            localStorage.setItem(zoomStartDayKey, pickerStartDate.format('MMMM D, YYYY'));
+            localStorage.setItem(zoomEndDayKey, pickerEndDate.format('MMMM D, YYYY'));
             localStorage.setItem(isChartZoomScroll, true);
             localStorage.setItem(isChartZoomed, true);
             localStorage.setItem(isCustomDateRange, true);
             localStorage.setItem(zoomtimeRangeKey, pickerDays);
-            // Set custom date range labels & select custom date ranges for the widget
-            $('#daterangepicker-widget span').html(pickerStart.format('MMMM D, YYYY') + ' - ' + pickerEnd.format('MMMM D, YYYY'));
-            $('#daterangepicker-widget').data('daterangepicker').setStartDate(moment(pickerStart.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
-            $('#daterangepicker-widget').data('daterangepicker').setEndDate(moment(pickerEnd.format('MMMM D, YYYY')).format('MM/DD/YYYY'));
+            // Set date range picker widget labels
+            setDateRangePickerWidgetLabel(pickerStartDate, pickerEndDate);
             // Now, load the charts with custom date ranges
             loadFetchedCharts(pickerDays);
             // refresh every 2.5 minutes
@@ -330,6 +332,11 @@ django.jQuery(function ($) {
             localStorage.setItem(lastFetchedChartsData, JSON.stringify(data));
           }
           else {
+            var initialStartLabel = localStorage.getItem(startDayKey) || moment().format('MMMM D, YYYY');
+            var initialEndLabel = localStorage.getItem(endDayKey) || moment().format('MMMM D, YYYY');
+            var initialStartDate = moment(initialStartLabel, 'MMMM D, YYYY');
+            var initialEndDate = moment(initialEndLabel, 'MMMM D, YYYY');
+            setDateRangePickerWidgetLabel(initialStartDate, initialEndDate);
             createCharts(JSON.parse(localStorage.getItem(lastFetchedChartsData)));
           }
           triggerZoomCharts('js-plotly-plot');

--- a/openwisp_monitoring/views.py
+++ b/openwisp_monitoring/views.py
@@ -66,6 +66,13 @@ class MonitoringApiViewMixin:
         # if custom dates are provided then validate custom dates
         if start_date and end_date:
             self._validate_custom_date(start_date, end_date, timezone)
+            # if valid custom dates then calculate custom days
+            time = '1d'
+            end = datetime.strptime(end_date, '%Y-%m-%d %H:%M:%S')
+            start = datetime.strptime(start_date, '%Y-%m-%d %H:%M:%S')
+            custom_days = (end - start).days
+            if custom_days:
+                time = f'{custom_days}d'
         if time not in Chart._get_group_map(time).keys():
             raise ValidationError('Time range not supported')
         charts = self._get_charts(request, *args, **kwargs)

--- a/openwisp_monitoring/views.py
+++ b/openwisp_monitoring/views.py
@@ -42,6 +42,8 @@ class MonitoringApiViewMixin:
             raise ValidationError(
                 'Incorrect custom date format, should be YYYY-MM-DD H:M:S'
             )
+        if (end - start).days > 365:
+            raise ValidationError("The date range shouldn't be greater than 365 days")
         if start > end:
             raise ValidationError('start_date cannot be greater than end_date')
         now_tz = datetime.now(tz=timezone(tmz)).strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
-  Added custom zooming to monitoring charts. 
- `Zoom In` : To get a detailed view of all the monitoring charts for a specific time range. 
- `Zoom Out` : To reset all monitoring charts to the last selected time range.

### `Demo`

https://user-images.githubusercontent.com/56113566/198017360-a56d1ba2-fe28-4738-9886-eb0851cc04dc.mp4

Closes #27

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
