### PR TITLE
[change] Changed default alert tolerances to reduce noise

### DIFF
--- a/docs/user/alerts.rst
+++ b/docs/user/alerts.rst
@@ -18,8 +18,9 @@ setting includes:
   - **Less than**: triggers when the value is below the threshold.
 
 - **Threshold**: the metric value that triggers the alert.
-- **Tolerance**: the duration (in minutes) for which the threshold must be
-  breached before an alert is triggered.
+- **Tolerance**: the duration (in minutes) the threshold must be
+  continuously breached before triggering an alert. Helps reduce noise
+  from flapping metrics.
 
 OpenWISP Monitoring provides built-in alerts for the following metrics:
 
@@ -42,7 +43,7 @@ enabled by default.
 ========= =================
 Operator  ``< (less than)``
 Threshold ``1``
-Tolerance ``0`` minutes
+Tolerance ``30`` minutes
 ========= =================
 
 .. note::
@@ -63,7 +64,7 @@ specified time. This alert is enabled by default.
 ========= =================
 Operator  ``< (less than)``
 Threshold ``1``
-Tolerance ``5`` minutes
+Tolerance ``10`` minutes
 ========= =================
 
 .. note::
@@ -103,7 +104,7 @@ default.
 ========= ====================
 Operator  ``> (greater than)``
 Threshold ``90`` (percent)
-Tolerance ``5`` minutes
+Tolerance ``30`` minutes
 ========= ====================
 
 Memory Usage
@@ -117,7 +118,7 @@ default.
 ========= ====================
 Operator  ``> (greater than)``
 Threshold ``95`` (percent)
-Tolerance ``5`` minutes
+Tolerance ``30`` minutes
 ========= ====================
 
 Disk Usage

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -657,7 +657,7 @@ class TestAdmin(
             )
             self.assertContains(
                 response,
-                'metric-content_type-object_id-0-alertsettings-0-custom_tolerance" value="0"',
+                'metric-content_type-object_id-0-alertsettings-0-custom_tolerance" value="30"',
             )
 
         with self.subTest(

--- a/openwisp_monitoring/monitoring/configuration.py
+++ b/openwisp_monitoring/monitoring/configuration.py
@@ -118,7 +118,7 @@ DEFAULT_METRICS = {
                 "query": chart_query["rtt"],
             },
         },
-        "alert_settings": {"operator": "<", "threshold": 1, "tolerance": 0},
+        "alert_settings": {"operator": "<", "threshold": 1, "tolerance": 30},
         "notification": {
             "problem": {
                 "verbose_name": "Ping PROBLEM",
@@ -151,7 +151,7 @@ DEFAULT_METRICS = {
         "name": "Configuration Applied",
         "key": "config_applied",
         "field_name": "config_applied",
-        "alert_settings": {"operator": "<", "threshold": 1, "tolerance": 5},
+        "alert_settings": {"operator": "<", "threshold": 1, "tolerance": 10},
         "notification": {
             "problem": {
                 "verbose_name": "Configuration Applied PROBLEM",
@@ -481,7 +481,7 @@ DEFAULT_METRICS = {
                 "query": chart_query["memory"],
             }
         },
-        "alert_settings": {"operator": ">", "threshold": 95, "tolerance": 5},
+        "alert_settings": {"operator": ">", "threshold": 95, "tolerance": 30},
         "notification": {
             "problem": {
                 "verbose_name": "Memory usage PROBLEM",
@@ -531,7 +531,7 @@ DEFAULT_METRICS = {
                 "query": chart_query["cpu"],
             }
         },
-        "alert_settings": {"operator": ">", "threshold": 90, "tolerance": 5},
+        "alert_settings": {"operator": ">", "threshold": 90, "tolerance": 30},
         "notification": {
             "problem": {
                 "verbose_name": "CPU usage PROBLEM",

--- a/openwisp_monitoring/monitoring/tests/test_admin.py
+++ b/openwisp_monitoring/monitoring/tests/test_admin.py
@@ -30,7 +30,7 @@ class TestAdmin(TestMonitoringMixin, TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(r, '<option value="&lt;" selected>less than</option>')
         self.assertContains(r, 'name="alertsettings-0-custom_threshold" value="1"')
-        self.assertContains(r, 'name="alertsettings-0-custom_tolerance" value="0"')
+        self.assertContains(r, 'name="alertsettings-0-custom_tolerance" value="30"')
 
     def test_admin_menu_groups(self):
         # Test menu group (openwisp-utils menu group) for Metric and Check models


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Description of Changes

Change the default alert tolerance for the most commonly generated alerts to reduce noise.

On most prod instances we maintain, we must have at least 30 minutes of tolerance or we would incur in the generation of too many email alerts, which is not useful in most situations.