### PR TITLE
[fix] Fixed unused fields in device monitoring API docs

### DIFF
--- a/jobs.json
+++ b/jobs.json
@@ -1,0 +1,1837 @@
+{
+  "total_count": 13,
+  "jobs": [
+    {
+      "id": 65673850603,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu6w",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850603",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850603",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:13:02Z",
+      "name": "Python==3.13 | django~=5.1.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:55Z",
+          "completed_at": "2026-03-04T06:59:57Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:57Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:05Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.13",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:05Z",
+          "completed_at": "2026-03-04T07:00:10Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:10Z",
+          "completed_at": "2026-03-04T07:01:39Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:39Z",
+          "completed_at": "2026-03-04T07:01:43Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:43Z",
+          "completed_at": "2026-03-04T07:01:55Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:55Z",
+          "completed_at": "2026-03-04T07:12:58Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:12:58Z",
+          "completed_at": "2026-03-04T07:12:58Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:12:58Z",
+          "completed_at": "2026-03-04T07:12:58Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.13",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:12:58Z",
+          "completed_at": "2026-03-04T07:12:58Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:12:58Z",
+          "completed_at": "2026-03-04T07:12:58Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:12:58Z",
+          "completed_at": "2026-03-04T07:12:58Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:12:58Z",
+          "completed_at": "2026-03-04T07:12:59Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:12:59Z",
+          "completed_at": "2026-03-04T07:12:59Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850603",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077824,
+      "runner_name": "GitHub Actions 1000077824",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850607,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu7w",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850607",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850607",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:55Z",
+      "completed_at": "2026-03-04T07:13:15Z",
+      "name": "Python==3.10 | django~=5.1.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T06:59:57Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:57Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:05Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.10",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:05Z",
+          "completed_at": "2026-03-04T07:00:10Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:10Z",
+          "completed_at": "2026-03-04T07:01:41Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:41Z",
+          "completed_at": "2026-03-04T07:01:48Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:48Z",
+          "completed_at": "2026-03-04T07:01:59Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:59Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.10",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:13:11Z",
+          "completed_at": "2026-03-04T07:13:11Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850607",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077825,
+      "runner_name": "GitHub Actions 1000077825",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850609,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu8Q",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850609",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850609",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:12:01Z",
+      "name": "Python==3.12 | django~=4.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:54Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.12",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:07Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:07Z",
+          "completed_at": "2026-03-04T07:01:49Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:49Z",
+          "completed_at": "2026-03-04T07:01:52Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:52Z",
+          "completed_at": "2026-03-04T07:02:05Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:02:05Z",
+          "completed_at": "2026-03-04T07:11:58Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:11:58Z",
+          "completed_at": "2026-03-04T07:11:58Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:11:58Z",
+          "completed_at": "2026-03-04T07:11:58Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.12",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:11:58Z",
+          "completed_at": "2026-03-04T07:11:58Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:11:58Z",
+          "completed_at": "2026-03-04T07:11:58Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:11:58Z",
+          "completed_at": "2026-03-04T07:11:58Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:11:58Z",
+          "completed_at": "2026-03-04T07:11:59Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:11:59Z",
+          "completed_at": "2026-03-04T07:11:59Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850609",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077826,
+      "runner_name": "GitHub Actions 1000077826",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850610,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu8g",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850610",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850610",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:07:35Z",
+      "name": "Python==3.11 | django~=5.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:54Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T07:00:00Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:00Z",
+          "completed_at": "2026-03-04T07:00:01Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:01Z",
+          "completed_at": "2026-03-04T07:00:01Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:01Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.11",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:05Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:05Z",
+          "completed_at": "2026-03-04T07:01:35Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:35Z",
+          "completed_at": "2026-03-04T07:01:40Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:40Z",
+          "completed_at": "2026-03-04T07:01:50Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:50Z",
+          "completed_at": "2026-03-04T07:07:32Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:07:32Z",
+          "completed_at": "2026-03-04T07:07:33Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:07:33Z",
+          "completed_at": "2026-03-04T07:07:33Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.11",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:07:33Z",
+          "completed_at": "2026-03-04T07:07:33Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:07:33Z",
+          "completed_at": "2026-03-04T07:07:33Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:07:33Z",
+          "completed_at": "2026-03-04T07:07:33Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:07:33Z",
+          "completed_at": "2026-03-04T07:07:33Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:07:33Z",
+          "completed_at": "2026-03-04T07:07:34Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850610",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077827,
+      "runner_name": "GitHub Actions 1000077827",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850616,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu-A",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850616",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850616",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:13:36Z",
+      "name": "Python==3.10 | django~=5.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:55Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T07:00:01Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:01Z",
+          "completed_at": "2026-03-04T07:00:01Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:01Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.10",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:06Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:06Z",
+          "completed_at": "2026-03-04T07:01:41Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:41Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:57Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:57Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.10",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:13:34Z",
+          "completed_at": "2026-03-04T07:13:34Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850616",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077832,
+      "runner_name": "GitHub Actions 1000077832",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850619,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu-w",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850619",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850619",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:01:49Z",
+      "name": "Python==3.13 | django~=5.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:54Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T07:00:00Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:00Z",
+          "completed_at": "2026-03-04T07:00:01Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.13",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:01Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:01:32Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:32Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 11,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.13",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:46Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:01:46Z",
+          "completed_at": "2026-03-04T07:01:47Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:01:47Z",
+          "completed_at": "2026-03-04T07:01:47Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:01:47Z",
+          "completed_at": "2026-03-04T07:01:47Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850619",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077831,
+      "runner_name": "GitHub Actions 1000077831",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850620,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu_A",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850620",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850620",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:12:31Z",
+      "name": "Python==3.12 | django~=5.1.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:55Z",
+          "completed_at": "2026-03-04T06:59:58Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:58Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:05Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.12",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:05Z",
+          "completed_at": "2026-03-04T07:00:10Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:10Z",
+          "completed_at": "2026-03-04T07:01:43Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:43Z",
+          "completed_at": "2026-03-04T07:01:49Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:49Z",
+          "completed_at": "2026-03-04T07:02:00Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:02:00Z",
+          "completed_at": "2026-03-04T07:12:27Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:12:27Z",
+          "completed_at": "2026-03-04T07:12:27Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:12:27Z",
+          "completed_at": "2026-03-04T07:12:27Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.12",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:12:27Z",
+          "completed_at": "2026-03-04T07:12:27Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:12:27Z",
+          "completed_at": "2026-03-04T07:12:27Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:12:27Z",
+          "completed_at": "2026-03-04T07:12:27Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:12:27Z",
+          "completed_at": "2026-03-04T07:12:28Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:12:28Z",
+          "completed_at": "2026-03-04T07:12:28Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850620",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077828,
+      "runner_name": "GitHub Actions 1000077828",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850623,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndu_w",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850623",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850623",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:01:39Z",
+      "name": "Python==3.12 | django~=5.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:54Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T06:59:58Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T06:59:58Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T07:00:00Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.12",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:00Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:01:26Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:26Z",
+          "completed_at": "2026-03-04T07:01:29Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:29Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 11,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.12",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:01:38Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:01:38Z",
+          "completed_at": "2026-03-04T07:01:38Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850623",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077830,
+      "runner_name": "GitHub Actions 1000077830",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850634,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndvCg",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850634",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850634",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:11:26Z",
+      "name": "Python==3.11 | django~=4.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:55Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T07:00:01Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:01Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.11",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:05Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:05Z",
+          "completed_at": "2026-03-04T07:01:23Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:23Z",
+          "completed_at": "2026-03-04T07:01:26Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:26Z",
+          "completed_at": "2026-03-04T07:01:37Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:37Z",
+          "completed_at": "2026-03-04T07:11:23Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:11:23Z",
+          "completed_at": "2026-03-04T07:11:23Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:11:23Z",
+          "completed_at": "2026-03-04T07:11:23Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.11",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:11:23Z",
+          "completed_at": "2026-03-04T07:11:23Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:11:23Z",
+          "completed_at": "2026-03-04T07:11:23Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:11:23Z",
+          "completed_at": "2026-03-04T07:11:23Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:11:23Z",
+          "completed_at": "2026-03-04T07:11:24Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:11:24Z",
+          "completed_at": "2026-03-04T07:11:24Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850634",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077829,
+      "runner_name": "GitHub Actions 1000077829",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850635,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndvCw",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850635",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850635",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:12:06Z",
+      "name": "Python==3.10 | django~=4.2.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:55Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T06:59:59Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T06:59:59Z",
+          "completed_at": "2026-03-04T07:00:00Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.10",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:00Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:01:28Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:28Z",
+          "completed_at": "2026-03-04T07:01:32Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:32Z",
+          "completed_at": "2026-03-04T07:01:43Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:43Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.10",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:12:05Z",
+          "completed_at": "2026-03-04T07:12:05Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850635",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077833,
+      "runner_name": "GitHub Actions 1000077833",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65673850646,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSndvFg",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65673850646",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65673850646",
+      "status": "completed",
+      "conclusion": "failure",
+      "created_at": "2026-03-04T06:59:52Z",
+      "started_at": "2026-03-04T06:59:54Z",
+      "completed_at": "2026-03-04T07:12:28Z",
+      "name": "Python==3.11 | django~=5.1.0",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2026-03-04T06:59:55Z",
+          "completed_at": "2026-03-04T06:59:56Z"
+        },
+        {
+          "name": "Initialize containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2026-03-04T06:59:56Z",
+          "completed_at": "2026-03-04T07:00:02Z"
+        },
+        {
+          "name": "Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2026-03-04T07:00:02Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Cache APT packages",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:03Z"
+        },
+        {
+          "name": "Disable man page auto-update",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2026-03-04T07:00:03Z",
+          "completed_at": "2026-03-04T07:00:04Z"
+        },
+        {
+          "name": "Set up and Cache Python 3.11",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2026-03-04T07:00:04Z",
+          "completed_at": "2026-03-04T07:00:07Z"
+        },
+        {
+          "name": "Install Dependencies",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2026-03-04T07:00:07Z",
+          "completed_at": "2026-03-04T07:01:27Z"
+        },
+        {
+          "name": "Start InfluxDB",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2026-03-04T07:01:27Z",
+          "completed_at": "2026-03-04T07:01:33Z"
+        },
+        {
+          "name": "QA checks",
+          "status": "completed",
+          "conclusion": "failure",
+          "number": 9,
+          "started_at": "2026-03-04T07:01:33Z",
+          "completed_at": "2026-03-04T07:01:44Z"
+        },
+        {
+          "name": "Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 10,
+          "started_at": "2026-03-04T07:01:44Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Show gecko web driver log on failures",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 11,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Upload Coverage",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 12,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Post Set up and Cache Python 3.11",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 21,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Post Cache APT packages",
+          "status": "completed",
+          "conclusion": "skipped",
+          "number": 22,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Post Run actions/checkout@v6",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 23,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Stop containers",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 24,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 25,
+          "started_at": "2026-03-04T07:12:26Z",
+          "completed_at": "2026-03-04T07:12:26Z"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65673850646",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": 1000077834,
+      "runner_name": "GitHub Actions 1000077834",
+      "runner_group_id": 0,
+      "runner_group_name": "GitHub Actions"
+    },
+    {
+      "id": 65674924356,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSofRRA",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65674924356",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65674924356",
+      "status": "completed",
+      "conclusion": "skipped",
+      "created_at": "2026-03-04T07:13:36Z",
+      "started_at": "2026-03-04T07:13:36Z",
+      "completed_at": "2026-03-04T07:13:36Z",
+      "name": "Deploy Docker Image",
+      "steps": [],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65674924356",
+      "labels": ["ubuntu-24.04"],
+      "runner_id": null,
+      "runner_name": null,
+      "runner_group_id": null,
+      "runner_group_name": null
+    },
+    {
+      "id": 65674924414,
+      "run_id": 22658692125,
+      "workflow_name": "OpenWISP Monitoring CI Build",
+      "head_branch": "fix/716-device-monitoring-api-schema",
+      "run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/runs/22658692125",
+      "run_attempt": 1,
+      "node_id": "CR_kwDODtHmKM8AAAAPSofRfg",
+      "head_sha": "8b3d8953611e07242ededcccd0289c918522b6dc",
+      "url": "https://api.github.com/repos/openwisp/openwisp-monitoring/actions/jobs/65674924414",
+      "html_url": "https://github.com/openwisp/openwisp-monitoring/actions/runs/22658692125/job/65674924414",
+      "status": "completed",
+      "conclusion": "skipped",
+      "created_at": "2026-03-04T07:13:36Z",
+      "started_at": "2026-03-04T07:13:36Z",
+      "completed_at": "2026-03-04T07:13:36Z",
+      "name": "coveralls",
+      "steps": [],
+      "check_run_url": "https://api.github.com/repos/openwisp/openwisp-monitoring/check-runs/65674924414",
+      "labels": ["ubuntu-latest"],
+      "runner_id": null,
+      "runner_name": null,
+      "runner_group_id": null,
+      "runner_group_name": null
+    }
+  ]
+}

