### PR TITLE
[fix] Store only AP clients in WiFi Sessions

### DIFF
--- a/openwisp_monitoring/device/tasks.py
+++ b/openwisp_monitoring/device/tasks.py
@@ -49,7 +49,8 @@ def save_wifi_clients_and_sessions(device_data, device_pk):
             continue
         interface_name = interface.get('name')
         wireless = interface.get('wireless', {})
-
+        if not wireless or wireless['mode'] != 'access_point':
+            continue
         ssid = wireless.get('ssid')
         clients = wireless.get('clients', [])
         for client in clients:

--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -283,6 +283,48 @@ class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
             ],
         }
 
+    mesh_interface = {
+        "addresses": [
+            {
+                "address": "fe80::6670:2ff:fe3e:9e8b",
+                "family": "ipv6",
+                "mask": 64,
+                "proto": "static",
+            }
+        ],
+        "mac": "64:70:02:3e:9e:8b",
+        "mtu": 1500,
+        "multicast": True,
+        "name": "mesh0-mng",
+        "txqueuelen": 1000,
+        "type": "wireless",
+        "up": True,
+        "wireless": {
+            "channel": 11,
+            "clients": [
+                {
+                    "auth": True,
+                    "authorized": True,
+                    "ht": True,
+                    "mac": "A0:F3:C1:A5:FA:35",
+                    "mfp": False,
+                    "noise": -95,
+                    "signal": 4,
+                    "vht": False,
+                    "wmm": True,
+                }
+            ],
+            "country": "ES",
+            "frequency": 2462,
+            "htmode": "HT20",
+            "mode": "802.11s",
+            "noise": -95,
+            "signal": 4,
+            "ssid": "battlemesh-mng",
+            "tx_power": 17,
+        },
+    }
+
 
 class DeviceMonitoringTestCase(TestDeviceMonitoringMixin, TestCase):
     pass

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -721,7 +721,9 @@ class TestWifiClientSession(TestWifiClientSessionMixin, TestCase):
     device_data_model = DeviceData
 
     def test_wifi_client_session_created(self):
-        device_data = self._save_device_data()
+        data = self._sample_data
+        data['interfaces'].append(self.mesh_interface)
+        device_data = self._save_device_data(data=data)
         self.assertEqual(WifiClient.objects.count(), 3)
         self.assertEqual(WifiSession.objects.count(), 3)
         wifi_client1 = WifiClient.objects.get(mac_address='00:ee:ad:34:f5:3b')


### PR DESCRIPTION
Ignore anything else which is coming from non access point interfaces.

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)