### PR TITLE
[fix] Use "iterator" method instead of "all" to iterate over objects

### DIFF
--- a/openwisp_monitoring/check/migrations/0007_create_checks.py
+++ b/openwisp_monitoring/check/migrations/0007_create_checks.py
@@ -10,7 +10,7 @@ def create_ping_checks(apps, schema_editor):
         ContentType = apps.get_model('contenttypes', 'ContentType')
         Check = apps.get_model('check', 'Check')
         Device = apps.get_model('config', 'Device')
-        for device in Device.objects.all():
+        for device in Device.objects.iterator():
             auto_create_check(
                 model=Device.__name__.lower(),
                 app_label=Device._meta.app_label,
@@ -28,7 +28,7 @@ def create_config_applied_checks(apps, schema_editor):
     ContentType = apps.get_model('contenttypes', 'ContentType')
     Check = apps.get_model('check', 'Check')
     Device = apps.get_model('config', 'Device')
-    for device in Device.objects.all():
+    for device in Device.objects.iterator():
         auto_create_check(
             model=Device.__name__.lower(),
             app_label=Device._meta.app_label,

--- a/openwisp_monitoring/device/migrations/0001_squashed_0002_devicemonitoring.py
+++ b/openwisp_monitoring/device/migrations/0001_squashed_0002_devicemonitoring.py
@@ -18,7 +18,7 @@ def create_device_monitoring(apps, schema_editor):
     """Data migration"""
     Device = apps.get_model('config', 'Device')
     DeviceMonitoring = apps.get_model('device_monitoring', 'DeviceMonitoring')
-    for device in Device.objects.all():
+    for device in Device.objects.iterator():
         DeviceMonitoring.objects.create(device=device)
 
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.



## Description of Changes

Updated code in  data migrations which used "Model.objects.all()" to use "Model.objects.all()".
