### PR TITLE
[fix] Fixed "migrate_timeseries" command

### DIFF
--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -148,9 +148,9 @@ class DatabaseClient(object):
             database=database,
         )
 
-    def store(self, points, database, retention_policy):
+    def _write(self, points, database, retention_policy):
         """
-        Store data points in the specified database.
+        Write data points in the specified database.
 
         This method writes data points to the specified database. If the size of the data exceeds
         the limit of a UDP packet, it falls back to using a TCP connection for writing data.
@@ -203,7 +203,7 @@ class DatabaseClient(object):
             'fields': values,
             'time': timestamp,
         }
-        self.store(
+        self._write(
             points=[point],
             database=kwargs.get('database') or self.db_name,
             retention_policy=kwargs.get('retention_policy'),
@@ -229,7 +229,7 @@ class DatabaseClient(object):
             )
         for database in data_points.keys():
             for rp in data_points[database].keys():
-                self.store(
+                self._write(
                     points=data_points[database][rp],
                     database=database,
                     retention_policy=rp,

--- a/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
+++ b/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
@@ -114,7 +114,7 @@ def migrate_influxdb_data(
             start = offset
             end = offset + min(write_data_count, SELECT_QUERY_LIMIT)
             response = retry_until_success(
-                timeseries_db.store,
+                timeseries_db._write,
                 write_data,
                 timeseries_db.db_name,
                 retention_policy=None,

--- a/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
+++ b/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
@@ -114,10 +114,10 @@ def migrate_influxdb_data(
             start = offset
             end = offset + min(write_data_count, SELECT_QUERY_LIMIT)
             response = retry_until_success(
-                timeseries_db.db.write_points,
+                timeseries_db.store,
                 write_data,
-                tags=metric.tags,
-                batch_size=WRITE_BATCH_SIZE,
+                timeseries_db.db_name,
+                retention_policy=None,
             )
             if response is True:
                 logger.info(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Bug:
The delete query for migrating "traffic" data included WHERE clause which is not supported in InfluxDB.

Fix:
Migrate the "traffic" data at the end. Delete metrics only after migrating "traffic" data.

Fixes #626

