### PR TITLE
[fix] Use "time" argument for calculating time in "Chart._get_time" #612

### DIFF
--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -729,7 +729,7 @@ class AbstractChart(TimeStampedEditableModel):
             return start_date
         if not isinstance(time, str):
             return str(time)
-        if time in cls._get_group_map().keys():
+        if time in cls._get_group_map(time).keys():
             days = int(time.strip('d'))
             now = timezone.now()
             if days > 3:

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -670,6 +670,11 @@ class TestDashboardTimeseriesView(
             self.assertEqual(response.status_code, 200)
             self.assertIsInstance(response.data['charts'], list)
 
+        with self.subTest('Test with custom valid group time'):
+            response = self.client.get(path, {'time': '5d'})
+            self.assertEqual(response.status_code, 200)
+            self.assertIsInstance(response.data['charts'], list)
+
         with self.subTest('Test with invalid group time'):
             response = self.client.get(path, {'time': '3w'})
             self.assertEqual(response.status_code, 400)


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #612

