### PR TITLE
[fix] Fixed backward compatibility issue with custom health status labels

### DIFF
--- a/openwisp_monitoring/device/settings.py
+++ b/openwisp_monitoring/device/settings.py
@@ -20,27 +20,19 @@ def get_critical_device_metrics():
 
 
 def get_health_status_labels():
-    labels = get_settings_value(
+    default_labels = {
+        'unknown': 'unknown',
+        'ok': 'ok',
+        'problem': 'problem',
+        'critical': 'critical',
+        'deactivated': 'deactivated',
+    }
+    labels = default_labels.copy()
+    configured_labels = get_settings_value(
         'HEALTH_STATUS_LABELS',
-        {
-            'unknown': 'unknown',
-            'ok': 'ok',
-            'problem': 'problem',
-            'critical': 'critical',
-            'deactivated': 'deactivated',
-        },
+        default_labels,
     )
-    try:
-        assert 'unknown' in labels
-        assert 'ok' in labels
-        assert 'problem' in labels
-        assert 'critical' in labels
-        assert 'deactivated' in labels
-    except AssertionError as e:  # pragma: no cover
-        raise ImproperlyConfigured(
-            'OPENWISP_MONITORING_HEALTH_STATUS_LABELS must contain the following '
-            'keys: unknown, ok, problem, critical'
-        ) from e
+    labels.update(configured_labels)
     return labels
 
 

--- a/openwisp_monitoring/device/tests/test_settings.py
+++ b/openwisp_monitoring/device/tests/test_settings.py
@@ -18,12 +18,3 @@ class TestSettings(DeviceMonitoringTestCase):
             from ..settings import get_critical_device_metrics
 
             get_critical_device_metrics()
-
-    @patch(
-        'django.conf.settings.OPENWISP_MONITORING_HEALTH_STATUS_LABELS', {}, create=True
-    )
-    def test_invalid_health_status_setting(self):
-        with self.assertRaises(ImproperlyConfigured):
-            from ..settings import get_health_status_labels
-
-            get_health_status_labels()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

When using customized OPENWISP_MONITORING_HEALTH_STATUS_LABELS, forgetting to add the new deactivated status label after upgrading would cause a crash of the application during startup.

This fix provides a set of valid defaults which is always present and gets overridden with the custom labels.

## Screenshot

N/A.