### PR TITLE
[chores] Do not allow selecting columns when exporting devices

### DIFF
--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -14,6 +14,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from import_export.admin import ImportExportMixin
+from import_export.forms import ExportForm
 from nested_admin.nested import (
     NestedGenericStackedInline,
     NestedModelAdmin,
@@ -370,6 +371,7 @@ class DeviceAdmin(BaseDeviceAdmin, NestedModelAdmin):
 
 
 class DeviceAdminExportable(ImportExportMixin, DeviceAdmin):
+    export_form_class = ExportForm
     resource_class = DeviceMonitoringResource
     # Added to support both reversion and import-export
     change_list_template = 'admin/config/change_list_device.html'


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

The django-export-import dependency was upgraded in openwisp-controller which now allows selecting the columns during export operation.

Since this can cause issues during import of files with limited fields, we decided to rollback to the old implementation which exports all the fields of the device model.

Related https://github.com/openwisp/openwisp-controller/pull/915

