### PR TITLE
[change] Close WiFi Session respecting tolerance of critical metrics #493

### DIFF
--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -20,6 +20,7 @@ from openwisp_utils.admin_theme import (
 from openwisp_utils.admin_theme.menu import register_menu_subitem
 
 from ..check import settings as check_settings
+from ..monitoring.signals import threshold_crossed
 from ..settings import MONITORING_API_BASEURL, MONITORING_API_URLCONF
 from ..utils import transaction_on_commit
 from . import settings as app_settings
@@ -180,11 +181,11 @@ class DeviceMonitoringConfig(AppConfig):
         if not app_settings.WIFI_SESSIONS_ENABLED:
             return
 
-        DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
+        Metric = load_model('monitoring', 'Metric')
         WifiSession = load_model('device_monitoring', 'WifiSession')
-        health_status_changed.connect(
+        threshold_crossed.connect(
             WifiSession.offline_device_close_session,
-            sender=DeviceMonitoring,
+            sender=Metric,
             dispatch_uid='offline_device_close_session',
         )
 

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -407,8 +407,13 @@ class AbstractWifiSession(TimeStampedEditableModel):
         return self.wifi_client.vendor
 
     @classmethod
-    def offline_device_close_session(cls, metric, **kwargs):
-        if not AbstractDeviceMonitoring.is_metric_critical(metric):
-            return
-        if not metric.is_healthy_tolerant:
-            tasks.offline_device_close_session.delay(device_id=metric.object_id)
+    def offline_device_close_session(
+        cls, metric, tolerance_crossed, first_time, target, **kwargs
+    ):
+        if (
+            not first_time
+            and tolerance_crossed
+            and not metric.is_healthy_tolerant
+            and AbstractDeviceMonitoring.is_metric_critical(metric)
+        ):
+            tasks.offline_device_close_session.delay(device_id=target.pk)

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -407,6 +407,8 @@ class AbstractWifiSession(TimeStampedEditableModel):
         return self.wifi_client.vendor
 
     @classmethod
-    def offline_device_close_session(cls, instance, *args, **kwargs):
-        if kwargs['status'] == 'critical':
-            tasks.offline_device_close_session.delay(device_id=instance.device_id)
+    def offline_device_close_session(cls, metric, **kwargs):
+        if not AbstractDeviceMonitoring.is_metric_critical(metric):
+            return
+        if not metric.is_healthy_tolerant:
+            tasks.offline_device_close_session.delay(device_id=metric.object_id)

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -838,12 +838,62 @@ class TestWifiClientSession(TestWifiClientSessionMixin, TestCase):
         self.assertEqual(WifiSession.objects.count(), 0)
 
     def test_device_offline_close_session(self):
+        start_time = now()
         device_monitoring = self._create_device_monitoring()
+        ping = self._create_object_metric(
+            name='ping',
+            key='ping',
+            field_name='reachable',
+            content_object=device_monitoring.device,
+        )
+        ping_alerts = self._create_alert_settings(
+            metric=ping, custom_operator='<', custom_threshold=1, custom_tolerance=1
+        )
+        load = self._create_object_metric(
+            name='load', content_object=device_monitoring.device
+        )
+        self._create_alert_settings(
+            metric=load, custom_operator='>', custom_threshold=90, custom_tolerance=0
+        )
+        ping.write(1)
+        load.write(50)
         wifi_client = self._create_wifi_client()
         self._create_wifi_session(
             wifi_client=wifi_client, device=device_monitoring.device
         )
-        self.assertEqual(WifiSession.objects.filter(stop_time__isnull=True).count(), 1)
-        device_monitoring.update_status('critical')
-        self.assertEqual(WifiSession.objects.filter(stop_time__isnull=True).count(), 0)
-        self.assertEqual(WifiSession.objects.count(), 1)
+
+        def _assert_open_wifi_session(count):
+            self.assertEqual(
+                WifiSession.objects.filter(stop_time__isnull=True).count(), count
+            )
+            self.assertEqual(WifiSession.objects.count(), 1)
+
+        # Sanity check
+        _assert_open_wifi_session(1)
+
+        # WiFi session does not close when a non-critical metric trepasses the threshold
+        load.write(95)
+        _assert_open_wifi_session(1)
+
+        # WiFi session does not close when a critical metric trepasses the threshold
+        # within the tolerance limit
+        ping.write(0)
+        _assert_open_wifi_session(1)
+
+        # WiFi session closes when a critical metric trepasses the threshold
+        # beyond the tolerance limit
+        with freeze_time(start_time + timedelta(minutes=2)):
+            ping.write(0)
+        _assert_open_wifi_session(0)
+
+        WifiSession.objects.update(stop_time=None)
+        with freeze_time(start_time + timedelta(minutes=2)):
+            ping.write(1)
+
+        # WiFi session closes when a critical metric trepasses the threshold
+        # beyond the tolerance limit when alerts are turned off
+        ping_alerts.is_active = False
+        ping_alerts.save()
+        with freeze_time(now() + timedelta(minutes=3)):
+            ping.write(0)
+        _assert_open_wifi_session(0)


### PR DESCRIPTION
WiFi sessions an of offline devices are closed when the threshold of device's critical metrics (ping) are crossed for longer than the tolerance set in metric's alert settings.

Closes #493

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
