### PR TITLE
[change] Add metric names to signal chart labels #311

### DIFF
--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -572,12 +572,14 @@ DEFAULT_METRICS = {
                 'type': 'scatter',
                 'fill': 'none',
                 'yaxis': {'zeroline': False},
-                'title': _('Signal Strength'),
+                'title': _('Signal Strength (RSSI)'),
                 'colors': (DEFAULT_COLORS[3], DEFAULT_COLORS[0]),
-                'description': _('Signal Strength and Signal Power, measured in dBm.'),
+                'description': _(
+                    'Signal Strength (RSSI) and Signal Power (RSRP), measured in dBm.'
+                ),
                 'summary_labels': [
-                    _('Average Signal Power'),
-                    _('Average Signal Strength'),
+                    _('Average Signal Power (RSRP)'),
+                    _('Average Signal Strength (RSSI)'),
                 ],
                 'unit': _(' dBm'),
                 'order': 205,
@@ -596,14 +598,16 @@ DEFAULT_METRICS = {
                 'type': 'scatter',
                 'fill': 'none',
                 'yaxis': {'zeroline': False},
-                'title': _('Signal Quality'),
+                'title': _('Signal Quality (RSRQ)'),
                 'colors': (DEFAULT_COLORS[3], DEFAULT_COLORS[0]),
                 'description': _(
-                    _('Signal Quality and Signal to Noise Ratio (SNR), measured in dB.')
+                    _(
+                        'Signal Quality (RSRQ) and Signal to Noise Ratio (SNR), measured in dB.'
+                    )
                 ),
                 'summary_labels': [
-                    _('Average Signal Quality'),
-                    _('Average Signal to Noise Ratio'),
+                    _('Average Signal Quality (RSRQ)'),
+                    _('Average Signal to Noise Ratio (SNR)'),
                 ],
                 'unit': _(' dB'),
                 'order': 206,


### PR DESCRIPTION
Fixes #311

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to #311 

Closes #311.

## Description of Changes

Change label names as follows:
- Signal Strength -> Signal Strength (RSSI)
- Signal Power -> Signal Power (RSRP)
- Signal Quality -> Signal Quality (RSRQ)
- Signal to Noise Ratio -> Signal to Noise Ratio (SNR)

Please describe these changes.

## Screenshot

![Screenshot from 2025-02-07 21-18-47](https://github.com/user-attachments/assets/f6aa1b7a-534f-4bc4-ae5c-dea0b2e0c1f6)

![Screenshot from 2025-02-07 21-20-38](https://github.com/user-attachments/assets/fdca9604-fd38-414d-873f-132b1e99beb9)

