### PR TITLE
[ci] 1.1: Run on Ubuntu 22.04 (Ubuntu 20.04 has been retired)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: Python==${{ matrix.python-version }} | ${{ matrix.django-version }}
     # Update this only when support for Django 3.2 is removed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       redis:


### PR DESCRIPTION
Run on Ubuntu 22.04 (Ubuntu 20.04 has been retired).