### PR TITLE
Add isnull to filters.py

### DIFF
--- a/openwisp_monitoring/device/api/filters.py
+++ b/openwisp_monitoring/device/api/filters.py
@@ -19,7 +19,7 @@ class WifiSessionFilter(FilterDjangoByOrgManaged):
             'device': ['exact'],
             'device__group': ['exact'],
             'start_time': ['exact', 'gt', 'gte', 'lt', 'lte'],
-            'stop_time': ['exact', 'gt', 'gte', 'lt', 'lte'],
+            'stop_time': ['exact', 'gt', 'gte', 'lt', 'lte', 'isnull'],
         }
 
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes https://github.com/openwisp/openwisp-monitoring/discussions/631

## Description of Changes

Adds isnull for stop_time in filters.py.
Afterwards one can filter by 'By stop time' --> No date via api.