### PR TITLE
[fix] Both 'rx_bytes' and 'tx_bytes' are present #595

### DIFF
--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -86,10 +86,11 @@ class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
         data = self._transform_wireless_interface_test_data(data)
         self.assertDictEqual(dd_data, data)
 
-    def create_test_data(self, no_resources=False):
+    def create_test_data(self, no_resources=False, data=None, assertions=True):
         o = self._create_org()
         d = self._create_device(organization=o)
-        data = self._data()
+        if not data:
+            data = self._data()
         # creation of resources metrics can be avoided in tests not involving them
         # this speeds up those tests by reducing requests made
         if no_resources:
@@ -97,6 +98,8 @@ class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
         r = self._post_data(d.id, d.key, data)
         self.assertEqual(r.status_code, 200)
         dd = DeviceData(pk=d.pk)
+        if not assertions:
+            return dd
         self.assertDataDict(dd.data, data)
         if no_resources:
             metric_count, chart_count = 4, 4

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -544,40 +544,6 @@ class TestDeviceData(BaseTestCase):
         result = dd.writer._calculate_increment('wlan0', 'rx_bytes', 1234.56)
         self.assertEqual(result, 1234)
 
-    def test_save_data_missing_tx_bytes(self):
-        """
-        Test that device data is saved successfully when tx_bytes is missing
-        while rx_bytes is present in interface statistics
-        """
-        dd = self._create_device_data()
-        data = deepcopy(self._sample_data)
-        del data['interfaces'][0]['statistics']['tx_bytes']
-        dd.data = data
-        dd.save_data()
-        dd_read = DeviceData(pk=dd.pk)
-        interface_stats = dd_read.data['interfaces'][0]['statistics']
-        self.assertEqual(interface_stats['rx_bytes'], 0)
-        self.assertNotIn('tx_bytes', interface_stats)
-        self.assertEqual(interface_stats['collisions'], 0)
-        self.assertEqual(interface_stats['multicast'], 0)
-
-    def test_save_data_missing_rx_bytes(self):
-        """
-        Test that device data is saved successfully when rx_bytes is missing
-        while tx_bytes is present in interface statistics
-        """
-        dd = self._create_device_data()
-        data = deepcopy(self._sample_data)
-        del data['interfaces'][0]['statistics']['rx_bytes']
-        dd.data = data
-        dd.save_data()
-        dd_read = DeviceData(pk=dd.pk)
-        interface_stats = dd_read.data['interfaces'][0]['statistics']
-        self.assertEqual(interface_stats['tx_bytes'], 864)
-        self.assertNotIn('rx_bytes', interface_stats)
-        self.assertEqual(interface_stats['collisions'], 0)
-        self.assertEqual(interface_stats['multicast'], 0)
-
 
 class TestDeviceMonitoring(CreateConnectionsMixin, BaseTestCase):
     """Test openwisp_monitoring.device.models.DeviceMonitoring"""

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -544,6 +544,40 @@ class TestDeviceData(BaseTestCase):
         result = dd.writer._calculate_increment('wlan0', 'rx_bytes', 1234.56)
         self.assertEqual(result, 1234)
 
+    def test_save_data_missing_tx_bytes(self):
+        """
+        Test that device data is saved successfully when tx_bytes is missing
+        while rx_bytes is present in interface statistics
+        """
+        dd = self._create_device_data()
+        data = deepcopy(self._sample_data)
+        del data['interfaces'][0]['statistics']['tx_bytes']
+        dd.data = data
+        dd.save_data()
+        dd_read = DeviceData(pk=dd.pk)
+        interface_stats = dd_read.data['interfaces'][0]['statistics']
+        self.assertEqual(interface_stats['rx_bytes'], 0)
+        self.assertNotIn('tx_bytes', interface_stats)
+        self.assertEqual(interface_stats['collisions'], 0)
+        self.assertEqual(interface_stats['multicast'], 0)
+
+    def test_save_data_missing_rx_bytes(self):
+        """
+        Test that device data is saved successfully when rx_bytes is missing
+        while tx_bytes is present in interface statistics
+        """
+        dd = self._create_device_data()
+        data = deepcopy(self._sample_data)
+        del data['interfaces'][0]['statistics']['rx_bytes']
+        dd.data = data
+        dd.save_data()
+        dd_read = DeviceData(pk=dd.pk)
+        interface_stats = dd_read.data['interfaces'][0]['statistics']
+        self.assertEqual(interface_stats['tx_bytes'], 864)
+        self.assertNotIn('rx_bytes', interface_stats)
+        self.assertEqual(interface_stats['collisions'], 0)
+        self.assertEqual(interface_stats['multicast'], 0)
+
 
 class TestDeviceMonitoring(CreateConnectionsMixin, BaseTestCase):
     """Test openwisp_monitoring.device.models.DeviceMonitoring"""

--- a/openwisp_monitoring/device/writer.py
+++ b/openwisp_monitoring/device/writer.py
@@ -80,7 +80,7 @@ class DeviceDataWriter(object):
             # Explicitly stated None to avoid skipping in case the stats are zero
             if (
                 ifstats.get('rx_bytes') is not None
-                and ifstats.get('rx_bytes') is not None
+                and ifstats.get('tx_bytes') is not None
             ):
                 field_value = self._calculate_increment(
                     ifname, 'rx_bytes', ifstats['rx_bytes']

--- a/openwisp_monitoring/device/writer.py
+++ b/openwisp_monitoring/device/writer.py
@@ -80,14 +80,14 @@ class DeviceDataWriter(object):
             # Explicitly stated None to avoid skipping in case the stats are zero
             if (
                 ifstats.get('rx_bytes') is not None
-                and ifstats.get('tx_bytes') is not None
+                or ifstats.get('tx_bytes') is not None
             ):
                 field_value = self._calculate_increment(
-                    ifname, 'rx_bytes', ifstats['rx_bytes']
+                    ifname, 'rx_bytes', ifstats.get('rx_bytes', 0)
                 )
                 extra_values = {
                     'tx_bytes': self._calculate_increment(
-                        ifname, 'tx_bytes', ifstats['tx_bytes']
+                        ifname, 'tx_bytes', ifstats.get('tx_bytes', 0)
                     )
                 }
                 name = f'{ifname} traffic'


### PR DESCRIPTION
Fixes #595

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

- Both 'rx_bytes' and 'tx_bytes' are present in the statistics.
- Neither of them is None, which allows for zero values (as per the comment).

Closes #595
