### PR TITLE
[change] Replaced iperf3 check _get_device_connection with DeviceConn…

### DIFF
--- a/openwisp_monitoring/check/tests/test_iperf3.py
+++ b/openwisp_monitoring/check/tests/test_iperf3.py
@@ -7,8 +7,7 @@ from django.test import TransactionTestCase
 from swapper import load_model
 
 from openwisp_controller.connection.connectors.ssh import Ssh
-from openwisp_controller.connection.models import DeviceConnection as device_connection
-from openwisp_controller.connection.settings import UPDATE_STRATEGIES
+from openwisp_controller.connection.settings import CONNECTORS, UPDATE_STRATEGIES
 from openwisp_controller.connection.tests.utils import CreateConnectionsMixin, SshServer
 from openwisp_monitoring.check.classes.iperf3 import get_iperf3_schema
 from openwisp_monitoring.check.classes.iperf3 import logger as iperf3_logger
@@ -26,10 +25,10 @@ from .iperf3_test_utils import (
     TEST_RSA_KEY,
 )
 
-Chart = load_model('monitoring', 'Chart')
-AlertSettings = load_model('monitoring', 'AlertSettings')
-Metric = load_model('monitoring', 'Metric')
 Check = load_model('check', 'Check')
+Chart = load_model('monitoring', 'Chart')
+Metric = load_model('monitoring', 'Metric')
+AlertSettings = load_model('monitoring', 'AlertSettings')
 
 
 class TestIperf3(
@@ -111,8 +110,10 @@ class TestIperf3(
             ),
         ]
 
-    def _perform_iperf3_check(self):
-        check = Check.objects.get(check_type=self._IPERF3)
+    def _perform_iperf3_check(self, object_id=None):
+        if not object_id:
+            object_id = self.device.id
+        check = Check.objects.get(check_type=self._IPERF3, object_id=object_id)
         return check.perform_check(store=False)
 
     def _set_auth_expected_calls(self, config):
@@ -317,32 +318,36 @@ class TestIperf3(
     @patch.object(iperf3_logger, 'warning')
     def test_iperf3_device_connection(self, mock_warn):
         dc = self.dc
-        with self.subTest('Test active device connection when management tunnel down'):
-            with patch.object(
-                device_connection, 'connect', return_value=False
-            ) as mocked_connect:
-                self._perform_iperf3_check()
-                mock_warn.assert_called_with(
-                    f'DeviceConnection for "{self.device}" is not working, iperf3 check skipped!'
-                )
-            self.assertEqual(mocked_connect.call_count, 1)
-
-        with self.subTest('Test device connection is not enabled'):
+        with self.subTest('Test iperf3 check when device connection is not enabled'):
             dc.enabled = False
             dc.save()
             self._perform_iperf3_check()
-            mock_warn.assert_called_with(
+            mock_warn.assert_called_once_with(
                 f'Failed to get a working DeviceConnection for "{self.device}", iperf3 check skipped!'
             )
+        mock_warn.reset_mock()
 
-        with self.subTest('Test device connection is not with right update strategy'):
-            dc.update_strategy = UPDATE_STRATEGIES[1][0]
-            dc.is_working = True
-            dc.enabled = True
-            dc.save()
-            self._perform_iperf3_check()
-            mock_warn.assert_called_with(
-                f'Failed to get a working DeviceConnection for "{self.device}", iperf3 check skipped!'
+        with self.subTest(
+            'Test iperf3 check with different credential connector type ie. snmp'
+        ):
+            device2 = self._create_device(
+                name='test-device-2', mac_address='00:11:22:33:44:66'
+            )
+            params = {'community': 'public', 'agent': 'snmp-agent', 'port': 161}
+            snmp_credentials = self._create_credentials(
+                params=params, connector=CONNECTORS[1][0], auto_add=True
+            )
+            dc2 = self._create_device_connection(
+                device=device2,
+                credentials=snmp_credentials,
+                update_strategy=UPDATE_STRATEGIES[0][0],
+            )
+            dc2.is_working = True
+            dc2.enabled = True
+            dc2.save()
+            self._perform_iperf3_check(object_id=device2.id)
+            mock_warn.assert_called_once_with(
+                f'Failed to get a working DeviceConnection for "{device2}", iperf3 check skipped!'
             )
 
     def test_iperf3_check_content_object_none(self):


### PR DESCRIPTION
- Replaced `_get_device_connection()` method of iperf3 check with [`DeviceConnection.get_working_connection()`](https://github.com/openwisp/openwisp-controller/blob/fdffd1c8410ddbc7b30bfdf05defe21c9d1ac8a5/openwisp_controller/connection/base/models.py#L265-L281)

Closes #475

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
