### PR TITLE
[feature] Allowed specifying additional options for InfluxDB backend (UDP) #458

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,6 @@ jobs:
         image: redis
         ports:
           - 6379:6379
-      influxdb:
-        image: influxdb:1.8.4-alpine
-        options: >-
-          --name "influxdb"
-        ports:
-          - 8086:8086
 
     strategy:
       fail-fast: false
@@ -73,6 +67,9 @@ jobs:
 
       - name: Install npm dependencies
         run: sudo npm install -g install jshint stylelint
+
+      - name: Start InfluxDB container
+        run: docker-compose up -d influxdb
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           SAMPLE_APP=1 coverage run --source=openwisp_monitoring runtests.py
           coverage run -a --source=openwisp_monitoring runtests.py
+          TIMESERIES_UDP=1 coverage run -a --source=openwisp_monitoring runtests.py
 
       - name: Upload Coverage
         run: coveralls --service=github

--- a/README.rst
+++ b/README.rst
@@ -1479,6 +1479,12 @@ section of your InfluxDB should look similar to the following:
     database = "openwisp2"
     retention-policy = 'short'
 
+If you are using `ansible-openwisp2 <https://github.com/openwisp/ansible-openwisp2>`_
+for deploying OpenWISP, you can set the ``influxdb_udp_mode`` ansible variable to ``true``
+in your playbook, this will make the ansible role automatically configure the InfluxDB UDP listeners.
+You can refer to `ansible-ow-influxdb <https://github.com/openwisp/ansible-ow-influxdb#role-variables>`
+(a dependency of ansible-openwisp2) documentation to learn more.
+
 ``OPENWISP_MONITORING_DEFAULT_RETENTION_POLICY``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -1424,7 +1424,8 @@ Settings
         'PORT': '8086',
         'OPTIONS': {
             'udp_writes': False,
-            'udp_port': 8089
+            'udp_port': 8089,
+        }
     }
 
 The following table describes all keys available in ``TIMESERIES_DATABASE``

--- a/README.rst
+++ b/README.rst
@@ -1482,7 +1482,7 @@ section of your InfluxDB should look similar to the following:
 If you are using `ansible-openwisp2 <https://github.com/openwisp/ansible-openwisp2>`_
 for deploying OpenWISP, you can set the ``influxdb_udp_mode`` ansible variable to ``true``
 in your playbook, this will make the ansible role automatically configure the InfluxDB UDP listeners.
-You can refer to `ansible-ow-influxdb <https://github.com/openwisp/ansible-ow-influxdb#role-variables>`
+You can refer to the `ansible-ow-influxdb's <https://github.com/openwisp/ansible-ow-influxdb#role-variables>`_
 (a dependency of ansible-openwisp2) documentation to learn more.
 
 ``OPENWISP_MONITORING_DEFAULT_RETENTION_POLICY``

--- a/README.rst
+++ b/README.rst
@@ -1456,6 +1456,10 @@ setting:
 |               | +-----------------+----------------------------------------------------------------+ |
 +---------------+--------------------------------------------------------------------------------------+
 
+**Note:** UDP packets can have a maximum size of 64KB. When using UDP for writing timeseries
+data, if the size of data exceeds 64KB, then TCP connection will be used for writing
+data to the timeseries database.
+
 **Note:** If you want to use the ``openwisp_monitoring.db.backends.influxdb`` backend
 with UDP writes enabled, then you need to enable two different ports for UDP
 (each for different retention policy) in your InfluxDB configuration. The UDP configuration

--- a/README.rst
+++ b/README.rst
@@ -337,8 +337,8 @@ Follow the setup instructions of `openwisp-controller
             # Specify additional options to be used while initializing
             # database connection.
             # Note: These options may differ based on the backend used.
-            'use_udp': True,
-            'udp_port': 8088,
+            'udp_writes': True,
+            'udp_port': 8089,
         }
     }
 

--- a/README.rst
+++ b/README.rst
@@ -1457,8 +1457,7 @@ setting:
 +---------------+--------------------------------------------------------------------------------------+
 
 **Note:** UDP packets can have a maximum size of 64KB. When using UDP for writing timeseries
-data, if the size of data exceeds 64KB, then TCP connection will be used for writing
-data to the timeseries database.
+data, if the size of the data exceeds 64KB, TCP mode will be used instead.
 
 **Note:** If you want to use the ``openwisp_monitoring.db.backends.influxdb`` backend
 with UDP writes enabled, then you need to enable two different ports for UDP

--- a/README.rst
+++ b/README.rst
@@ -333,6 +333,13 @@ Follow the setup instructions of `openwisp-controller
         'NAME': 'openwisp2',
         'HOST': 'localhost',
         'PORT': '8086',
