### PR TITLE
[fix] Handled ZeroDivisionError in DeviceDataWriter._write_disk

### DIFF
--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -514,6 +514,23 @@ class TestDeviceData(MonitoringTestMixin, DeviceMonitoringTestCase):
             else:
                 self.fail("ValidationError not raised")
 
+    def test_disk_size_bytes_zero(self):
+        """Ensures buggy data doesn't crash the writer"""
+        dd = self._create_device_data()
+        data = deepcopy(self._sample_data)
+        data["resources"]["disk"] = [
+            {
+                "used_bytes": 0,
+                "available_bytes": 0,
+                "filesystem": "/dev/root",
+                "mount_point": "/",
+                "used_percent": 100,
+                "size_bytes": 0,
+            }
+        ]
+        dd.writer.write(data)
+        self.assertEqual(dd.data["resources"]["disk"][0]["used_percent"], 100)
+
     def test_resources_no_key(self):
         dd = self._create_device_data()
         with self.subTest("Test No Resources"):

--- a/openwisp_monitoring/device/writer.py
+++ b/openwisp_monitoring/device/writer.py
@@ -1,10 +1,10 @@
 import logging
 from copy import deepcopy
 from datetime import datetime, timedelta
-from django.utils import timezone
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
 from pytz import UTC
 from swapper import load_model
 
@@ -306,9 +306,11 @@ class DeviceDataWriter(object):
         if created:
             self._create_resources_chart(metric, resource="disk")
             self._create_resources_alert_settings(metric, resource="disk")
-        self._append_metric_data(
-            metric, 100 * used_bytes / size_bytes, current, time=time
-        )
+        try:
+            value = 100 * used_bytes / size_bytes
+        except ZeroDivisionError:
+            value = 100
+        self._append_metric_data(metric, value, current, time=time)
 
     def _write_memory(
         self, memory, primary_key, content_type, current=False, time=None


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Let's make sure the metric writer doesn't crash if for any reason the reported disk size is zero.