### PR TITLE
[fix] Make wireless SSID optional in monitoring schema #729

### DIFF
--- a/openwisp_monitoring/device/schema.py
+++ b/openwisp_monitoring/device/schema.py
@@ -197,7 +197,6 @@ schema = {
                             "frequency",
                             "mode",
                             "noise",
-                            "ssid",
                             "tx_power",
                         ],
                         "properties": {

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -449,6 +449,18 @@ class TestDeviceData(MonitoringTestMixin, DeviceMonitoringTestCase):
         dd.data = data
         dd.validate_data()
 
+    def test_wireless_ssid_not_required(self):
+        """Regression test for https://github.com/openwisp/openwisp-monitoring/issues/729
+
+        Verifies that wireless interface data without an SSID
+        (e.g. when an AP is disabled) passes schema validation.
+        """
+        dd = self._create_device_data()
+        data = deepcopy(self._sample_data)
+        del data["interfaces"][0]["wireless"]["ssid"]
+        dd.data = data
+        dd.validate_data()
+
     @patch("openwisp_monitoring.device.settings.MAC_VENDOR_DETECTION", True)
     def test_mac_vendor_info(self):
         dd = self.test_save_data()

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -760,15 +760,13 @@ class TestDashboardMap(
         location.full_clean()
         location.save()
         series_value = WebDriverWait(self.web_driver, 5).until(
-            lambda d: d.execute_script(
-                """
+            lambda d: d.execute_script("""
                 const options = window._owGeoMap.echarts.getOption();
                 const series = options.series.find(
                     (s) => s.type === "scatter" || s.type === "effectScatter",
                 );
                 return series.data.find(d => d.name === "Test-Location").value;
-            """
-            )
+            """)
         )
         self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
@@ -779,15 +777,13 @@ class TestDashboardMap(
             location.full_clean()
             location.save()
             series_value = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
                     );
                     return series.data.find(d => d.name === "Test-Location").value;
-                """
-                )
+                """)
             )
             self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
@@ -837,8 +833,7 @@ class TestDashboardMap(
             org2_location.save()
             sleep(0.3)  # Wait for JS animation
             series_locations = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -846,8 +841,7 @@ class TestDashboardMap(
                     const org1_location = series.data.find(l => l.name === "Org1-Location")
                     const org2_location = series.data.find(l => l.name === "Org2-Location")
                     return {org1_location, org2_location}
-                """
-                )
+                """)
             )
             self.assertEqual(
                 [org1_location.geometry.x, org1_location.geometry.y],
@@ -873,8 +867,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org1_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -882,8 +875,7 @@ class TestDashboardMap(
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             finally:
                 org1_driver.quit()
@@ -908,8 +900,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org2_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -917,8 +908,7 @@ class TestDashboardMap(
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             finally:
                 org2_driver.quit()


### PR DESCRIPTION
Removed `ssid` from the required fields in the wireless interface schema. When a wireless access point is disabled, the monitoring agent does not report an SSID, which caused schema validation to fail with: `'ssid' is a required property`.

The `ssid` property definition is retained, it is simply no longer mandatory. Added a regression test to verify wireless data without an SSID passes validation.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #729

## Description of Changes

- Removed `ssid` from the `required` array in the wireless interface schema (`device/schema.py`)
- Added regression test `test_wireless_ssid_not_required` in `test_models.py`