--- a/logs.zip
+++ b/logs.zip
@@ -1,0 +1,5 @@
+{
+  "message": "Must have admin rights to Repository.",
+  "documentation_url": "https://docs.github.com/rest/actions/workflow-runs#download-workflow-run-logs",
+  "status": "403"
+}

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -13,7 +13,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from pytz import UTC
-from rest_framework import pagination, serializers, status
+from rest_framework import pagination, status
 from rest_framework.generics import (
     GenericAPIView,
     ListAPIView,

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -36,7 +36,6 @@ from openwisp_users.api.mixins import FilterByOrganizationManaged
 
 from ...settings import CACHE_TIMEOUT
 from ...views import MonitoringApiViewMixin
-from ..schema import schema
 from ..signals import device_metrics_received
 from ..tasks import write_device_metrics
 from .filters import (
@@ -124,9 +123,8 @@ class DeviceMetricView(
         )
         .all()
     )
-    serializer_class = serializers.Serializer
+    serializer_class = MonitoringDeviceDetailSerializer
     permission_classes = [DevicePermission]
-    schema = schema
 
     @classmethod
     def invalidate_get_device_cache(cls, instance, **kwargs):

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -19,7 +19,8 @@ from openwisp_utils.tests import capture_any_output, catch_signal
 
 from ... import settings as monitoring_settings
 from ...monitoring.signals import post_metric_write, pre_metric_write
-from ..api.serializers import WifiSessionSerializer
+from ..api.serializers import MonitoringDeviceDetailSerializer, WifiSessionSerializer
+from ..api.views import DeviceMetricView
 from ..signals import device_metrics_received
 from . import DeviceMonitoringTestCase, TestWifiClientSessionMixin
 
@@ -1432,6 +1433,31 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         points = self._read_metric(m, limit=1, extra_fields=["tx_bytes"])
         self.assertEqual(points[0].get("rx_bytes"), 324)
         self.assertEqual(points[0].get("tx_bytes"), 0)
+
+    def test_device_metric_view_schema_not_empty(self):
+        """
+        Ensures DeviceMetricView uses a proper serializer (not blank)
+        and does not shadow DRF's schema attribute with a plain dict.
+        """
+
+        # serializer_class must be the concrete serializer, not blank
+        self.assertIs(
+            DeviceMetricView.serializer_class,
+            MonitoringDeviceDetailSerializer,
+        )
+        # Serializer must expose real fields
+        fields = MonitoringDeviceDetailSerializer().get_fields()
+        self.assertTrue(len(fields) > 0, "Serializer should declare fields")
+        for expected in ("id", "name", "monitoring"):
+            self.assertIn(expected, fields)
+        # The view must NOT shadow DRF's schema with a plain dict
+        schema_attr = getattr(DeviceMetricView, "schema", None)
+        if schema_attr is not None:
+            self.assertFalse(
+                isinstance(schema_attr, dict),
+                "DeviceMetricView.schema must not be a plain dict; "
+                "it would shadow DRF's APIView.schema and break API docs.",
+            )
 
 
 class TestGeoApi(TestGeoMixin, AuthenticationMixin, DeviceMonitoringTestCase):

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -760,15 +760,13 @@ class TestDashboardMap(
         location.full_clean()
         location.save()
         series_value = WebDriverWait(self.web_driver, 5).until(
-            lambda d: d.execute_script(
-                """
+            lambda d: d.execute_script("""
                 const options = window._owGeoMap.echarts.getOption();
                 const series = options.series.find(
                     (s) => s.type === "scatter" || s.type === "effectScatter",
                 );
                 return series.data.find(d => d.name === "Test-Location").value;
-            """
-            )
+            """)
         )
         self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
@@ -779,15 +777,13 @@ class TestDashboardMap(
             location.full_clean()
             location.save()
             series_value = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
                     );
                     return series.data.find(d => d.name === "Test-Location").value;
-                """
-                )
+                """)
             )
             self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