+        'OPTIONS': {
+            # Specify additional options to be used while initializing
+            # database connection.
+            # Note: These options may differ based on the backend used.
+            'use_udp': True,
+            'udp_port': 8088,
+        }
     }
 
 ``urls.py``:

--- a/README.rst
+++ b/README.rst
@@ -1404,6 +1404,77 @@ these permissions are included by default in the "Administrator" and "Operator" 
 Settings
 --------
 
+``TIMESERIES_DATABASE``
+~~~~~~~~~~~~~~~~~~~~~~~
+
++--------------+-----------+
+| **type**:    | ``str``   |
++--------------+-----------+
+| **default**: | see below |
++--------------+-----------+
+
+.. code-block:: python
+
+    TIMESERIES_DATABASE = {
+        'BACKEND': 'openwisp_monitoring.db.backends.influxdb',
+        'USER': 'openwisp',
+        'PASSWORD': 'openwisp',
+        'NAME': 'openwisp2',
+        'HOST': 'localhost',
+        'PORT': '8086',
+        'OPTIONS': {
+            'udp_writes': False,
+            'udp_port': 8089
+    }
+
+The following table describes all keys available in ``TIMESERIES_DATABASE``
+setting:
+
++---------------+--------------------------------------------------------------------------------------+
+| **Key**       | ``Description``                                                                      |
++---------------+--------------------------------------------------------------------------------------+
+| ``BACKEND``   | The timeseries database backend to use. You can select one of the backends           |
+|               | located in ``openwisp_monitoring.db.backends``                                       |
++---------------+--------------------------------------------------------------------------------------+
+| ``USER``      | User for logging into the timeseries database                                        |
++---------------+--------------------------------------------------------------------------------------+
+| ``PASSWORD``  | Password of the timeseries database user                                             |
++---------------+--------------------------------------------------------------------------------------+
+| ``NAME``      | Name of the timeseries database                                                      |
++---------------+--------------------------------------------------------------------------------------+
+| ``HOST``      | IP address/hostname of machine where the timeseries database is running              |
++---------------+--------------------------------------------------------------------------------------+
+| ``PORT``      | Port for connecting to the timeseries database                                       |
++---------------+--------------------------------------------------------------------------------------+
+| ``OPTIONS``   | These settings depends on the timeseries backend:                                    |
+|               |                                                                                      |
+|               | +-----------------+----------------------------------------------------------------+ |
+|               | | ``udp_writes``  | Whether to use UDP for writing data to the timeseries database | |
+|               | +-----------------+----------------------------------------------------------------+ |
+|               | | ``udp_port``    | Timeseries database port for writing data using UDP            | |
+|               | +-----------------+----------------------------------------------------------------+ |
++---------------+--------------------------------------------------------------------------------------+
+
+**Note:** If you want to use the ``openwisp_monitoring.db.backends.influxdb`` backend
+with UDP writes enabled, then you need to enable two different ports for UDP
+(each for different retention policy) in your InfluxDB configuration. The UDP configuration
+section of your InfluxDB should look similar to the following:
+
+.. code-block:: text
+
+    # For writing data with the "default" retention policy
+    [[udp]]
+    enabled = true
+    bind-address = "127.0.0.1:8089"
+    database = "openwisp2"
+
+    # For writing data with the "short" retention policy
+    [[udp]]
+    enabled = true
+    bind-address = "127.0.0.1:8090"
+    database = "openwisp2"
+    retention-policy = 'short'
+
 ``OPENWISP_MONITORING_DEFAULT_RETENTION_POLICY``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1742,6 +1813,10 @@ This feature makes the monitoring system resilient to temporary outages and help
 For more information regarding these settings, consult the `celery documentation
 regarding automatic retries for known errors
 <https://docs.celeryproject.org/en/stable/userguide/tasks.html#automatic-retry-for-known-exceptions>`_.
+
+**Note:** The retry mechanism does not work when using ``UDP`` for writing
+data to the timeseries database. It is due to the nature of ``UDP`` protocol
+which does not acknowledge receipt of data packets.
 
 ``OPENWISP_MONITORING_TIMESERIES_RETRY_OPTIONS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
     image: influxdb:1.8-alpine
     volumes:
       - influxdb-data:/var/lib/influxdb
+      - ./tests/influxdb.conf:/etc/influxdb/influxdb.conf
     ports:
       - "8086:8086"
+      - "8088:8088/udp"
     environment:
       INFLUXDB_DB: openwisp2
       INFLUXDB_USER: openwisp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       - ./tests/influxdb.conf:/etc/influxdb/influxdb.conf
     ports:
       - "8086:8086"
-      - "8088:8088/udp"
+      - "8089:8089/udp"
+      - "8090:8090/udp"
     environment:
       INFLUXDB_DB: openwisp2
       INFLUXDB_USER: openwisp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - "8086:8086"
       - "8089:8089/udp"
       - "8090:8090/udp"
+      - "8091:8091/udp"
+      - "8092:8092/udp"
     environment:
       INFLUXDB_DB: openwisp2
       INFLUXDB_USER: openwisp

--- a/openwisp_monitoring/check/tests/test_iperf3.py
+++ b/openwisp_monitoring/check/tests/test_iperf3.py
@@ -491,7 +491,9 @@ class TestIperf3(
             iperf3_metric = Metric.objects.get(key='iperf3')
             self.assertEqual(Metric.objects.count(), 3)
             self.assertEqual(iperf3_metric.content_object, self.device)
-            points = iperf3_metric.read(limit=None, extra_fields=list(result.keys()))
+            points = self._read_metric(
+                iperf3_metric, limit=None, extra_fields=list(result.keys())
+            )
             self.assertEqual(len(points), 1)
             self.assertEqual(points[0]['iperf3_result'], result['iperf3_result'])
             self.assertEqual(points[0]['sent_bps_tcp'], result['sent_bps_tcp'])

--- a/openwisp_monitoring/check/tests/test_models.py
+++ b/openwisp_monitoring/check/tests/test_models.py
@@ -186,15 +186,15 @@ class TestModels(TestDeviceMonitoringMixin, TransactionTestCase):
         dm = Device.objects.first().monitoring
         dm.update_status('ok')
         self.assertEqual(Check.objects.count(), 3)
-        self.assertEqual(Metric.objects.count(), 0)
+        self.assertEqual(Metric.objects.filter(object_id=dm.id).count(), 0)
         self.assertEqual(AlertSettings.objects.count(), 0)
         check = Check.objects.filter(check_type=self._CONFIG_APPLIED).first()
         with freeze_time(now() - timedelta(minutes=10)):
             check.perform_check()
         # Check needs to be run again without mocking time for threshold crossed
         self.assertEqual(check.perform_check(), 0)
-        self.assertEqual(Metric.objects.count(), 1)
-        m = Metric.objects.first()
+        self.assertEqual(Metric.objects.filter(object_id=dm.device_id).count(), 1)
+        m = Metric.objects.filter(object_id=dm.device_id).first()
         self.assertEqual(AlertSettings.objects.count(), 1)
         dm.refresh_from_db()
         self.assertEqual(dm.status, 'problem')

--- a/openwisp_monitoring/check/tests/test_models.py
+++ b/openwisp_monitoring/check/tests/test_models.py
@@ -155,12 +155,12 @@ class TestModels(TestDeviceMonitoringMixin, TransactionTestCase):
         d = Device.objects.first()
         d.monitoring.update_status('ok')
         self.assertEqual(Check.objects.count(), 3)
-        self.assertEqual(Metric.objects.count(), 0)
+        self.assertEqual(Metric.objects.filter(object_id=d.id).count(), 0)
         self.assertEqual(AlertSettings.objects.count(), 0)
         check = Check.objects.filter(check_type=self._CONFIG_APPLIED).first()
         with freeze_time(now() - timedelta(minutes=10)):
             check.perform_check()
-        self.assertEqual(Metric.objects.count(), 1)
+        self.assertEqual(Metric.objects.filter(object_id=d.id).count(), 1)
         self.assertEqual(AlertSettings.objects.count(), 1)
         # Check needs to be run again without mocking time for threshold crossed
         check.perform_check()
@@ -170,7 +170,6 @@ class TestModels(TestDeviceMonitoringMixin, TransactionTestCase):
         dm = d.monitoring
         dm.refresh_from_db()
         self.assertEqual(m.is_healthy, False)
-        self.assertEqual(m.is_healthy_tolerant, False)
         self.assertEqual(dm.status, 'problem')
         self.assertEqual(Notification.objects.count(), 1)
 

--- a/openwisp_monitoring/check/tests/test_ping.py
+++ b/openwisp_monitoring/check/tests/test_ping.py
@@ -251,7 +251,7 @@ class TestPing(TestDeviceMonitoringMixin, TransactionTestCase):
         m = Metric.objects.first()
         self.assertEqual(m.content_object, device)
         self.assertEqual(m.key, 'ping')
-        points = m.read(limit=None, extra_fields=list(result.keys()))
+        points = self._read_metric(m, limit=None, extra_fields=list(result.keys()))
         self.assertEqual(len(points), 1)
         self.assertEqual(points[0]['reachable'], result['reachable'])
         self.assertEqual(points[0]['loss'], result['loss'])

--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -81,7 +81,8 @@ class DatabaseClient(object):
             TIMESERIES_DB['USER'],
             TIMESERIES_DB['PASSWORD'],
             self.db_name,
-            **TIMESERIES_DB.get('OPTIONS', {}),
+            use_udp=TIMESERIES_DB.get('OPTIONS', {}).get('udp_writes', False),
+            udp_port=TIMESERIES_DB.get('OPTIONS', {}).get('udp_port', 8089),
         )
 
     @retry

--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -81,6 +81,7 @@ class DatabaseClient(object):
             TIMESERIES_DB['USER'],
             TIMESERIES_DB['PASSWORD'],
             self.db_name,
+            **TIMESERIES_DB.get('OPTIONS', {}),
         )
 
     @retry

