### PR TITLE
[change:ux] Renamed Uptime chart to Ping Success Rate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -641,12 +641,12 @@ Ping
 +--------------------+----------------------------------------------------------------+
 | **configuration**: | ``ping``                                                       |
 +--------------------+----------------------------------------------------------------+
-| **charts**:        | ``uptime``, ``packet_loss``, ``rtt``                           |
+| **charts**:        | ``uptime`` (Ping Success Rate), ``packet_loss``, ``rtt``       |
 +--------------------+----------------------------------------------------------------+
 
 **Ping Success Rate**:
 
-.. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/uptime.png
+.. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/1.1/ping-success-rate.png
   :align: center
 
 **Packet loss**:

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ Available Features
   uptime, RAM status, CPU load averages,
   Interface properties and addresses, WiFi interface status and associated clients,
   Neighbors information, DHCP Leases, Disk/Flash status
-* Monitoring charts for `uptime <#ping>`_, `packet loss <#ping>`_,
+* Monitoring charts for `ping success rate <#ping>`_, `packet loss <#ping>`_,
   `round trip time (latency) <#ping>`_,
   `associated wifi clients <#wifi-clients>`_, `interface traffic <#traffic>`_,
   `RAM usage <#memory-usage>`_, `CPU load <#cpu-load>`_, `flash/disk usage <#disk-usage>`_,
@@ -644,7 +644,7 @@ Ping
 | **charts**:        | ``uptime``, ``packet_loss``, ``rtt``                           |
 +--------------------+----------------------------------------------------------------+
 
-**Uptime**:
+**Ping Success Rate**:
 
 .. figure:: https://github.com/openwisp/openwisp-monitoring/raw/docs/docs/uptime.png
   :align: center
@@ -1001,9 +1001,9 @@ Available Checks
 Ping
 ~~~~
 
-This check returns information on device ``uptime`` and ``RTT (Round trip time)``.
-The Charts ``uptime``, ``packet loss`` and ``rtt`` are created. The ``fping``
-command is used to collect these metrics.
+This check returns information on Ping Success Rate and RTT (Round trip time).
+It creates charts like Ping Success Rate, Packet Loss and RTT.
+These metrics are collected using the ``fping`` Linux program.
 You may choose to disable auto creation of this check by setting
 `OPENWISP_MONITORING_AUTO_PING <#OPENWISP_MONITORING_AUTO_PING>`_ to ``False``.
 
@@ -2188,19 +2188,19 @@ An example usage has been shown below.
         'charts': {
             'uptime': {
                 'type': 'bar',
-                'title': _('Uptime'),
+                'title': _('Ping Success Rate'),
                 'description': _(
                     'A value of 100% means reachable, 0% means unreachable, values in '
                     'between 0% and 100% indicate the average reachability in the '
                     'period observed. Obtained with the fping linux program.'
                 ),
-                'summary_labels': [_('Average uptime')],
+                'summary_labels': [_('Average Ping Success Rate')],
                 'unit': '%',
                 'order': 200,
                 'colorscale': {
                     'max': 100,
                     'min': 0,
-                    'label': _('Reachable'),
+                    'label': _('Rate'),
                     'scale': [
                         [[0, '#c13000'],
                         [0.1,'cb7222'],
@@ -2209,7 +2209,7 @@ An example usage has been shown below.
                         [1, '#498b26']],
                     ],
                     'map': [
-                       [100, '#498b26', _('Reachable')],
+                       [100, '#498b26', _('Flawless')],
                        [90, '#7db201', _('Mostly Reachable')],
                        [50, '#deed0e', _('Partly Reachable')],
                        [10, '#cb7222', _('Mostly Unreachable')],

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -58,19 +58,19 @@ DEFAULT_METRICS = {
         'charts': {
             'uptime': {
                 'type': 'bar',
-                'title': _('Uptime'),
+                'title': _('Ping Success Rate'),
                 'description': _(
                     'A value of 100% means reachable, 0% means unreachable, values in '
                     'between 0% and 100% indicate the average reachability in the '
                     'period observed. Obtained with the fping linux program.'
                 ),
-                'summary_labels': [_('Average uptime')],
+                'summary_labels': [_('Average Ping Success Rate')],
                 'unit': '%',
                 'order': 200,
                 'colorscale': {
                     'max': 100,
                     'min': 0,
-                    'label': _('Reachable'),
+                    'label': _('Rate'),
                     'scale': [
                         [0, '#c13000'],
                         [0.1, '#ec7204'],
@@ -79,7 +79,7 @@ DEFAULT_METRICS = {
                         [1, '#7db201'],
                     ],
                     'map': [
-                        [100, '#7db201', _('Reachable')],
+                        [100, '#7db201', _('Flawless')],
                         [90, '#90d000', _('Mostly Reachable')],
                         [50, '#deed0e', _('Partly Reachable')],
                         [10, '#ec7204', _('Mostly Unreachable')],


### PR DESCRIPTION
This is needed to avoid confusion with the concept of system uptime.

Checks:

- [x] I have manually tested the proposed changes
- [ ] I have written new test cases to avoid regressions (if necessary)
- [x] I have updated the documentation (e.g. README.rst)
