### PR TITLE
[fix] Fixed wifi session tabular inline error #504

### DIFF
--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -275,6 +275,22 @@ class DeviceAdmin(BaseDeviceAdmin, NestedModelAdmin):
 
     health_status.short_description = _('health status')
 
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        device = self.get_object(request, object_id)
+        if device and device.wifisession_set.exists():
+            # We need to provide default formset values
+            # to avoid management formset errors when wifi sessions
+            # are created while editing the DeviceAdmin change page
+            wifisession_formset_data = {
+                'wifisession_set-TOTAL_FORMS': '1',
+                'wifisession_set-INITIAL_FORMS': '1',
+            }
+            request.POST = request.POST.copy()
+            request.POST.update(wifisession_formset_data)
+        return super().change_view(
+            request, object_id, form_url=form_url, extra_context=extra_context
+        )
+
     def get_form(self, request, obj=None, **kwargs):
         """
         Adds the help_text of DeviceMonitoring.status field


### PR DESCRIPTION
If wifi sessions are created in the background while the user is still on the device change page, saving the device object can raise a formset error. To prevent this, we can check if wifi sessions exist before saving the device object and provide default values for the complaining formset fields.

Fixes #504

<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
