### PR TITLE
[change] Use OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY for OPENWISP_MONITORING_MANAGEMENT_IP_ONLY

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1650,6 +1650,12 @@ If the devices are connecting to your OpenWISP instance using a shared layer2
 network, hence the OpenWSP server can reach the devices using the ``last_ip``
 field, you can set this to ``False``.
 
+**Note:** If this setting is not configured, it will fallback to the value of
+`OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY setting
+<https://github.com/openwisp/openwisp-controller#openwisp_controller_management_ip_only>`_.
+If ``OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY`` also not configured,
+then it will fallback to ``True``.
+
 ``OPENWISP_MONITORING_DEVICE_RECOVERY_DETECTION``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/openwisp_monitoring/check/settings.py
+++ b/openwisp_monitoring/check/settings.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from ..settings import get_settings_value
 
 CHECK_CLASSES = get_settings_value(
@@ -10,7 +12,12 @@ CHECK_CLASSES = get_settings_value(
 )
 AUTO_PING = get_settings_value('AUTO_PING', True)
 AUTO_CONFIG_CHECK = get_settings_value('AUTO_DEVICE_CONFIG_CHECK', True)
-MANAGEMENT_IP_ONLY = get_settings_value('MANAGEMENT_IP_ONLY', True)
+# If OPENWISP_MONITORING_MANAGEMENT_IP_ONLY is not configured, use
+# OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY.
+MANAGEMENT_IP_ONLY = get_settings_value(
+    'MANAGEMENT_IP_ONLY',
+    getattr(settings, 'OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY', True),
+)
 PING_CHECK_CONFIG = get_settings_value('PING_CHECK_CONFIG', {})
 AUTO_IPERF3 = get_settings_value('AUTO_IPERF3', False)
 IPERF3_CHECK_CONFIG = get_settings_value('IPERF3_CHECK_CONFIG', {})


### PR DESCRIPTION
If OPENWISP_MONITORING_MANAGEMENT_IP_ONLY is not configured in the project settings, then it will fallback to the value of OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY setting. If OPENWISP_CONTROLLER_MANAGEMENT_IP_ONLY is also not present, then then it will fallback to ``True``.

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [ ] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)

**Blockers**
- [ ] https://github.com/openwisp/openwisp-controller/pull/710 

