### PR TITLE
monitoring/api/views.py  added the rest api parameters in the swagge…

### DIFF
--- a/openwisp_monitoring/monitoring/api/views.py
+++ b/openwisp_monitoring/monitoring/api/views.py
@@ -1,5 +1,7 @@
 from cache_memoize import cache_memoize
 from django.db.models import Q
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
@@ -181,6 +183,52 @@ class DashboardTimeseriesView(ProtectedAPIMixin, MonitoringApiViewMixin, APIView
             return []
         return orgs
 
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "organization_slug",
+                openapi.IN_QUERY,
+                description="Organization slug (e.g. PHYTunes)",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+            openapi.Parameter(
+                "location_id",
+                openapi.IN_QUERY,
+                description="Location ID",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+            openapi.Parameter(
+                "floorplan_id",
+                openapi.IN_QUERY,
+                description="Floor plan ID.",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+            openapi.Parameter(
+                "time",
+                openapi.IN_QUERY,
+                description="Timeframe in days (e.g. 1d means 1 day and same goes with higher)",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+            openapi.Parameter(
+                "start",
+                openapi.IN_QUERY,
+                description="Start time in YYYY-MM-DD H:M:S format",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+            openapi.Parameter(
+                "end",
+                openapi.IN_QUERY,
+                description="End time in YYYY-MM-DD H:M:S format",
+                type=openapi.TYPE_STRING,
+                required=False,
+            ),
+        ]
+    )
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
         if not request.GET.get("csv"):


### PR DESCRIPTION
monitoring/api/views.py  added the rest api parameters in the swagger docs #715.

there are some parameter on api/v1/monitoring/dashboard endpoint which are mentioned in the api docs but those parameter are not available in the swagger docs and redoc, and my changes solve this issue I have implemented the @swagger_auto_schema decorator which lets this parameter appear in the swagger ui and redoc.

fixes #715

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.




## Description of Changes
first the swagger ui was not showing the parameter fields on api/v1/monitoring/dashboard endpoint in swagger and redoc , and I've made some changes which lets the parameter fields appear in swagger and redoc docs.

## Screenshot

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b7592e0f-01b2-4a8b-9ece-38d396bd8d89" />

