### PR TITLE
[tests] Fixed hardcoded config_app_label and app_label in device test_admin

### DIFF
--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -49,7 +49,6 @@ class TestAdmin(
 
     resources_fields = TestImportExportMixin.resource_fields
     resources_fields.append("monitoring_status")
-    app_label = "config"
     _device_params = {
         "group": "",
         "management_ip": "",
@@ -912,7 +911,7 @@ class TestWifiSessionAdmin(
     TestWifiClientSessionMixin,
     TestCase,
 ):
-    config_app_label = "config"
+    config_app_label = Device._meta.app_label
     wifi_session_app_label = WifiSession._meta.app_label
     wifi_session_model_name = WifiSession._meta.model_name
 

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -43,6 +43,10 @@ class TestAdmin(
 ):
     """Test the additions of openwisp-monitoring to DeviceAdmin"""
 
+    # Since TestImportExportMixin expects app_label for config app
+    app_label = Device._meta.app_label
+    config_app_label = Device._meta.app_label
+
     resources_fields = TestImportExportMixin.resource_fields
     resources_fields.append("monitoring_status")
     app_label = "config"
@@ -118,7 +122,7 @@ class TestAdmin(
             content_object=dd,
             params={},
         )
-        url = reverse("admin:config_device_change", args=[dd.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[dd.pk])
         response = self.client.get(url)
         self.assertContains(response, "<h2>Status</h2>")
         self.assertContains(response, "<h2>Charts</h2>")
@@ -189,7 +193,7 @@ class TestAdmin(
         )
         data["interfaces"][2]["wireless"]["mode"] = "station"
         self._post_data(d.id, d.key, data)
-        url = reverse("admin:config_device_change", args=[d.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[d.pk])
         r = self.client.get(url)
         with self.subTest("DHCP lease MAC is shown"):
             self.assertContains(r, "f2:f1:3e:56:d2:77")
@@ -229,7 +233,7 @@ class TestAdmin(
     def test_status_data_contains_wifi_version(self):
         data = self._data()
         d = self._create_device(organization=self._create_org())
-        url = reverse("admin:config_device_change", args=[d.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[d.pk])
         self._post_data(d.id, d.key, data)
         response = self.client.get(url)
         self.assertContains(
@@ -254,7 +258,7 @@ class TestAdmin(
     def test_status_data_contains_wifi_client_he_vht_ht_unknown(self):
         data = deepcopy(self._data())
         d = self._create_device(organization=self._create_org())
-        url = reverse("admin:config_device_change", args=[d.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[d.pk])
         wireless_interface = data["interfaces"][0]["wireless"]
         client = data["interfaces"][0]["wireless"]["clients"][0]
 
@@ -329,13 +333,13 @@ class TestAdmin(
 
     def test_no_device_data(self):
         d = self._create_device(organization=self._create_org())
-        url = reverse("admin:config_device_change", args=[d.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[d.pk])
         r = self.client.get(url)
         self.assertNotContains(r, "<h2>Status</h2>")
         self.assertNotContains(r, "AlertSettings")
 
     def test_device_add_view(self):
-        url = reverse("admin:config_device_add")
+        url = reverse(f"admin:{self.config_app_label}_device_add")
         r = self.client.get(url)
         self.assertNotContains(r, "AlertSettings")
         self.assertContains(
@@ -356,7 +360,7 @@ class TestAdmin(
         org = device.organization
         org.is_active = False
         org.save()
-        url = reverse("admin:config_device_change", args=[device.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[device.pk])
         response = self.client.get(url)
         self.assertContains(response, "<h2>Status</h2>")
         self.assertContains(response, "<h2>Charts</h2>")
@@ -375,19 +379,19 @@ class TestAdmin(
             d.key,
             {"type": "DeviceMonitoring", "interfaces": [{"name": "br-lan"}]},
         )
-        url = reverse("admin:config_device_change", args=[dd.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[dd.pk])
         self.client.get(url)
 
     def test_wifi_clients_admin(self):
         dd = self.create_test_data(no_resources=True)
-        url = reverse("admin:config_device_change", args=[dd.id])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[dd.id])
         r1 = self.client.get(url, follow=True)
         self.assertEqual(r1.status_code, 200)
         self.assertContains(r1, "00:ee:ad:34:f5:3b")
 
     def test_interface_properties_admin(self):
         dd = self.create_test_data(no_resources=True)
-        url = reverse("admin:config_device_change", args=[dd.id])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[dd.id])
         r1 = self.client.get(url, follow=True)
         self.assertEqual(r1.status_code, 200)
         self.assertContains(r1, "44:d1:fa:4b:38:44")
@@ -416,7 +420,7 @@ class TestAdmin(
                 ],
             },
         )
-        url = reverse("admin:config_device_change", args=[dd.id])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[dd.id])
         r1 = self.client.get(url, follow=True)
         self.assertEqual(r1.status_code, 200)
         self.assertContains(r1, "Bridge Members")
@@ -484,7 +488,7 @@ class TestAdmin(
                 ],
             },
         )
-        url = reverse("admin:config_device_change", args=[d.id])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[d.id])
         r1 = self.client.get(url, follow=True)
         self.assertEqual(r1.status_code, 200)
         self.assertContains(r1, "Signal Strength (LTE)")
@@ -495,7 +499,7 @@ class TestAdmin(
     def test_uuid_bug(self):
         dd = self.create_test_data(no_resources=True)
         uuid = str(dd.pk).replace("-", "")
-        url = reverse("admin:config_device_change", args=[uuid])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[uuid])
         r = self.client.get(url)
         self.assertContains(r, "<h2>Status</h2>")
 
@@ -531,7 +535,7 @@ class TestAdmin(
 
     def test_health_checks_list(self):
         dd = self.create_test_data()
-        url = reverse("admin:config_device_change", args=[dd.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[dd.pk])
         r = self.client.get(url)
         self.assertNotContains(r, "<label>Health checks:</label>")
         m = Metric.objects.filter(configuration="disk").first()
@@ -560,7 +564,7 @@ class TestAdmin(
 
     def test_wifisession_inline(self):
         device = self._create_device()
-        path = reverse("admin:config_device_change", args=[device.id])
+        path = reverse(f"admin:{self.config_app_label}_device_change", args=[device.id])
 
         with self.subTest("Test inline absent when no WiFiSession is present"):
             response = self.client.get(path)
@@ -605,7 +609,7 @@ class TestAdmin(
         )
         ping_check.full_clean()
         ping_check.save()
-        url = reverse("admin:config_device_change", args=[device.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[device.pk])
         metric = self._create_general_metric(
             name="", content_object=device, configuration="ping"
         )
@@ -748,7 +752,7 @@ class TestAdmin(
         metric = self._create_general_metric(
             name="", content_object=device, configuration="iperf3"
         )
-        url = reverse("admin:config_device_change", args=[device.pk])
+        url = reverse(f"admin:{self.config_app_label}_device_change", args=[device.pk])
         alertsettings = self._create_alert_settings(metric=metric)
         test_inline_params = {
             "name": device.name,
@@ -863,13 +867,14 @@ class TestAdmin(
 
     def test_device_admin_recover_button_visibility(self):
         self._create_device(organization=self._create_org())
-        url = reverse("admin:config_device_changelist")
+        url = reverse(f"admin:{self.config_app_label}_device_changelist")
         response = self.client.get(url)
         self.assertContains(
             response,
-            """
+            f"""
                 <li>
-                    <a href="/admin/config/device/recover/" class="recoverlink">Recover deleted Devices</a>
+                    <a href="/admin/{self.config_app_label}/device/recover/" """
+            """class="recoverlink">Recover deleted Devices</a>
                 </li>
             """,
             html=True,
@@ -907,6 +912,7 @@ class TestWifiSessionAdmin(
     TestWifiClientSessionMixin,
     TestCase,
 ):
+    config_app_label = "config"
     wifi_session_app_label = WifiSession._meta.app_label
     wifi_session_model_name = WifiSession._meta.model_name
 
@@ -1051,7 +1057,9 @@ class TestWifiSessionAdmin(
         device_data = self._save_device_data()
         device = Device.objects.first()
         device.deactivate()
-        path = reverse("admin:config_device_delete", args=[device_data.pk])
+        path = reverse(
+            f"admin:{self.config_app_label}_device_delete", args=[device_data.pk]
+        )
         response = self.client.post(path, {"post": "yes"}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(Device.objects.count(), 0)
@@ -1076,7 +1084,9 @@ class TestWifiSessionAdmin(
         device = Device.objects.all().first()
 
         with self.subTest("Test device wifi session inline"):
-            url = reverse("admin:config_device_change", args=[device.id])
+            url = reverse(
+                f"admin:{self.config_app_label}_device_change", args=[device.id]
+            )
             response = self.client.get(url)
             self.assertContains(
                 response,


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

This adds config_app_label attrs in device test_admin tests to make them derivable in other django apps.

I currently also need to set app_label, since the derived TestImportExportMixin requires it... we could probably devise a slightly nicer way of dealing with it, like f.i. renaming the variable config_app_label (in controller) in TestImportExportMixin to make it more explicit which app it is referring to...

