### PR TITLE
[fix] Wrap measurement name in double quotes in timeseries_migrate command

### DIFF
--- a/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
+++ b/openwisp_monitoring/monitoring/migrations/influxdb/influxdb_alter_structure_0006.py
@@ -12,12 +12,12 @@ from openwisp_monitoring.db.exceptions import TimeseriesWriteException
 SELECT_QUERY_LIMIT = 1000
 WRITE_BATCH_SIZE = 1000
 READ_QUERY = (
-    "SELECT {fields} FROM {measurement}"
+    "SELECT {fields} FROM \"{measurement}\""
     " WHERE content_type='{content_type_key}'"
     " AND object_id='{object_id}'"
 )
 DELETE_QUERY = (
-    "DROP SERIES FROM {old_measurement}"
+    "DROP SERIES FROM \"{old_measurement}\""
     " WHERE content_type='{content_type_key}'"
     " AND object_id='{object_id}'"
 )


### PR DESCRIPTION
Bug:
The READ_QUERY was failing if the measurement name starts with an integer.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

