### PR TITLE
[deps] Updated urllib3 and python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ openwisp-controller @ https://github.com/openwisp/openwisp-controller/tarball/ma
 influxdb~=5.3.1
 django-nested-admin~=4.0.2
 netaddr~=0.8.0
-python-dateutil~=2.8.2
+python-dateutil>=2.7.0,<3.0.0
 openwisp-utils[rest] @ https://github.com/openwisp/openwisp-utils/tarball/master
-urllib3~=2.0.3


### PR DESCRIPTION
The urllib3 library is automatically pulled from requests which is now defined in openwisp-utils, so we don't need to have it defined here.