### PR TITLE
[fix] Fixed traffic type issue

### DIFF
--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -162,11 +162,8 @@ class DatabaseClient(object):
             logger.warning(f'got exception while writing to tsdb: {exception}')
             if isinstance(exception, self.client_error):
                 exception_code = getattr(exception, 'code', None)
-                exception_message = getattr(exception, 'content')
-                if (
-                    exception_code == 400
-                    and 'points beyond retention policy dropped' in exception_message
-                ):
+                # do not retry any request which returns 400
+                if exception_code == 400:
                     return
             raise TimeseriesWriteException
 

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -18,6 +18,7 @@ from .. import settings as app_settings
 from ..signals import health_status_changed
 from ..tasks import delete_wifi_clients_and_sessions, trigger_device_checks
 from ..utils import get_device_cache_key
+from ..writer import DeviceDataWriter
 from . import DeviceMonitoringTestCase, TestWifiClientSessionMixin
 
 DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')
@@ -539,6 +540,12 @@ class TestDeviceData(BaseTestCase):
         device.monitoring.save()
         update_config.delay(device.pk)
         mocked_logger_info.assert_called_once()
+
+    def test_calculate_increment(self):
+        dd = self._create_device_data()
+        dd.writer._init_previous_data()
+        result = dd.writer._calculate_increment('wlan0', 'rx_bytes', 1234.56)
+        self.assertEqual(result, 1234)
 
 
 class TestDeviceMonitoring(CreateConnectionsMixin, BaseTestCase):

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -18,7 +18,6 @@ from .. import settings as app_settings
 from ..signals import health_status_changed
 from ..tasks import delete_wifi_clients_and_sessions, trigger_device_checks
 from ..utils import get_device_cache_key
-from ..writer import DeviceDataWriter
 from . import DeviceMonitoringTestCase, TestWifiClientSessionMixin
 
 DeviceMonitoring = load_model('device_monitoring', 'DeviceMonitoring')

--- a/openwisp_monitoring/device/writer.py
+++ b/openwisp_monitoring/device/writer.py
@@ -354,12 +354,12 @@ class DeviceDataWriter(object):
         # and to calculate the traffic performed since the last
         # measurement we have to calculate the difference
         if value >= previous_counter:
-            return value - previous_counter
+            return int(value - previous_counter)
         # on the other side, if the current value is less than
         # the previous value, it means that the counter was restarted
         # (eg: reboot, configuration reload), so we keep the whole amount
         else:
-            return value
+            return int(value)
 
     def _create_traffic_chart(self, metric):
         """


### PR DESCRIPTION
Type cast traffic data to integer to avoid type errors in InfluxDB.

Also avoid retrying any operation which fails with exception code 400.

Checks:

- [x] I have manually tested the proposed changes
- [x] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)

Fixes #512.
