### PR TITLE
[change] Renamed daterangepicker widget labels #487

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Available Features
 * Maintains a record of `WiFi sessions <#monitoring-wifi-sessions>`_ with clients'
   MAC address and vendor, session start and stop time and connected device
   along with other information
-* Charts can be viewed at resolutions of 1 day, 3 days, a week, a month and a year
+* Charts can be viewed at resolutions of the last 1 day, 3 days, 7 days, 30 days, and 365 days
 * Configurable alerts
 * CSV Export of monitoring data
 * An overview of the status of the network is shown in the admin dashboard,

--- a/openwisp_monitoring/device/static/monitoring/css/wifi-sessions.css
+++ b/openwisp_monitoring/device/static/monitoring/css/wifi-sessions.css
@@ -8,7 +8,6 @@ td.original p {
 #wifisession_set-group {
   margin-bottom: 0px;
 }
-
 #wifisession_set-group th {
   border-top: 0 none;
 }

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -30,9 +30,9 @@ django.jQuery(function ($) {
         addDateRangePickerLabel(start.format('MMMM D, YYYY'), end.format('MMMM D, YYYY'));
         $("[data-range-key='Last 1 Day']").attr('data-time', '1d');
         $("[data-range-key='Last 3 Days']").attr('data-time', '3d');
-        $("[data-range-key='Last Week']").attr('data-time', '7d');
-        $("[data-range-key='Last Month']").attr('data-time', '30d');
-        $("[data-range-key='Last Year']").attr('data-time', '365d');
+        $("[data-range-key='Last 7 Days']").attr('data-time', '7d');
+        $("[data-range-key='Last 30 Days']").attr('data-time', '30d');
+        $("[data-range-key='Last 365 Days']").attr('data-time', '365d');
         $("[data-range-key='Custom Range']").attr('data-time', 'Custom Range');
       }
 
@@ -46,9 +46,9 @@ django.jQuery(function ($) {
         ranges: {
           'Last 1 Day': [moment().subtract(1, 'days'), moment()],
           'Last 3 Days': [moment().subtract(3, 'days'), moment()],
-          'Last Week': [moment().subtract(7, 'days'), moment()],
-          'Last Month': [moment().subtract(30, 'days'), moment()],
-          'Last Year': [moment().subtract(365, 'days'), moment()],
+          'Last 7 Days': [moment().subtract(7, 'days'), moment()],
+          'Last 30 Days': [moment().subtract(30, 'days'), moment()],
+          'Last 365 Days': [moment().subtract(365, 'days'), moment()],
         }
       }, initDateRangePickerWidget);
       initDateRangePickerWidget(start, end);

--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -21,6 +21,14 @@ django.jQuery(function ($) {
     var range = localStorage.getItem(timeRangeKey) || $('#monitoring-timeseries-default-time').data('value');
     var start = localStorage.getItem(isCustomDateRange) === 'true' ? moment() : moment().subtract(range.split('d')[0], 'days');
 
+    // Initialize date range picker labels
+    var last1DayLabel = gettext('Last 1 Day');
+    var last3DaysLabel = gettext('Last 3 Days');
+    var last7DaysLabel = gettext('Last 7 Days');
+    var last30DaysLabel = gettext('Last 30 Days');
+    var last365DaysLabel = gettext('Last 365 Days');
+    var customDateRangeLabel = gettext('Custom Range');
+
       // Add label to daterangepicker widget
       function addDateRangePickerLabel(startDate, endDate) {
         $('#daterangepicker-widget span').html(startDate + ' - ' + endDate);
@@ -28,12 +36,12 @@ django.jQuery(function ($) {
 
       function initDateRangePickerWidget(start, end) {
         addDateRangePickerLabel(start.format('MMMM D, YYYY'), end.format('MMMM D, YYYY'));
-        $("[data-range-key='Last 1 Day']").attr('data-time', '1d');
-        $("[data-range-key='Last 3 Days']").attr('data-time', '3d');
-        $("[data-range-key='Last 7 Days']").attr('data-time', '7d');
-        $("[data-range-key='Last 30 Days']").attr('data-time', '30d');
-        $("[data-range-key='Last 365 Days']").attr('data-time', '365d');
-        $("[data-range-key='Custom Range']").attr('data-time', 'Custom Range');
+        $(`[data-range-key='${last1DayLabel}']`).attr('data-time', '1d');
+        $(`[data-range-key='${last3DaysLabel}']`).attr('data-time', '3d');
+        $(`[data-range-key='${last7DaysLabel}']`).attr('data-time', '7d');
+        $(`[data-range-key='${last30DaysLabel}']`).attr('data-time', '30d');
+        $(`[data-range-key='${last365DaysLabel}']`).attr('data-time', '365d');
+        $(`[data-range-key='${customDateRangeLabel}']`).attr('data-time', customDateRangeLabel);
       }
 
       $('#daterangepicker-widget').daterangepicker({
@@ -43,12 +51,17 @@ django.jQuery(function ($) {
         maxSpan: {
           "year": 1,
         },
+        locale: {
+          applyLabel: gettext('Apply'),
+          cancelLabel: gettext('Cancel'),
+          customRangeLabel: gettext(customDateRangeLabel),
+        },
         ranges: {
-          'Last 1 Day': [moment().subtract(1, 'days'), moment()],
-          'Last 3 Days': [moment().subtract(3, 'days'), moment()],
-          'Last 7 Days': [moment().subtract(7, 'days'), moment()],
-          'Last 30 Days': [moment().subtract(30, 'days'), moment()],
-          'Last 365 Days': [moment().subtract(365, 'days'), moment()],
+          [`${last1DayLabel}`]: [moment().subtract(1, 'days'), moment()],
+          [`${last3DaysLabel}`]: [moment().subtract(3, 'days'), moment()],
+          [`${last7DaysLabel}`]: [moment().subtract(7, 'days'), moment()],
+          [`${last30DaysLabel}`]: [moment().subtract(30, 'days'), moment()],
+          [`${last365DaysLabel}`]: [moment().subtract(365, 'days'), moment()],
         }
       }, initDateRangePickerWidget);
       initDateRangePickerWidget(start, end);
@@ -167,7 +180,7 @@ django.jQuery(function ($) {
       getChartFetchUrl = function (time) {
         var url = baseUrl + time;
         // pass pickerEndDate and pickerStartDate to url
-        if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(pickerChosenLabelKey) === 'Custom Range') {
+        if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(pickerChosenLabelKey) === customDateRangeLabel) {
           var startDate = localStorage.getItem(startDateTimeKey);
           var endDate = localStorage.getItem(endDateTimeKey);
           if (localStorage.getItem(isChartZoomed) === 'true') {
@@ -305,7 +318,7 @@ django.jQuery(function ($) {
       var time = localStorage.getItem(timeRangeKey);
       location.href = baseUrl + time + '&csv=1';
       // If custom or pickerChosenLabelKey is 'Custom Range', pass pickerEndDate and pickerStartDate to csv url
-      if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(pickerChosenLabelKey) === 'Custom Range') {
+      if (localStorage.getItem(isCustomDateRange) === 'true' || localStorage.getItem(pickerChosenLabelKey) === customDateRangeLabel) {
       var startDate = localStorage.getItem(startDateTimeKey);
       var endDate = localStorage.getItem(endDateTimeKey);
       if (localStorage.getItem(isChartZoomed) === 'true') {


### PR DESCRIPTION
![Screenshot from 2023-03-17 17-00-42](https://user-images.githubusercontent.com/56113566/225892965-ca2c4d06-0122-45ea-acd7-0c929e034ed6.png)

Renamed date range widget label from last week, month and year to 7 days, 30 days and 365 days to avoid any misunderstandings in the future.

Closes #487

Checks:

- [x] I have manually tested the proposed changes
- [x] I have updated the documentation (e.g. README.rst)
