### PR TITLE
[bug] Fixed influxDB image by using emulation approach for ARM64 native machines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   influxdb:
     image: influxdb:1.8-alpine
+    platform: linux/amd64
     volumes:
       - influxdb-data:/var/lib/influxdb
       - ./tests/influxdb.conf:/etc/influxdb/influxdb.conf
@@ -27,7 +28,7 @@ services:
       INFLUXDB_USER_PASSWORD: openwisp
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:7
     ports:
       - "6379:6379"
     entrypoint: redis-server --appendonly yes


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #735.


## Description of Changes

- Added `platform: linux/amd64` to InfluxDB service in docker-compose.yml to enable x86 emulation on ARM native machines (Mac Silicon). This allows InfluxDB 1.8-alpine to run on ARM architecture without requiring upgrade to v2 temporarily.
- Also updated the redis image for the same reason.