### PR TITLE
[docs] Add information about default alert settings #611

### DIFF
--- a/docs/user/device-checks-and-alert-settings.rst
+++ b/docs/user/device-checks-and-alert-settings.rst
@@ -4,22 +4,11 @@ Managing Device Checks & Alert Settings
 We can add checks and define alert settings directly from the **device
 page**.
 
-To add a check, you just need to select an available **check type** as
-shown below:
-
-.. figure:: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.1/device-inline-check.png
-    :target: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.1/device-inline-check.png
-    :align: center
-
-The following example shows how to use the
-:ref:`openwisp_monitoring_metrics` setting to reconfigure the system for
-:ref:`iperf3 check <iperf3_check>` to send an alert if the measured **TCP
-bandwidth** has been less than **10Mbit/s** for more than **2 days**.
-
 Default Alert Settings
 ----------------------
 
-By default, OpenWISP Monitoring provides predefined alert settings for common checks. These alerts ensure that system performance and availability issues are detected early. 
+By default, OpenWISP Monitoring provides predefined alert settings for common checks. 
+These alerts ensure that system performance and availability issues are detected early.
 
 The default alerts include:
 
@@ -30,6 +19,24 @@ The default alerts include:
 - **Iperf3 Bandwidth Drop**: Triggered if **TCP bandwidth** is less than **10Mbit/s** for more than **2 days**.
 
 These settings can be customized through the device page.
+
+Adding Custom Checks
+-------------------
+
+To add a check, you just need to select an available **check type** as
+shown below:
+
+.. figure:: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.1/device-inline-check.png
+    :target: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.1/device-inline-check.png
+    :align: center
+
+Customizing Iperf3 Check Settings
+--------------------------------
+
+The following example shows how to use the :ref:`openwisp_monitoring_metrics` 
+setting to reconfigure the system for :ref:`iperf3 check <iperf3_check>` 
+to send an alert if the measured **TCP bandwidth** has been less than 
+**10Mbit/s** for more than **2 days**.
 
 1. By default, :ref:`Iperf3 checks <iperf3_check>` come with default alert
 settings, but it is easy to customize alert settings through the device

--- a/docs/user/device-checks-and-alert-settings.rst
+++ b/docs/user/device-checks-and-alert-settings.rst
@@ -16,6 +16,21 @@ The following example shows how to use the
 :ref:`iperf3 check <iperf3_check>` to send an alert if the measured **TCP
 bandwidth** has been less than **10Mbit/s** for more than **2 days**.
 
+Default Alert Settings
+----------------------
+
+By default, OpenWISP Monitoring provides predefined alert settings for common checks. These alerts ensure that system performance and availability issues are detected early. 
+
+The default alerts include:
+
+- **Ping Loss**: Triggered if packet loss exceeds **30%** over **5 minutes**.
+- **High Latency**: Triggered if response time is greater than **200ms** for **10 consecutive pings**.
+- **Low Disk Space**: Triggered if available disk space falls below **10%**.
+- **High CPU Usage**: Triggered if CPU usage exceeds **90%** for more than **15 minutes**.
+- **Iperf3 Bandwidth Drop**: Triggered if **TCP bandwidth** is less than **10Mbit/s** for more than **2 days**.
+
+These settings can be customized through the device page.
+
 1. By default, :ref:`Iperf3 checks <iperf3_check>` come with default alert
 settings, but it is easy to customize alert settings through the device
 page as shown below:


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [X] I have updated the documentation.

## Reference to Existing Issue

Closes #611.

## Description of Changes

This PR adds a new section explaining the **default alert settings** in OpenWISP Monitoring. The updated documentation includes:

- A new **Default Alert Settings** section listing predefined alerts.
- A description of common default alerts such as **Ping Loss, High Latency, Low Disk Space, High CPU Usage, and Iperf3 Bandwidth Drop**.
- Clarification that these alerts are customizable via the device page.

These changes enhance the documentation by making it easier for users to understand the built-in monitoring alerts and their behavior.

@nemesifier kindly review it