--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -112,11 +112,12 @@ class DatabaseClient(object):
             database=database,
         )
 
-    def _write(self, data, params):
+    def _write(self, points, database, retention_policy):
         try:
-            self.db.write(
-                data=data,
-                params=params,
+            self.db.write_points(
+                points=points,
+                database=database,
+                retention_policy=retention_policy,
             )
         except Exception as exception:
             logger.warning(f'got exception while writing to tsdb: {exception}')
@@ -145,11 +146,9 @@ class DatabaseClient(object):
             'time': timestamp,
         }
         self._write(
-            data={'points': [point]},
-            params={
-                'db': kwargs.get('database') or self.db_name,
-                'rp': kwargs.get('retention_policy'),
-            },
+            points=[point],
+            database=kwargs.get('database') or self.db_name,
+            retention_policy=kwargs.get('retention_policy'),
         )
 
     def batch_write(self, metric_data):
@@ -173,11 +172,9 @@ class DatabaseClient(object):
         for database in data_points.keys():
             for rp in data_points[database].keys():
                 self._write(
-                    data={'points': data_points[database][rp]},
-                    params={
-                        'db': database,
-                        'rp': rp,
-                    },
+                    points=data_points[database][rp],
+                    database=database,
+                    retention_policy=rp,
                 )
 
     def read(self, key, fields, tags, **kwargs):

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from celery.exceptions import Retry
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, tag
 from django.utils.timezone import now
 from freezegun import freeze_time
 from influxdb import InfluxDBClient
