### PR TITLE
[change] Avoid running the iperf3 check when device monitoring status is …

### DIFF
--- a/openwisp_monitoring/check/classes/iperf3.py
+++ b/openwisp_monitoring/check/classes/iperf3.py
@@ -204,7 +204,7 @@ class Iperf3(BaseCheck):
         # Avoid running the iperf3 check when the device monitoring status is "critical"
         if (
             self.related_object.monitoring
-            and self.related_object.monitoring.status in ('critical',)
+            and self.related_object.monitoring.status == 'critical'
         ):
             logger.info(
                 (

--- a/openwisp_monitoring/check/classes/iperf3.py
+++ b/openwisp_monitoring/check/classes/iperf3.py
@@ -206,8 +206,11 @@ class Iperf3(BaseCheck):
             self.related_object.monitoring
             and self.related_object.monitoring.status in ('critical',)
         ):
-            logger.warning(
-                f'"{self.related_object}" DeviceMonitoring health status is "critical", iperf3 check skipped!'
+            logger.info(
+                (
+                    f'"{self.related_object}" DeviceMonitoring '
+                    'health status is "critical", iperf3 check skipped!'
+                )
             )
             return
         time = self._get_param(

--- a/openwisp_monitoring/check/classes/iperf3.py
+++ b/openwisp_monitoring/check/classes/iperf3.py
@@ -20,6 +20,7 @@ Chart = load_model('monitoring', 'Chart')
 Metric = load_model('monitoring', 'Metric')
 AlertSettings = load_model('monitoring', 'AlertSettings')
 DeviceConnection = load_model('connection', 'DeviceConnection')
+DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
 
 DEFAULT_IPERF3_CHECK_CONFIG = {
     'host': {
@@ -199,6 +200,14 @@ class Iperf3(BaseCheck):
                     f'Iperf3 servers for organization "{org}" '
                     f'is not configured properly, iperf3 check skipped!'
                 )
+            )
+            return
+        device_monitoring = DeviceMonitoring.objects.filter(
+            device=self.related_object
+        ).first()
+        if device_monitoring and device_monitoring.status in ('critical',):
+            logger.warning(
+                f'"{self.related_object}" DeviceMonitoring health status is "critical", iperf3 check skipped!'
             )
             return
         time = self._get_param(

--- a/openwisp_monitoring/check/classes/iperf3.py
+++ b/openwisp_monitoring/check/classes/iperf3.py
@@ -20,7 +20,6 @@ Chart = load_model('monitoring', 'Chart')
 Metric = load_model('monitoring', 'Metric')
 AlertSettings = load_model('monitoring', 'AlertSettings')
 DeviceConnection = load_model('connection', 'DeviceConnection')
-DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
 
 DEFAULT_IPERF3_CHECK_CONFIG = {
     'host': {
@@ -202,10 +201,11 @@ class Iperf3(BaseCheck):
                 )
             )
             return
-        device_monitoring = DeviceMonitoring.objects.filter(
-            device=self.related_object
-        ).first()
-        if device_monitoring and device_monitoring.status in ('critical',):
+        # Avoid running the iperf3 check when the device monitoring status is "critical"
+        if (
+            self.related_object.monitoring
+            and self.related_object.monitoring.status in ('critical',)
+        ):
             logger.warning(
                 f'"{self.related_object}" DeviceMonitoring health status is "critical", iperf3 check skipped!'
             )

--- a/openwisp_monitoring/check/tests/test_iperf3.py
+++ b/openwisp_monitoring/check/tests/test_iperf3.py
@@ -30,6 +30,7 @@ Check = load_model('check', 'Check')
 Chart = load_model('monitoring', 'Chart')
 Metric = load_model('monitoring', 'Metric')
 AlertSettings = load_model('monitoring', 'AlertSettings')
+DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
 
 
 class TestIperf3(
@@ -364,6 +365,15 @@ class TestIperf3(
             mock_warn.assert_called_once_with(
                 f'Failed to get a working DeviceConnection for "{device2}", iperf3 check skipped!'
             )
+
+    @patch.object(iperf3_logger, 'warning')
+    def test_iperf3_check_device_monitoring_critical(self, mock_warn):
+        device_monitoring = DeviceMonitoring.objects.get(device=self.device)
+        device_monitoring.update_status('critical')
+        self._perform_iperf3_check()
+        mock_warn.assert_called_once_with(
+            f'"{self.device}" DeviceMonitoring health status is "critical", iperf3 check skipped!'
+        )
 
     def test_iperf3_check_content_object_none(self):
         check = Check(name='Iperf3 check', check_type=self._IPERF3, params={})

--- a/openwisp_monitoring/check/tests/test_iperf3.py
+++ b/openwisp_monitoring/check/tests/test_iperf3.py
@@ -30,7 +30,6 @@ Check = load_model('check', 'Check')
 Chart = load_model('monitoring', 'Chart')
 Metric = load_model('monitoring', 'Metric')
 AlertSettings = load_model('monitoring', 'AlertSettings')
-DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
 
 
 class TestIperf3(
@@ -368,8 +367,7 @@ class TestIperf3(
 
     @patch.object(iperf3_logger, 'warning')
     def test_iperf3_check_device_monitoring_critical(self, mock_warn):
-        device_monitoring = DeviceMonitoring.objects.get(device=self.device)
-        device_monitoring.update_status('critical')
+        self.device.monitoring.update_status('critical')
         self._perform_iperf3_check()
         mock_warn.assert_called_once_with(
             f'"{self.device}" DeviceMonitoring health status is "critical", iperf3 check skipped!'

--- a/openwisp_monitoring/check/tests/test_iperf3.py
+++ b/openwisp_monitoring/check/tests/test_iperf3.py
@@ -365,12 +365,15 @@ class TestIperf3(
                 f'Failed to get a working DeviceConnection for "{device2}", iperf3 check skipped!'
             )
 
-    @patch.object(iperf3_logger, 'warning')
-    def test_iperf3_check_device_monitoring_critical(self, mock_warn):
+    @patch.object(iperf3_logger, 'info')
+    def test_iperf3_check_device_monitoring_critical(self, mock_info):
         self.device.monitoring.update_status('critical')
         self._perform_iperf3_check()
-        mock_warn.assert_called_once_with(
-            f'"{self.device}" DeviceMonitoring health status is "critical", iperf3 check skipped!'
+        mock_info.assert_called_once_with(
+            (
+                f'"{self.device}" DeviceMonitoring '
+                'health status is "critical", iperf3 check skipped!'
+            )
         )
 
     def test_iperf3_check_content_object_none(self):


### PR DESCRIPTION
- Avoid running the iperf3 check when device monitoring status is `'critical'`

Closes #476

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
