### PR TITLE
build dynamic timeseries_db based on selected backend from registry

### DIFF
--- a/openwisp_monitoring/db/backends/registry.py
+++ b/openwisp_monitoring/db/backends/registry.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    path: str
+    required_keys: Tuple[str, ...]
+    default_options: Dict[str, object]
+
+
+BUILTIN_BACKENDS: Dict[str, BackendSpec] = {
+    "influxdb": BackendSpec(
+        path="openwisp_monitoring.db.backends.influxdb",
+        required_keys=("NAME", "HOST", "PORT", "USER", "PASSWORD"),
+        default_options={
+            "HOST": "localhost",
+            "PORT": "8086",
+            "NAME": "openwisp2",
+            "USER": "openwisp",
+        },
+    )
+}
+
+DEFAULT_BACKEND_KEY = "influxdb"
+DEFAULT_BACKEND_PATH = BUILTIN_BACKENDS[DEFAULT_BACKEND_KEY].path
+
+
+def builtin_backend_paths() -> Tuple[str, ...]:
+    return tuple(spec.path for spec in BUILTIN_BACKENDS.values())
+
+
+def default_options_for_backend(backend_path: str) -> Dict[str, object]:
+    for spec in BUILTIN_BACKENDS.values():
+        if spec.path == backend_path:
+            return dict(spec.default_options)
+    return {}
+
+
+def resolve_backend_path(backend_value: str) -> str:
+    if backend_value in BUILTIN_BACKENDS:
+        return BUILTIN_BACKENDS[backend_value].path
+    return backend_value
+
+
+def required_keys_for_backend(backend_path: str) -> Tuple[str, ...]:
+    for spec in BUILTIN_BACKENDS.values():
+        if spec.path == backend_path:
+            return spec.required_keys
+    return tuple()


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #731 

## Description of Changes
This PR removes InfluxDB-specific assumptions from the timeseries backend loader and introduces a small built-in backend registry. This makes it possible to add new timeseries backends  without modifying the generic loader logic again.

It also paves the way for a dynamic backend option, where Ansible/Docker can choose the backend and 
``db/backends/__init__.py`` loads the correct backend accordingly.

<img width="841" height="451" alt="Base-Page-8 drawio" src="https://github.com/user-attachments/assets/602db865-5b92-4461-8985-a942306bb4a0" />

## Problems addressed

1) Backend selection was not extensible
The loader implicitly assumed a single backend (InfluxDB) and enforced a fixed set of InfluxDB-specific keys (USER, PASSWORD, HOST, PORT, NAME). This blocks adding additional backends because the loader enforces InfluxDB’s configuration contract globally.

2) Backend configuration defaults were scattered
Defaults for connection parameters and backend paths were embedded in the module loader logic. As we add support for other backends maintaining backend connection parameters would be hard.