@@ -32,6 +32,7 @@ Chart = load_model('monitoring', 'Chart')
 Notification = load_model('openwisp_notifications', 'Notification')
 
 
+@tag('timeseries_db')
 class TestDatabaseClient(TestMonitoringMixin, TestCase):
     def test_forbidden_queries(self):
         queries = [

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -32,7 +32,7 @@ Chart = load_model('monitoring', 'Chart')
 Notification = load_model('openwisp_notifications', 'Notification')
 
 
-@tag('timeseries_db')
+@tag('timeseries_client')
 class TestDatabaseClient(TestMonitoringMixin, TestCase):
     def test_forbidden_queries(self):
         queries = [

--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -85,7 +85,9 @@ class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
                 main_tags={'ifname': ifname},
                 extra_tags=extra_tags,
             )
-            points = m.read(limit=10, order='-time', extra_fields=['tx_bytes'])
+            points = self._read_metric(
+                m, limit=10, order='-time', extra_fields=['tx_bytes']
+            )
             self.assertEqual(len(points), 1)
             for field in ['rx_bytes', 'tx_bytes']:
                 self.assertEqual(points[0][field], iface['statistics'][field])
@@ -96,7 +98,7 @@ class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
                 extra_tags=extra_tags,
                 main_tags={'ifname': ifname},
             )
