### PR TITLE
[fix] Log info in retry mechanism when attempts fail

### DIFF
--- a/openwisp_monitoring/utils.py
+++ b/openwisp_monitoring/utils.py
@@ -23,7 +23,7 @@ def retry(method):
             try:
                 return method(*args, **kwargs)
             except Exception as err:
-                logger.info(
+                logger.exception(
                     f'Error while executing method "{method.__name__}":\n{err}\n'
                     f'Attempt {attempt_no} out of {max_retries}.\n'
                 )


### PR DESCRIPTION
Properly logs exceptions happening in wrapped code.

The `retry` wrapper is hiding exceptions happening in user's code.  This PR will
allow users to inspect the logs and see where the exception originated for tasks
that have been wrapped in the `retry` decorator.