### PR TITLE
[chores] Improve device map tooltip

### DIFF
--- a/openwisp_monitoring/device/static/monitoring/css/device-map.css
+++ b/openwisp_monitoring/device/static/monitoring/css/device-map.css
@@ -29,6 +29,9 @@
   background-color: #000000;
   color: #fff;
 }
+.map-detail table {
+  width: 100%;
+}
 #device-map-container {
   margin: 50px auto;
   position: relative;

--- a/openwisp_monitoring/device/static/monitoring/js/device-map.js
+++ b/openwisp_monitoring/device/static/monitoring/js/device-map.js
@@ -205,7 +205,7 @@
       clusteringThreshold: 0,
       clusterRadius: 100,
       clusterSeparation: 20,
-      disableClusteringAtLevel: 16,
+      disableClusteringAtLevel: 15,
       mapOptions: {
         // Use sensible fallback if the backend does not provide DEFAULT_CENTER.
         center: leafletConfig.DEFAULT_CENTER || [55.78, 11.54],
@@ -213,12 +213,24 @@
         minZoom: leafletConfig.MIN_ZOOM || 1,
         maxZoom: leafletConfig.MAX_ZOOM || 24,
         fullscreenControl: true,
+        // Force tooltips ON for all viewport widths; override library's
+        // responsive media rules that hide tooltips under 851px.
+        baseOptions: {
+          media: [
+            {
+              query: { minWidth: 0 },
+              option: { tooltip: { show: true } },
+            },
+          ],
+        },
       },
       mapTileConfig: tiles,
       nodeCategories: Object.keys(colors).map((status) => ({
         name: status,
         nodeStyle: { color: colors[status] },
       })),
+      // Hide ECharts node labels completely at any zoom level
+      showLabelsAtZoomLevel: 10000,
       echartsOption: {
         tooltip: {
           confine: true,


### PR DESCRIPTION
Set table width to 100% in map details for better layout. Adjust clustering to disable at zoom level 15 instead of 16, force tooltips to show on all viewport widths, and hide ECharts node labels at all zoom levels for a cleaner map display.

## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #<issue-number>.

Please [open a new issue](https://github.com/openwisp/openwisp-monitoring/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Please describe these changes.

## Screenshot

Please include any relevant screenshots.