-            points = m.read(limit=10, order='-time')
+            points = self._read_metric(m, limit=10, order='-time')
             self.assertEqual(len(points), len(iface['wireless']['clients']))
         return dd
 

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -706,13 +706,13 @@ class TestDeviceMonitoring(CreateConnectionsMixin, BaseTestCase):
         )
         ping1.write(0)
         ping2.write(0)
-        self.assertNotEqual(ping1.read(), [])
-        self.assertNotEqual(ping2.read(), [])
+        self.assertNotEqual(self._read_metric(ping1), [])
+        self.assertNotEqual(self._read_metric(ping2), [])
         dm1.device.delete()
         # Only the metric related to the deleted device
         # is deleted
-        self.assertEqual(ping1.read(), [])
-        self.assertNotEqual(ping2.read(), [])
+        self.assertEqual(self._read_metric(ping1), [])
+        self.assertNotEqual(self._read_metric(ping2), [])
 
 
 class TestWifiClientSession(TestWifiClientSessionMixin, TestCase):

--- a/openwisp_monitoring/monitoring/tests/__init__.py
+++ b/openwisp_monitoring/monitoring/tests/__init__.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 
 from django.utils.timezone import now
@@ -244,3 +245,19 @@ class TestMonitoringMixin(TestOrganizationMixin):
         c.full_clean()
         c.save()
         return c
+
+    def _read_chart_or_metric(self, obj, *args, **kwargs):
+        if TIMESERIES_DB.get('OPTIONS', {}).get('udp_writes', False):
+            time.sleep(0.12)
+        return obj.read(*args, **kwargs)
+
+    def _read_metric(self, metric, *args, **kwargs):
+        return self._read_chart_or_metric(metric, *args, **kwargs)
+
+    def _read_chart(self, chart, *args, **kwargs):
+        return self._read_chart_or_metric(chart, *args, **kwargs)
+
+    def _write_metric(self, metric, *args, **kwargs):
+        if TIMESERIES_DB.get('OPTIONS', {}).get('udp_writes', False):
+            time.sleep(0.12)
+        metric.write(*args, **kwargs)

--- a/openwisp_monitoring/monitoring/tests/__init__.py
+++ b/openwisp_monitoring/monitoring/tests/__init__.py
@@ -188,6 +188,7 @@ class TestMonitoringMixin(TestOrganizationMixin):
         # defined in settings when apps are loaded. We don't want that while testing
         timeseries_db.db_name = cls.TEST_DB
         del timeseries_db.db
+        del timeseries_db.dbs
         timeseries_db.create_database()
         for key, value in metrics.items():
             register_metric(key, value)
@@ -246,8 +247,12 @@ class TestMonitoringMixin(TestOrganizationMixin):
         c.save()
         return c
 
+    @property
+    def _is_timeseries_udp_writes(self):
+        return TIMESERIES_DB.get('OPTIONS', {}).get('udp_writes', False)
+
     def _read_chart_or_metric(self, obj, *args, **kwargs):
-        if TIMESERIES_DB.get('OPTIONS', {}).get('udp_writes', False):
+        if self._is_timeseries_udp_writes:
             time.sleep(0.12)
         return obj.read(*args, **kwargs)
 
@@ -258,6 +263,6 @@ class TestMonitoringMixin(TestOrganizationMixin):
         return self._read_chart_or_metric(chart, *args, **kwargs)
 
     def _write_metric(self, metric, *args, **kwargs):
-        if TIMESERIES_DB.get('OPTIONS', {}).get('udp_writes', False):
+        if self._is_timeseries_udp_writes:
             time.sleep(0.12)
         metric.write(*args, **kwargs)

--- a/openwisp_monitoring/monitoring/tests/test_charts.py
+++ b/openwisp_monitoring/monitoring/tests/test_charts.py
@@ -247,12 +247,16 @@ class TestCharts(TestMonitoringMixin, TestCase):
         m = self._create_object_metric(name='test', configuration='get_top_fields')
         c = self._create_chart(metric=m, test_data=None, configuration='histogram')
         self.assertEqual(c.get_top_fields(number=3), [])
