### PR TITLE
[feature] Allow opening indoor floor map view without node click

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
           pip install -U pip wheel setuptools
           pip install -r requirements-test.txt
           pip install -U -I -e .
-          pip uninstall -y Django
           pip install -U ${{ matrix.django-version }}
           sudo npm install -g prettier
 

--- a/openwisp_monitoring/device/static/monitoring/js/floorplan.js
+++ b/openwisp_monitoring/device/static/monitoring/js/floorplan.js
@@ -517,6 +517,7 @@
         initialZoom = map.getZoom();
         map.invalidateSize();
         $(".floorplan-loading-spinner").hide();
+
         map.on("fullscreenchange", () => {
           const floorNavigation = $("#floorplan-navigation");
           const zoomSnap = map.options.zoomSnap || 1;

--- a/openwisp_monitoring/device/static/monitoring/js/floorplan.js
+++ b/openwisp_monitoring/device/static/monitoring/js/floorplan.js
@@ -12,6 +12,7 @@
   let maps = {};
   let locationId = null;
   let popstateHandler = null;
+  let hashchangeHandler = null;
   const escapeHtml = function (text) {
     if (!text) return "";
     const div = document.createElement("div");
@@ -41,8 +42,8 @@
     }
     const params = new URLSearchParams(indoorFragment);
     const fragmentId = params.get("id");
-    // fragments format is expected to be "<locationId>:<floor>"
-    const [fragmentLocationId, fragmentFloor] = fragmentId?.split(":") || [];
+    // fragments format is expected to be "<locationId>_<floor>"
+    const [fragmentLocationId, fragmentFloor] = fragmentId?.split("_") || [];
     if (!fragmentLocationId || fragmentFloor == null) {
       return null;
     }
@@ -55,19 +56,14 @@
       "000",
       fragmentLocationId,
     );
-    openFloorPlan(`${floorplanUrl}`, fragmentLocationId, fragmentFloor);
+    openFloorPlan(floorplanUrl, fragmentLocationId, fragmentFloor);
   }
 
-  async function openFloorPlan(url, id = null, floor = currentFloor) {
-    if ($("#floorplan-overlay")) {
-      closeButtonHandler();
-    }
-    locationId = id;
-    // Handle browser back/forward navigation: close the indoor map overlay
-    // If the indoor map fragment is removed from the URL, close the overlay
-    // should be done before async tasks that are performed later
+  // Handle browser back/forward navigation
+  function setupPopstateHandler() {
     if (popstateHandler) {
       window.removeEventListener("popstate", popstateHandler);
+      popstateHandler = null;
     }
     popstateHandler = () => {
       const indoorMapId = getIndoorMapIdFromUrl();
@@ -77,6 +73,44 @@
       }
     };
     window.addEventListener("popstate", popstateHandler);
+  }
+
+  // Handle manual URL fragment changes (e.g., pasting URL in address bar)
+  function setupHashChangeHandler() {
+    if (hashchangeHandler) {
+      window.removeEventListener("hashchange", hashchangeHandler);
+      hashchangeHandler = null;
+    }
+    hashchangeHandler = () => {
+      const indoorMapId = getIndoorMapIdFromUrl();
+      const isOverlayOpen = $("#floorplan-overlay").length > 0;
+      if (indoorMapId) {
+        const { fragmentLocationId, fragmentFloor } = indoorMapId;
+        const floorplanUrl = window._owGeoMapConfig.indoorCoordinatesUrl.replace(
+          "000",
+          fragmentLocationId,
+        );
+        openFloorPlan(floorplanUrl, fragmentLocationId, fragmentFloor);
+      } else if (isOverlayOpen) {
+        closeButtonHandler();
+      }
+    };
+    window.addEventListener("hashchange", hashchangeHandler);
+  }
+
+  async function openFloorPlan(url, id = null, floor = currentFloor) {
+    if ($("#floorplan-overlay").length) {
+      closeButtonHandler();
+    }
+    // coerce url to string
+    url = String(url);
+    locationId = id;
+    // Handle browser back/forward navigation: close the indoor map overlay
+    // If the indoor map fragment is removed from the URL, close the overlay
+    // should be done before async tasks that are performed later
+    setupPopstateHandler();
+    // Handle manual url changes like pasting new url after the initial load
+    setupHashChangeHandler();
 
     await fetchData(url, floor);
     const idx = floors.indexOf(currentFloor);
@@ -294,6 +328,28 @@
     }
     $floorDiv.show();
     maps[currentFloor]?.leaflet?.invalidateSize();
