### PR TITLE
[fix] Fixed DeviceMetricView.post passing UUID object to celery task

### DIFF
--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -175,7 +175,7 @@ class DeviceMetricView(MonitoringApiViewMixin, GenericAPIView):
             return Response({'detail': _('Incorrect time format')}, status=400)
         # writing data is intensive, let's pass that to the background workers
         write_device_metrics.delay(
-            self.instance.pk, self.instance.data, time=time_obj, current=current
+            str(self.instance.pk), self.instance.data, time=time_obj, current=current
         )
         device_metrics_received.send(
             sender=self.model,


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please make sure you have read
the OpenWISP Contributing Guidelines:
http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly
-->

Checks:

- [ ] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [ ] I have updated the documentation (e.g. README.rst)