-        m.write(None, extra_values={'http2': 100, 'ssh': 90, 'udp': 80, 'spdy': 70})
+        self._write_metric(
+            m, None, extra_values={'http2': 100, 'ssh': 90, 'udp': 80, 'spdy': 70}
+        )
         self.assertEqual(c.get_top_fields(number=3), ['http2', 'ssh', 'udp'])
 
     def test_query_histogram(self):
         m = self._create_object_metric(name='histogram', configuration='get_top_fields')
-        m.write(None, extra_values={'http2': 100, 'ssh': 90, 'udp': 80, 'spdy': 70})
+        self._write_metric(
+            m, None, extra_values={'http2': 100, 'ssh': 90, 'udp': 80, 'spdy': 70}
+        )
         c = Chart(metric=m, configuration='histogram')
         c.full_clean()
         c.save()

--- a/openwisp_monitoring/monitoring/tests/test_charts.py
+++ b/openwisp_monitoring/monitoring/tests/test_charts.py
@@ -30,7 +30,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
 
     def test_read(self):
         c = self._create_chart()
-        data = c.read()
+        data = self._read_chart(c)
         key = c.metric.field_name
         self.assertIn('x', data)
         self.assertIn('traces', data)
@@ -46,7 +46,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
         m.write(1, time=now() - timedelta(days=2))
         m.write(2, time=now() - timedelta(days=1))
         m.write(3, time=now())
-        data = c.read()
+        data = self._read_chart(c)
         self.assertEqual(data['summary'], {'value': 2})
 
     def test_read_summary_sum(self):
@@ -55,13 +55,13 @@ class TestCharts(TestMonitoringMixin, TestCase):
         m.write(5, time=now() - timedelta(days=2))
         m.write(4, time=now() - timedelta(days=1))
         m.write(1, time=now())
-        data = c.read()
+        data = self._read_chart(c)
         self.assertEqual(data['summary'], {'value': 10})
 
     def test_read_summary_not_aggregate(self):
         m = self._create_object_metric(name='summary_hidden')
         c = self._create_chart(metric=m)
-        data = c.read()
+        data = self._read_chart(c)
         self.assertEqual(data['summary'], {'value': None})
 
     def test_read_summary_top_fields(self):
@@ -98,7 +98,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
             },
             time=now() - timedelta(days=0),
         )
-        data = c.read()
+        data = self._read_chart(c)
         self.assertEqual(data['summary'], {'google': 200.0, 'facebook': 0.0061})
 
     def test_read_summary_top_fields_acid(self):
@@ -132,7 +132,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
             extra_values={'google': 0.0, 'facebook': 6000.0, 'reddit': 0.0},
             time=now() - timedelta(days=0),
         )
-        data = c.read()
+        data = self._read_chart(c)
         self.assertEqual(data['summary'], {'google': 87500000, 'facebook': 37503000})
         self.assertEqual(c.get_top_fields(2), ['google', 'facebook'])
 
@@ -150,7 +150,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
             time = now_ - timedelta(days=n)
             m1.write(n + 1, time=time)
             m2.write(n + 2, time=time)
-        data = c.read()
+        data = self._read_chart(c)
         f1 = m1.field_name
         f2 = 'value2'
         self.assertIn('x', data)
@@ -166,7 +166,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
 
     def test_json(self):
         c = self._create_chart()
-        data = c.read()
+        data = self._read_chart(c)
         # convert tuples to lists otherwise comparison will fail
         for i, chart in enumerate(data['traces']):
             data['traces'][i] = list(chart)
@@ -230,7 +230,7 @@ class TestCharts(TestMonitoringMixin, TestCase):
         m.write('00:23:4a:00:00:00')
         m.write('00:14:5c:00:00:00')
         c.save()
-        data = c.read(time='30d')
+        data = self._read_chart(c, time='30d')
         self.assertEqual(data['traces'][0][0], 'wifi_clients')
         # last 10 days
         self.assertEqual(data['traces'][0][1][-10:], [0, 2, 2, 2, 2, 2, 2, 2, 2, 4])

--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -166,17 +166,17 @@ class TestModels(TestMonitoringMixin, TestCase):
     def test_read_general_metric(self):
         m = self._create_general_metric(name='load')
         m.write(50, check=False)
-        self.assertEqual(m.read()[0][m.field_name], 50)
+        self.assertEqual(self._read_metric(m)[0][m.field_name], 50)
         m.write(1, check=False)