+    // Since the div containing the indoor map is saved after the first render
+    // and later floors are shown or hidden instead of re-rendered, onReady is not
+    // triggered again. Therefore we need to push the URL fragment manually
+    // when switching floors.
+    pushIndoorMapIdFragment(maps[currentFloor], locationId, floor);
+  }
+
+  function pushIndoorMapIdFragment(indoorMap, locationId, floor) {
+    if (!indoorMap) {
+      return;
+    }
+    const fragments = indoorMap?.utils?.parseUrlFragments();
+    const indoorMapId = indoorMap?.config?.bookmarkableActions?.id;
+    if (!fragments || !indoorMapId) {
+      return;
+    }
+    const indoorParams = fragments[indoorMapId] || new URLSearchParams();
+    if (!indoorParams.get("id")) {
+      indoorParams.set("id", `${locationId}_${floor}`);
+    }
+    fragments[indoorMapId] = indoorParams;
+    indoorMap?.utils?.updateUrlFragments(fragments);
   }
 
   let currentPopup = null;
@@ -333,6 +389,15 @@
       .setLatLng(node?.properties.location)
       .setContent(popupContent)
       .openOn(map);
+    currentPopup.on("remove", () => {
+      const fragments = netjsongraphInstance.utils.parseUrlFragments();
+      const { id } = netjsongraphInstance.config.bookmarkableActions;
+      if (fragments[id]) {
+        fragments[id].delete("nodeId");
+        netjsongraphInstance.utils.updateUrlFragments(fragments);
+      }
+      currentPopup = null;
+    });
   }
 
   function renderIndoorMap(allResults, imageUrl, divId, floor) {
@@ -363,7 +428,7 @@
       },
       bookmarkableActions: {
         enabled: true,
-        id: `${locationId}:${floor}`,
+        id: `${locationId}_${floor}`,
         zoomOnRestore: false,
       },
       nodeCategories: Object.keys(status_colors).map((status) => ({
@@ -452,7 +517,6 @@
         initialZoom = map.getZoom();
         map.invalidateSize();
         $(".floorplan-loading-spinner").hide();
-
         map.on("fullscreenchange", () => {
           const floorNavigation = $("#floorplan-navigation");
           const zoomSnap = map.options.zoomSnap || 1;
@@ -469,6 +533,10 @@
           }
           map.invalidateSize();
         });
+        // Push the indoor map fragment id=<locationId>:<floor> to the URL once the map
+        // instance is ready, so the indoor map can be opened directly from the URL
+        // without requiring a node click to add the fragment.
+        pushIndoorMapIdFragment(this, locationId, floor);
       },
       onClickElement: function (type, data) {
         loadPopUpContent(data, this);

--- a/openwisp_monitoring/device/static/monitoring/js/location-inline.js
+++ b/openwisp_monitoring/device/static/monitoring/js/location-inline.js
@@ -36,7 +36,7 @@
       return;
     }
 
-    const indoorMapId = `id=${locationId}:${floor}&nodeId=${deviceLocationId}`;
+    const indoorMapId = `id=${locationId}_${floor}&nodeId=${deviceLocationId}`;
     const openIndoorDeviceBtn = `
       <div class="form-row field-indoor-view-button view-on-map-div">
         <div>

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -480,6 +480,13 @@ class TestDashboardMap(
 
         with self.subTest("Test setting url fragments on click event of node"):
             self._open_popup("_owGeoMap", location.id)
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"nodeId={location.id}"
+                    in d.execute_script("return window.location.hash;")
+                )
+            except TimeoutException:
+                self.fail("URL fragment was not updated after opening geo map popup")
             current_hash = self.web_driver.execute_script(
                 "return window.location.hash;"
             )
@@ -588,6 +595,12 @@ class TestDashboardMap(
             self.assertGreater(len(canvases), 0)
 
         with self.subTest("Test redirecting to device page from indoor map"):
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: d.execute_script("return window._owIndoorMap != null")
+                )
+            except TimeoutException:
+                self.fail("Indoor map was not initialized")
             self._open_popup("_owIndoorMap", device2.id)
             open_device_btn = self.find_element(
                 By.CSS_SELECTOR,
@@ -687,11 +700,32 @@ class TestDashboardMap(
             ".map-detail .floorplan-btn",
             timeout=5,
         ).click()
+        canvases = self.find_elements(
+            By.CSS_SELECTOR, "#floor-content-1 canvas", timeout=5
+        )
+        try:
+            WebDriverWait(self.web_driver, 5).until(
+                lambda d: d.execute_script("return window._owIndoorMap != null")
+            )
+        except TimeoutException:
+            self.fail("Indoor map was not initialized")
+        self.assertGreater(len(canvases), 0)
         mapId = "dashboard-geo-map"
         indoorMapId = f"{location.id}_{floorplan.floor}"
 
         with self.subTest("Test setting url fragments on click event of node"):
             self._open_popup("_owIndoorMap", device.id)
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"id={quote_plus(indoorMapId)}&nodeId={device_location.id}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment was not updated after opening indoor map node popup"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -723,13 +757,20 @@ class TestDashboardMap(
             tabs = self.web_driver.window_handles
             self.web_driver.switch_to.window(tabs[1])
             self.web_driver.get(incorrect_url)
-            self.wait_for_invisibility(By.CSS_SELECTOR, ".njg-tooltip-inner")
+            popup_not_displayed = self.wait_for_invisibility(
+                By.CSS_SELECTOR, ".njg-tooltip-inner"
+            )
+            self.assertTrue(popup_not_displayed)
             self.web_driver.close()
             self.web_driver.switch_to.window(tabs[0])
 
+        # Cleanup in case of failure to ensure the it does not end up with multiple tabs open
         if len(self.web_driver.window_handles) > 1:
-            self.web_driver.close()
-            self.web_driver.switch_to.window(self.web_driver.window_handles[0])
+            primary_tab = self.web_driver.window_handles[0]
+            for tab in self.web_driver.window_handles[1:]:
+                self.web_driver.switch_to.window(tab)
+                self.web_driver.close()
+            self.web_driver.switch_to.window(primary_tab)
 
     def test_dashboard_map_without_permissions(self):
         org = self._get_org()
@@ -763,17 +804,20 @@ class TestDashboardMap(
         location.geometry = Point(12.513124, 41.898903)
         location.full_clean()
         location.save()
-        series_value = WebDriverWait(self.web_driver, 5).until(
-            lambda d: d.execute_script(
-                """
-                const options = window._owGeoMap.echarts.getOption();
-                const series = options.series.find(
-                    (s) => s.type === "scatter" || s.type === "effectScatter",
-                );
-                return series.data.find(d => d.name === "Test-Location").value;
-            """
+        try:
+            series_value = WebDriverWait(self.web_driver, 5).until(
+                lambda d: d.execute_script("""
+                    const options = window._owGeoMap.echarts.getOption();
+                    const series = options.series.find(
+                        (s) => s.type === "scatter" || s.type === "effectScatter",
+                    );
+                    const item = series.data.find(d => d.name === "Test-Location");
+                    if (!item) return false;
+                    return item.value;
+                """)
             )
-        )
+        except TimeoutException:
+            self.fail("Failed to retrieve mobile location data")
         self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
         with self.subTest("Test mobile location with open device list popup"):
@@ -782,17 +826,20 @@ class TestDashboardMap(
             location.geometry = Point(12.511124, 41.898903)
             location.full_clean()
             location.save()
-            series_value = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
-                    const options = window._owGeoMap.echarts.getOption();
-                    const series = options.series.find(
-                        (s) => s.type === "scatter" || s.type === "effectScatter",
-                    );
-                    return series.data.find(d => d.name === "Test-Location").value;
-                """
+            try:
+                series_value = WebDriverWait(self.web_driver, 5).until(
+                    lambda d: d.execute_script("""
+                        const options = window._owGeoMap.echarts.getOption();
+                        const series = options.series.find(
+                            (s) => s.type === "scatter" || s.type === "effectScatter",
+                        );
+                        const item = series.data.find(d => d.name === "Test-Location");
+                        if (!item) return false;
+                        return item.value;
+                    """)
                 )
-            )
+            except TimeoutException:
+                self.fail("Failed to retrieve updated mobile location data")
             self.assertEqual([location.geometry.x, location.geometry.y], series_value)
 
     def test_mobile_location_updates_on_dashboard_map_with_org_isolation(self):
@@ -840,19 +887,21 @@ class TestDashboardMap(
             org2_location.full_clean()
             org2_location.save()
             sleep(0.3)  # Wait for JS animation
-            series_locations = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
-                    const options = window._owGeoMap.echarts.getOption();
-                    const series = options.series.find(
-                        (s) => s.type === "scatter" || s.type === "effectScatter",
-                    );
-                    const org1_location = series.data.find(l => l.name === "Org1-Location")
-                    const org2_location = series.data.find(l => l.name === "Org2-Location")
-                    return {org1_location, org2_location}
-                """
+            try:
+                series_locations = WebDriverWait(self.web_driver, 5).until(
+                    lambda d: d.execute_script("""
+                        const options = window._owGeoMap.echarts.getOption();
+                        const series = options.series.find(
+                            (s) => s.type === "scatter" || s.type === "effectScatter",
+                        );
+                        const org1_location = series.data.find(l => l.name === "Org1-Location")
+                        const org2_location = series.data.find(l => l.name === "Org2-Location")
+                        if (!org1_location || !org2_location) return false;
+                        return {org1_location, org2_location}
+                    """)
                 )
-            )
+            except TimeoutException:
+                self.fail("Failed to retrieve org location data from superuser")
             self.assertEqual(
                 [org1_location.geometry.x, org1_location.geometry.y],
                 series_locations["org1_location"]["value"],
@@ -877,18 +926,20 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org1_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
                         );
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
+                        if (!org1_location) return false;
+                        if (org2_location !== undefined) return false;
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
+            except TimeoutException:
+                self.fail("Failed to retrieve org1 location data from org1 user")
             finally:
                 org1_driver.quit()
             self.assertEqual(
@@ -912,18 +963,20 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org2_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
                         );
                         const org1_location = series.data.find(l => l.name === "Org1-Location")
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
+                        if (org1_location !== undefined) return false;
+                        if (!org2_location) return false;
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
+            except TimeoutException:
+                self.fail("Failed to retrieve org2 location data from org2 user")
             finally:
                 org2_driver.quit()
             self.assertEqual(
@@ -963,6 +1016,15 @@ class TestDashboardMap(
                 "#open-location-btn",
                 timeout=5,
             ).click()
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"nodeId={location.id}"
+                    in d.execute_script("return window.location.hash;")
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment was not updated after opening location from device page"
+                )
             current_hash = self.web_driver.execute_script(
                 "return window.location.hash;"
             )
@@ -997,12 +1059,23 @@ class TestDashboardMap(
             popup = self.wait_for_visibility(
                 By.CSS_SELECTOR, ".njg-tooltip-inner", timeout=5
             )
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"nodeId={device_location.id}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment was not updated after opening indoor device from device page"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
             expected_hash = (
                 f"#id={mapId}&nodeId={location.id};"
-                f"id={indoorMapId}&nodeId={device_location.id}"
+                f"id={quote_plus(indoorMapId)}&nodeId={device_location.id}"
             )
             self.assertIn(expected_hash, current_hash)
             self.assertTrue(floorplan_overlay.is_displayed())
@@ -1038,20 +1111,24 @@ class TestDashboardMap(
         indoorMapId1 = f"{location.id}_{floorplan1.floor}"
         indoorMapId2 = f"{location.id}_{floorplan2.floor}"
 
-        with self.subTest(
-            "Test setting url fragments on just opening floorplan overlay"
-        ):
+        with self.subTest("Test URL fragment set when floorplan overlay is opened"):
             self.wait_for(
                 "element_to_be_clickable",
                 By.CSS_SELECTOR,
                 ".map-detail .floorplan-btn",
                 timeout=5,
             ).click()
-            # Required wait as the id param is added inside onReady of the indoor map
-            WebDriverWait(self.web_driver, 5).until(
-                lambda d: f"id={quote_plus(indoorMapId1)}"
-                in d.execute_script("return decodeURIComponent(window.location.hash);")
-            )
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"id={quote_plus(indoorMapId1)}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment was not updated after opening floorplan overlay"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -1060,8 +1137,27 @@ class TestDashboardMap(
             )
             self.assertIn(expected_hash, current_hash)
 
-        with self.subTest("Test nodeId param added and removed on popup open or close"):
+        with self.subTest(
+            "Test nodeId param added on indoor map popup open and removed on close"
+        ):
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: d.execute_script("return window._owIndoorMap != null")
+                )
+            except TimeoutException:
+                self.fail("Indoor map was not initialized")
             self._open_popup("_owIndoorMap", device1.id)
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"nodeId={device_location1.id}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment was not updated after opening indoor map node popup"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -1076,6 +1172,17 @@ class TestDashboardMap(
                 "#floorplan-container .leaflet-popup-close-button",
                 timeout=5,
             ).click()
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"id={quote_plus(indoorMapId1)}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment nodeId was not removed after closing indoor map popup"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -1084,17 +1191,24 @@ class TestDashboardMap(
             )
             self.assertIn(expected_hash, current_hash)
 
-        with self.subTest("Test params change on switching floor on indoor map"):
+        with self.subTest(
+            "Test URL fragment updates when switching floors on indoor map and device popup opened/closed"
+        ):
             self.wait_for(
                 "element_to_be_clickable",
                 By.CSS_SELECTOR,
                 "#floorplan-navigation .right-arrow",
                 timeout=5,
             ).click()
-            WebDriverWait(self.web_driver, 5).until(
-                lambda d: f"id={quote_plus(indoorMapId2)}"
-                in d.execute_script("return decodeURIComponent(window.location.hash);")
-            )
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"id={quote_plus(indoorMapId2)}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail("URL fragment was not updated after switching to floor 2")
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -1102,7 +1216,24 @@ class TestDashboardMap(
                 f"#id={mapId}&nodeId={location.id};" f"id={quote_plus(indoorMapId2)}"
             )
             self.assertIn(expected_hash, current_hash)
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: d.execute_script("return window._owIndoorMap != null")
+                )
+            except TimeoutException:
+                self.fail("Indoor map was not initialized after opening floorplan")
             self._open_popup("_owIndoorMap", device2.id)
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"nodeId={device_location2.id}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment was not updated after opening device2 popup on floor 2"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -1117,6 +1248,17 @@ class TestDashboardMap(
                 "#floorplan-container .leaflet-popup-close-button",
                 timeout=5,
             ).click()
+            try:
+                WebDriverWait(self.web_driver, 5).until(
+                    lambda d: f"id={quote_plus(indoorMapId2)}"
+                    in d.execute_script(
+                        "return decodeURIComponent(window.location.hash);"
+                    )
+                )
+            except TimeoutException:
+                self.fail(
+                    "URL fragment nodeId was not removed after closing device2 popup"
+                )
             current_hash = self.web_driver.execute_script(
                 "return decodeURIComponent(window.location.hash);"
             )
@@ -1125,7 +1267,9 @@ class TestDashboardMap(
             )
             self.assertIn(expected_hash, current_hash)
 
-        with self.subTest("Test applying url fragments with only nodeId param"):
+        with self.subTest(
+            "Test URL fragment with only nodeId param: state applied on new tab, popup not shown"
+        ):
             current_url = self.web_driver.current_url
             self.web_driver.switch_to.new_window("tab")
             tabs = self.web_driver.window_handles
@@ -1145,6 +1289,10 @@ class TestDashboardMap(
             self.web_driver.close()
             self.web_driver.switch_to.window(tabs[0])
 
+        # Cleanup in case of failure to ensure the it does not end up with multiple tabs open
         if len(self.web_driver.window_handles) > 1:
-            self.web_driver.close()
-            self.web_driver.switch_to.window(self.web_driver.window_handles[0])
+            primary_tab = self.web_driver.window_handles[0]
+            for tab in self.web_driver.window_handles[1:]:
+                self.web_driver.switch_to.window(tab)
+                self.web_driver.close()
+            self.web_driver.switch_to.window(primary_tab)

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -688,7 +688,7 @@ class TestDashboardMap(
             timeout=5,
         ).click()
         mapId = "dashboard-geo-map"
-        indoorMapId = f"{location.id}:{floorplan.floor}"
+        indoorMapId = f"{location.id}_{floorplan.floor}"
 
         with self.subTest("Test setting url fragments on click event of node"):
             self._open_popup("_owIndoorMap", device.id)
@@ -726,6 +726,10 @@ class TestDashboardMap(
             self.wait_for_invisibility(By.CSS_SELECTOR, ".njg-tooltip-inner")
             self.web_driver.close()
             self.web_driver.switch_to.window(tabs[0])
+
+        if len(self.web_driver.window_handles) > 1:
+            self.web_driver.close()
+            self.web_driver.switch_to.window(self.web_driver.window_handles[0])
 
     def test_dashboard_map_without_permissions(self):
         org = self._get_org()
@@ -941,7 +945,7 @@ class TestDashboardMap(
         )
         self.login()
         mapId = "dashboard-geo-map"
-        indoorMapId = f"{location.id}:{floorplan.floor}"
+        indoorMapId = f"{location.id}_{floorplan.floor}"
 
         with self.subTest("Open geographic location on full map page"):
             url = reverse(
@@ -1004,3 +1008,143 @@ class TestDashboardMap(
             self.assertTrue(floorplan_overlay.is_displayed())
             self.assertTrue(popup.is_displayed())
             self.assertIn(device.name, popup.get_attribute("innerHTML"))
+
+    def test_indoor_map_fragment_added_on_map_ready_without_node_click(self):
+        org = self._get_org()
+        location = self._create_location(type="indoor", organization=org)
+        floorplan1 = self._create_floorplan(floor=1, location=location)
+        floorplan2 = self._create_floorplan(floor=2, location=location)
+        device1 = self._create_device(
+            name="Test-Device1", mac_address="00:00:00:00:00:01", organization=org
+        )
+        device2 = self._create_device(
+            name="Test-Device2", mac_address="00:00:00:00:00:02", organization=org
+        )
+        device_location1 = self._create_object_location(
+            content_object=device1,
+            location=location,
+            floorplan=floorplan1,
+            organization=org,
+        )
+        device_location2 = self._create_object_location(
+            content_object=device2,
+            location=location,
+            floorplan=floorplan2,
+            organization=org,
+        )
+        self.login()
+        self._open_popup("_owGeoMap", location.id)
+        mapId = "dashboard-geo-map"
+        indoorMapId1 = f"{location.id}_{floorplan1.floor}"
+        indoorMapId2 = f"{location.id}_{floorplan2.floor}"
+
+        with self.subTest(
+            "Test setting url fragments on just opening floorplan overlay"
+        ):
+            self.wait_for(
+                "element_to_be_clickable",
+                By.CSS_SELECTOR,
+                ".map-detail .floorplan-btn",
+                timeout=5,
+            ).click()
+            # Required wait as the id param is added inside onReady of the indoor map
+            WebDriverWait(self.web_driver, 5).until(
+                lambda d: f"id={quote_plus(indoorMapId1)}"
+                in d.execute_script("return decodeURIComponent(window.location.hash);")
+            )
+            current_hash = self.web_driver.execute_script(
+                "return decodeURIComponent(window.location.hash);"
+            )
+            expected_hash = (
+                f"#id={mapId}&nodeId={location.id};" f"id={quote_plus(indoorMapId1)}"
+            )
+            self.assertIn(expected_hash, current_hash)
+
+        with self.subTest("Test nodeId param added and removed on popup open or close"):
+            self._open_popup("_owIndoorMap", device1.id)
+            current_hash = self.web_driver.execute_script(
+                "return decodeURIComponent(window.location.hash);"
+            )
+            expected_hash = (
+                f"#id={mapId}&nodeId={location.id};"
+                f"id={quote_plus(indoorMapId1)}&nodeId={device_location1.id}"
+            )
+            self.assertIn(expected_hash, current_hash)
+            self.wait_for(
+                "element_to_be_clickable",
+                By.CSS_SELECTOR,
+                "#floorplan-container .leaflet-popup-close-button",
+                timeout=5,
+            ).click()
+            current_hash = self.web_driver.execute_script(
+                "return decodeURIComponent(window.location.hash);"
+            )
+            expected_hash = (
+                f"#id={mapId}&nodeId={location.id};" f"id={quote_plus(indoorMapId1)}"
+            )
+            self.assertIn(expected_hash, current_hash)
+
+        with self.subTest("Test params change on switching floor on indoor map"):
+            self.wait_for(
+                "element_to_be_clickable",
+                By.CSS_SELECTOR,
+                "#floorplan-navigation .right-arrow",
+                timeout=5,
+            ).click()
+            WebDriverWait(self.web_driver, 5).until(
+                lambda d: f"id={quote_plus(indoorMapId2)}"
+                in d.execute_script("return decodeURIComponent(window.location.hash);")
+            )
+            current_hash = self.web_driver.execute_script(
+                "return decodeURIComponent(window.location.hash);"
+            )
+            expected_hash = (
+                f"#id={mapId}&nodeId={location.id};" f"id={quote_plus(indoorMapId2)}"
+            )
+            self.assertIn(expected_hash, current_hash)
+            self._open_popup("_owIndoorMap", device2.id)
+            current_hash = self.web_driver.execute_script(
+                "return decodeURIComponent(window.location.hash);"
+            )
+            expected_hash = (
+                f"#id={mapId}&nodeId={location.id};"
+                f"id={quote_plus(indoorMapId2)}&nodeId={device_location2.id}"
+            )
+            self.assertIn(expected_hash, current_hash)
+            self.wait_for(
+                "element_to_be_clickable",
+                By.CSS_SELECTOR,
+                "#floorplan-container .leaflet-popup-close-button",
+                timeout=5,
+            ).click()
+            current_hash = self.web_driver.execute_script(
+                "return decodeURIComponent(window.location.hash);"
+            )
+            expected_hash = (
+                f"#id={mapId}&nodeId={location.id};" f"id={quote_plus(indoorMapId2)}"
+            )
+            self.assertIn(expected_hash, current_hash)
+
+        with self.subTest("Test applying url fragments with only nodeId param"):
+            current_url = self.web_driver.current_url
+            self.web_driver.switch_to.new_window("tab")
+            tabs = self.web_driver.window_handles
+            self.web_driver.switch_to.window(tabs[1])
+            self.web_driver.get(current_url)
+            floor_heading = self.find_element(By.CSS_SELECTOR, "#floorplan-title")
+            self.assertIn("2nd floor", floor_heading.text.lower())
+            canvases = self.find_elements(
+                By.CSS_SELECTOR, "#floor-content-2 canvas", timeout=5
+            )
+            self.assertGreater(len(canvases), 0)
+            popup_not_displayed = self.wait_for_invisibility(
+                By.CSS_SELECTOR,
+                ".njg-tooltip-inner",
+            )
+            self.assertTrue(popup_not_displayed)
+            self.web_driver.close()
+            self.web_driver.switch_to.window(tabs[0])
+
+        if len(self.web_driver.window_handles) > 1:
+            self.web_driver.close()
+            self.web_driver.switch_to.window(self.web_driver.window_handles[0])


### PR DESCRIPTION
Adds support for pushing indoor map fragments when the floorplan overlay is opened or when switching floors. This allows direct opening of indoor floor views via URL without requiring a node click.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #749.

## Description of Changes
- To open the floorplan overlay directly from the URL, both locationId and floor are required in the fragment (`id=<locationId>:<floor>`). Previously, this fragment was added only after clicking on a node.
- Added a new function `pushIndoorMapIdFragment()` which ensures the id parameter (<locationId>:<floor>) is added to the URL.
- Called this function in two places because the indoor map DOM element is reused (shown/hidden when switching floors):
    - inside onReady() for the initial load
    - at the end of the floor show logic when the hidden floor container is displayed
- Added logic to remove the nodeId parameter when the popup is closed.
- Added a Selenium test to check this functionality. 

## Additional Changes
- Fixed flaky Selenium tests discovered during development. Used a tmate session in CI to debug the issue and identify the root cause.
- Added clearer failure messages for timeout exceptions in tests to improve debugging when Selenium waits fail.
- Fixed CI failures occurring on Python 3.12 / 3.13 with Django 5.2, where tests were failing with django.core import errors.

## Screenshot
[Screencast from 2026-03-06 18-06-07.webm](https://github.com/user-attachments/assets/8add47e7-2d25-4c1f-a510-2e4ef21d95c0)
