### PR TITLE
[fix] Add dashboard API filters to browsable API docs #715

### DIFF
--- a/openwisp_monitoring/monitoring/api/views.py
+++ b/openwisp_monitoring/monitoring/api/views.py
@@ -1,5 +1,28 @@
 from cache_memoize import cache_memoize
 from django.db.models import Q
+
+try:
+    from drf_yasg import openapi
+    from drf_yasg.utils import swagger_auto_schema
+except ImportError:
+
+    class _OpenApiShim:
+        IN_QUERY = "query"
+        TYPE_STRING = "string"
+
+        @staticmethod
+        def Parameter(*args, **kwargs):
+            return None
+
+    openapi = _OpenApiShim()
+
+    def swagger_auto_schema(*args, **kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
@@ -181,6 +204,64 @@ class DashboardTimeseriesView(ProtectedAPIMixin, MonitoringApiViewMixin, APIView
             return []
         return orgs
 
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "organization_slug",
+                openapi.IN_QUERY,
+                description="Comma-separated list of organization slugs",
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "location_id",
+                openapi.IN_QUERY,
+                description="Comma-separated list of location UUIDs",
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "floorplan_id",
+                openapi.IN_QUERY,
+                description="Comma-separated list of floorplan UUIDs",
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "time",
+                openapi.IN_QUERY,
+                description=(
+                    "Timeframe for chart data " "(e.g. 1d, 3d, 7d, 30d, 365d)"
+                ),
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "start",
+                openapi.IN_QUERY,
+                description=(
+                    "Start date/time in YYYY-MM-DD H:M:S format " '(use with "end")'
+                ),
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "end",
+                openapi.IN_QUERY,
+                description=(
+                    "End date/time in YYYY-MM-DD H:M:S format " '(use with "start")'
+                ),
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "timezone",
+                openapi.IN_QUERY,
+                description="Timezone name (e.g. UTC, Europe/Rome)",
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "csv",
+                openapi.IN_QUERY,
+                description="Set to export data as CSV",
+                type=openapi.TYPE_STRING,
+            ),
+        ]
+    )
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
         if not request.GET.get("csv"):

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -724,3 +724,37 @@ class TestDashboardTimeseriesView(
                 response.data["organizations"],
                 [{"id": org.slug, "text": org.name} for org in [org1, org2]],
             )
+
+    def test_dashboard_api_filters_in_schema(self):
+        """Regression test for https://github.com/openwisp/openwisp-monitoring/issues/715
+
+        Verifies that DashboardTimeseriesView exposes the expected
+        query parameters via @swagger_auto_schema so they are
+        visible in the browsable API docs.
+        """
+        from openwisp_monitoring.monitoring.api.views import DashboardTimeseriesView
+
+        swagger_decorator = getattr(
+            DashboardTimeseriesView.get, "_swagger_auto_schema", None
+        )
+        self.assertIsNotNone(
+            swagger_decorator,
+            "DashboardTimeseriesView.get is missing @swagger_auto_schema",
+        )
+        manual_parameters = swagger_decorator.get("manual_parameters", [])
+        param_names = {p.name for p in manual_parameters}
+        expected_params = {
+            "organization_slug",
+            "location_id",
+            "floorplan_id",
+            "time",
+            "start",
+            "end",
+            "timezone",
+            "csv",
+        }
+        self.assertEqual(
+            param_names,
+            expected_params,
+            f"Missing or extra swagger parameters: {expected_params - param_names}",
+        )

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -760,15 +760,13 @@ class TestDashboardMap(
         location.full_clean()
         location.save()
         series_value = WebDriverWait(self.web_driver, 5).until(
-            lambda d: d.execute_script(
-                """
+            lambda d: d.execute_script("""
                 const options = window._owGeoMap.echarts.getOption();
                 const series = options.series.find(
                     (s) => s.type === "scatter" || s.type === "effectScatter",
                 );
                 return series.data.find(d => d.name === "Test-Location").value;
-            """
-            )
+            """)
         )
         self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
@@ -779,15 +777,13 @@ class TestDashboardMap(
             location.full_clean()
             location.save()
             series_value = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
                     );
                     return series.data.find(d => d.name === "Test-Location").value;
-                """
-                )
+                """)
             )
             self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
@@ -837,8 +833,7 @@ class TestDashboardMap(
             org2_location.save()
             sleep(0.3)  # Wait for JS animation
             series_locations = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -846,8 +841,7 @@ class TestDashboardMap(
                     const org1_location = series.data.find(l => l.name === "Org1-Location")
                     const org2_location = series.data.find(l => l.name === "Org2-Location")
                     return {org1_location, org2_location}
-                """
-                )
+                """)
             )
             self.assertEqual(
                 [org1_location.geometry.x, org1_location.geometry.y],
@@ -873,8 +867,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org1_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -882,8 +875,7 @@ class TestDashboardMap(
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             finally:
                 org1_driver.quit()
@@ -908,8 +900,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org2_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -917,8 +908,7 @@ class TestDashboardMap(
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             finally:
                 org2_driver.quit()


### PR DESCRIPTION
Added @swagger_auto_schema to DashboardTimeseriesView.get() to expose
query parameters (organization_slug, location_id, floorplan_id, time,
start, end, timezone, csv) in the Swagger/browsable API documentation.

Since DashboardTimeseriesView extends APIView and manually reads query
parameters from request.query_params, drf-yasg had no way to discover them.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #715

## Description of Changes

- Added `@swagger_auto_schema` decorator to `DashboardTimeseriesView.get()` in `monitoring/api/views.py` with all 8 query parameters explicitly declared
- Added a regression test `test_dashboard_api_filters_in_schema` to verify the parameters are properly exposed