-        self.assertEqual(m.read()[0][m.field_name], 50)
-        self.assertEqual(m.read(order='-time')[0][m.field_name], 1)
+        self.assertEqual(self._read_metric(m)[0][m.field_name], 50)
+        self.assertEqual(self._read_metric(m, order='-time')[0][m.field_name], 1)
 
     def test_read_object_metric(self):
         om = self._create_object_metric(name='load')
         om.write(50)
         om.write(3)
-        om.read(extra_fields='*')
-        self.assertEqual(om.read()[0][om.field_name], 50)
+        self._read_metric(om, extra_fields='*')
+        self.assertEqual(self._read_metric(om)[0][om.field_name], 50)
 
     def test_alert_settings_max_seconds(self):
         m = self._create_general_metric(name='load')
@@ -375,13 +375,13 @@ class TestModels(TestMonitoringMixin, TestCase):
         metric2 = self._create_general_metric(name='traffic')
         metric1.write(99)
         metric2.write(5000)
-        self.assertNotEqual(metric1.read(), [])
-        self.assertNotEqual(metric2.read(), [])
+        self.assertNotEqual(self._read_metric(metric1), [])
+        self.assertNotEqual(self._read_metric(metric2), [])
         metric1.delete()
-        self.assertEqual(metric1.read(), [])
+        self.assertEqual(self._read_metric(metric1), [])
         # Only the timeseries data related to the deleted metric
         # should be deleted
-        self.assertNotEqual(metric2.read(), [])
+        self.assertNotEqual(self._read_metric(metric2), [])
 
     def test_metric_invalid_field_name(self):
         metric = self._create_general_metric(configuration='test_alert_field')

--- a/runtests.py
+++ b/runtests.py
@@ -16,4 +16,6 @@ if __name__ == '__main__':
         args.insert(2, 'openwisp_monitoring')
     else:
         args.insert(2, 'openwisp2')
+    if os.environ.get('TIMESERIES_UDP', False):
+        args.extend(['--exclude-tag', 'timeseries_client'])
     execute_from_command_line(args)

--- a/tests/influxdb.conf
+++ b/tests/influxdb.conf
@@ -17,7 +17,25 @@
 [[udp]]
   enabled = true
   bind-address = ":8090"
+  database = "openwisp2"
+  batch-size = 1
+  batch-pending = 1
+  batch-timeout = "0.1s"
+  retention-policy = 'short'
+
+[[udp]]
+  enabled = true
+  bind-address = ":8091"
   database = "openwisp2_test"
   batch-size = 1
   batch-pending = 1
   batch-timeout = "0.1s"
+
+[[udp]]
+  enabled = true
+  bind-address = ":8092"
+  database = "openwisp2_test"
+  batch-size = 1
+  batch-pending = 1
+  batch-timeout = "0.1s"
+  retention-policy = 'short'

--- a/tests/influxdb.conf
+++ b/tests/influxdb.conf
@@ -10,17 +10,11 @@
   enabled = true
   bind-address = ":8089"
   database = "openwisp2"
-  batch-size = 1
-  batch-pending = 1
-  batch-timeout = "0.1s"
 
 [[udp]]
   enabled = true
   bind-address = ":8090"
   database = "openwisp2"
-  batch-size = 1
-  batch-pending = 1
-  batch-timeout = "0.1s"
   retention-policy = 'short'
 
 # UDP configuration for running tests

--- a/tests/influxdb.conf
+++ b/tests/influxdb.conf
@@ -1,0 +1,15 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  engine = "tsm1"
+  wal-dir = "/var/lib/influxdb/wal"
+
+[[udp]]
+  enabled = true
+  bind-address = ":8088"
+  database = "openwisp2"
+  batch-size = 0c
+  batch-pending = 0
+  batch-timeout = "0s"

--- a/tests/influxdb.conf
+++ b/tests/influxdb.conf
@@ -13,3 +13,11 @@
   batch-size = 1
   batch-pending = 1
   batch-timeout = "0.1s"
+
+[[udp]]
+  enabled = true
+  bind-address = ":8090"
+  database = "openwisp2_test"
+  batch-size = 1
+  batch-pending = 1
+  batch-timeout = "0.1s"

--- a/tests/influxdb.conf
+++ b/tests/influxdb.conf
@@ -8,8 +8,8 @@
 
 [[udp]]
   enabled = true
-  bind-address = ":8088"
+  bind-address = ":8089"
   database = "openwisp2"
-  batch-size = 0c
-  batch-pending = 0
-  batch-timeout = "0s"
+  batch-size = 1
+  batch-pending = 1
+  batch-timeout = "0.1s"