@@ -837,8 +833,7 @@ class TestDashboardMap(
             org2_location.save()
             sleep(0.3)  # Wait for JS animation
             series_locations = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -846,8 +841,7 @@ class TestDashboardMap(
                     const org1_location = series.data.find(l => l.name === "Org1-Location")
                     const org2_location = series.data.find(l => l.name === "Org2-Location")
                     return {org1_location, org2_location}
-                """
-                )
+                """)
             )
             self.assertEqual(
                 [org1_location.geometry.x, org1_location.geometry.y],
@@ -873,8 +867,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org1_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -882,8 +875,7 @@ class TestDashboardMap(
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             finally:
                 org1_driver.quit()
@@ -908,8 +900,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org2_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -917,8 +908,7 @@ class TestDashboardMap(
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             finally:
                 org2_driver.quit()


### PR DESCRIPTION
Removed the 'schema' attribute from DeviceMetricView which was accidentally shadowing DRF's APIView.schema attribute used by drf-yasg for Swagger documentation generation. This caused the browsable API to show misleading 'example' and 'Model' tabs with empty content.

Also changed serializer_class from the empty serializers.Serializer to MonitoringDeviceDetailSerializer so that drf-yasg can properly auto-generate the response schema documentation.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #716

## Description of Changes

- Removed `schema = schema` from [DeviceMetricView](cci:2://file:///Users/sargun/.gemini/antigravity/scratch/openwisp-monitoring/openwisp_monitoring/device/api/views.py:102:0-214:29) — this NetJSON validation dict was shadowing DRF's `APIView.schema` attribute, confusing drf-yasg
- Changed `serializer_class` from empty `serializers.Serializer` to [MonitoringDeviceDetailSerializer](cci:2://file:///Users/sargun/.gemini/antigravity/scratch/openwisp-monitoring/openwisp_monitoring/device/api/serializers.py:117:0-118:59)
- Removed the now-unused `from ..schema import schema` import

Note: The data validation schema on the **model** (`AbstractDeviceData.schema`) is unaffected — only the view attribute was removed.
