### PR TITLE
[ci] Removed `gsoc22-iperf` from CI build branches [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,10 @@ on:
     branches:
       - master
       - dev
-      - gsoc22-iperf
   pull_request:
     branches:
       - master
       - dev
-      - gsoc22-iperf
 
 jobs:
   build:


### PR DESCRIPTION
As we already know, `gsoc22-iperf` [merged into master](https://github.com/openwisp/openwisp-monitoring/commit/11b31ffea2e32b93085e04b5fcb806682cbecc58), therefore now we can safely remove it from CI build.