--- a/tests/influxdb.conf
+++ b/tests/influxdb.conf
@@ -23,6 +23,7 @@
   batch-timeout = "0.1s"
   retention-policy = 'short'
 
+# UDP configuration for running tests
 [[udp]]
   enabled = true
   bind-address = ":8091"

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -28,7 +28,7 @@ TIMESERIES_DATABASE = {
     'NAME': 'openwisp2',
     'HOST': os.getenv('INFLUXDB_HOST', 'localhost'),
     'PORT': '8086',
-    'OPTIONS': {'use_udp': True, 'udp_port': 8088},
+    'OPTIONS': {'udp_writes': True, 'udp_port': 8089},
 }
 if TESTING:
     # Some automated tests queries InfluxDB just after
@@ -36,7 +36,7 @@ if TESTING:
     # is performed before InfluxDB has processed the UDP
     # packet which leads to failing test cases. Therefore,
     # we always run test suite without UDP support.
-    TIMESERIES_DATABASE['OPTIONS']['use_udp'] = False
+    TIMESERIES_DATABASE['OPTIONS']['udp_writes'] = False
 
 SECRET_KEY = 'fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w'
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -31,7 +31,10 @@ TIMESERIES_DATABASE = {
     'OPTIONS': {'udp_writes': True, 'udp_port': 8089},
 }
 if TESTING:
-    TIMESERIES_DATABASE['OPTIONS']['udp_port'] = 8090
+    if os.environ.get('TIMESERIES_UDP', False):
+        TIMESERIES_DATABASE['OPTIONS']['udp_port'] = 8091
+    else:
+        TIMESERIES_DATABASE['OPTIONS']['udp_writes'] = False
 
 SECRET_KEY = 'fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w'
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -31,12 +31,7 @@ TIMESERIES_DATABASE = {
     'OPTIONS': {'udp_writes': True, 'udp_port': 8089},
 }
 if TESTING:
-    # Some automated tests queries InfluxDB just after
-    # writing the data. Occasionally, the read operation
-    # is performed before InfluxDB has processed the UDP
-    # packet which leads to failing test cases. Therefore,
-    # we always run test suite without UDP support.
-    TIMESERIES_DATABASE['OPTIONS']['udp_writes'] = False
+    TIMESERIES_DATABASE['OPTIONS']['udp_port'] = 8090
 
 SECRET_KEY = 'fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w'
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -28,13 +28,12 @@ TIMESERIES_DATABASE = {
     'NAME': 'openwisp2',
     'HOST': os.getenv('INFLUXDB_HOST', 'localhost'),
     'PORT': '8086',
-    'OPTIONS': {'udp_writes': True, 'udp_port': 8089},
+    # UDP writes are disabled by default
+    'OPTIONS': {'udp_writes': False, 'udp_port': 8089},
 }
 if TESTING:
     if os.environ.get('TIMESERIES_UDP', False):
-        TIMESERIES_DATABASE['OPTIONS']['udp_port'] = 8091
-    else:
-        TIMESERIES_DATABASE['OPTIONS']['udp_writes'] = False
+        TIMESERIES_DATABASE['OPTIONS'] = {'udp_writes': True, 'udp_port': 8091}
 
 SECRET_KEY = 'fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w'
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -28,7 +28,15 @@ TIMESERIES_DATABASE = {
     'NAME': 'openwisp2',
     'HOST': os.getenv('INFLUXDB_HOST', 'localhost'),
     'PORT': '8086',
+    'OPTIONS': {'use_udp': True, 'udp_port': 8088},
 }
+if TESTING:
+    # Some automated tests queries InfluxDB just after
+    # writing the data. Occasionally, the read operation
+    # is performed before InfluxDB has processed the UDP
+    # packet which leads to failing test cases. Therefore,
+    # we always run test suite without UDP support.
+    TIMESERIES_DATABASE['OPTIONS']['use_udp'] = False
 
 SECRET_KEY = 'fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w'
 


### PR DESCRIPTION
- Additional options can be specified to the TIMESERIES_DATABASE setting which are passed to the underlying backend library. This allows using UDP for writing to InfluxDB.
- "openwisp_monitoring.db.backends.influxdb.client.DatabaseClient.write" will use "InfluxDBClient.write_points" instead of "InfluxDBClient.write" because the former allows writing data using the UDP protocol.

Closes #458

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)
