### PR TITLE
[docker-compose] Remove deprecated version field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   monitoring:
     image: openwisp/openwisp-monitoring:develop


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

No related issue.

I believe opening an issue for this small cleanup is unnecessary.

## Description of Changes

Removed the deprecated `version` field from the `docker-compose.yml` file.  
As of newer Docker Compose versions, this field is no longer required.  
This update eliminates unnecessary warnings.

## Screenshot

Not applicable.
