### PR TITLE
Fixed device metric collection when mobile signal is missing

### DIFF
--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -222,7 +222,7 @@ class DeviceMetricView(MonitoringApiViewMixin, GenericAPIView):
                 return tech
 
     def _write_mobile_signal(self, interface, ifname, ct, pk, current=False, time=None):
-        access_type = self._get_mobile_signal_type(interface['mobile']['signal'])
+        access_type = self._get_mobile_signal_type(interface['mobile'].get('signal'))
         if not access_type:
             return
         data = interface['mobile']['signal'][access_type]

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -943,6 +943,11 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             dd.data['interfaces'][0]['mobile'], data['interfaces'][0]['mobile']
         )
 
+        with self.subTest('signal key not present at all'):
+            del data['interfaces'][0]['mobile']['signal']
+            response = self._post_data(device.id, device.key, data)
+            self.assertEqual(response.status_code, 200)
+
     def test_pre_metric_write_signal(self):
         d = self._create_device(organization=self._create_org())
         data = {'type': 'DeviceMonitoring', 'resources': {'cpus': 1, 'load': [0, 0, 0]}}


### PR DESCRIPTION
The previous patch https://github.com/openwisp/openwisp-monitoring/commit/67bc8867e677b21de2d9c342670fd16fffb00b8d didn't take into account the case in which the `signal` key is missing entirely.