### PR TITLE
[fix] Fix duplicate check creation in auto_create_check_receiver

### DIFF
--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -114,14 +114,15 @@ class AbstractCheck(TimeStampedEditableModel):
 
 
 def _auto_check_receiver(sender, instance, **kwargs):
+    from swapper import load_model
+
+    Check = load_model("check", "Check")
+
     model = sender.__name__.lower()
     app_label = sender._meta.app_label
     object_id = str(instance.pk)
 
     ct = ContentType.objects.get_for_model(instance)
-
-    # safe import to avoid circular dependency
-    from openwisp_monitoring.check.models import Check
 
     for class_string, name, auto_create_setting in app_settings.CHECK_CLASSES:
         if not getattr(app_settings, auto_create_setting):

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -74,26 +74,20 @@ class AbstractCheck(TimeStampedEditableModel):
         self.check_instance.validate()
 
     def full_clean(self, *args, **kwargs):
-        # The name of the check will be the same as the
-        # 'check_type' chosen by the user when the
-        # name field is empty (useful for CheckInline)
         if not self.name:
             self.name = self.get_check_type_display()
         return super().full_clean(*args, **kwargs)
 
     @cached_property
     def check_class(self):
-        """Returns the check class."""
         return import_string(self.check_type)
 
     @cached_property
     def check_instance(self):
-        """Returns the check class instance."""
         check_class = self.check_class
         return check_class(check=self, params=self.params)
 
     def perform_check(self, store=True):
-        """Initializes check instance and calls the check method."""
         if (
             hasattr(self.content_object, "is_deactivated")
             and self.content_object.is_deactivated()
@@ -106,14 +100,16 @@ class AbstractCheck(TimeStampedEditableModel):
 
     def perform_check_delayed(self, duration=0):
         from ..tasks import perform_check
-
         perform_check.apply_async(args=[self.id], countdown=duration)
 
     @classmethod
-    def auto_create_check_receiver(cls, created, **kwargs):
+    def auto_create_check_receiver(cls, sender, instance, created, **kwargs):
         if not created:
             return
-        transaction_on_commit(lambda: _auto_check_receiver(created=created, **kwargs))
+
+        transaction_on_commit(
+            lambda: _auto_check_receiver(sender=sender, instance=instance)
+        )
 
 
 def _auto_check_receiver(sender, instance, **kwargs):
@@ -121,9 +117,22 @@ def _auto_check_receiver(sender, instance, **kwargs):
     app_label = sender._meta.app_label
     object_id = str(instance.pk)
 
+    ct = ContentType.objects.get_for_model(instance)
+
     for class_string, name, auto_create_setting in app_settings.CHECK_CLASSES:
         if not getattr(app_settings, auto_create_setting):
             continue
+
+        
+        from openwisp_monitoring.check.models import Check
+
+        if Check.objects.filter(
+            content_type=ct,
+            object_id=object_id,
+            name=name
+        ).exists():
+            continue
+
         auto_create_check.delay(
             model=model,
             app_label=app_label,

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -14,6 +14,9 @@ from ...utils import transaction_on_commit
 from .. import settings as app_settings
 from ..tasks import auto_create_check
 
+# ✅ moved import here (outside loop, top-level safe)
+from openwisp_monitoring.check.models import Check
+
 
 class AbstractCheck(TimeStampedEditableModel):
     name = models.CharField(max_length=64, db_index=True)
@@ -122,10 +125,7 @@ def _auto_check_receiver(sender, instance, **kwargs):
     for class_string, name, auto_create_setting in app_settings.CHECK_CLASSES:
         if not getattr(app_settings, auto_create_setting):
             continue
-
         
-        from openwisp_monitoring.check.models import Check
-
         if Check.objects.filter(
             content_type=ct,
             object_id=object_id,

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -14,7 +14,6 @@ from ...utils import transaction_on_commit
 from .. import settings as app_settings
 from ..tasks import auto_create_check
 
-# ✅ moved import here (outside loop, top-level safe)
 from openwisp_monitoring.check.models import Check
 
 

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -124,15 +124,18 @@ def _auto_check_receiver(sender, instance, **kwargs):
 
     ct = ContentType.objects.get_for_model(instance)
 
+    existing_check_types = set(
+        Check.objects.filter(
+            content_type=ct,
+            object_id=object_id,
+        ).values_list("check_type", flat=True)
+    )
+
     for class_string, name, auto_create_setting in app_settings.CHECK_CLASSES:
         if not getattr(app_settings, auto_create_setting):
             continue
 
-        if Check.objects.filter(
-            content_type=ct,
-            object_id=object_id,
-            check_type=class_string,
-        ).exists():
+        if class_string in existing_check_types:
             continue
 
         auto_create_check.delay(

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -124,6 +124,8 @@ def _auto_check_receiver(sender, instance, **kwargs):
 
     ct = ContentType.objects.get_for_model(instance)
 
+    # Prefetch existing check_types for this object to ensure idempotency
+    # This avoids creating duplicate checks when the signal is triggered multiple times
     existing_check_types = set(
         Check.objects.filter(
             content_type=ct,

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -14,8 +14,6 @@ from ...utils import transaction_on_commit
 from .. import settings as app_settings
 from ..tasks import auto_create_check
 
-from openwisp_monitoring.check.models import Check
-
 
 class AbstractCheck(TimeStampedEditableModel):
     name = models.CharField(max_length=64, db_index=True)
@@ -102,6 +100,7 @@ class AbstractCheck(TimeStampedEditableModel):
 
     def perform_check_delayed(self, duration=0):
         from ..tasks import perform_check
+
         perform_check.apply_async(args=[self.id], countdown=duration)
 
     @classmethod
@@ -121,14 +120,16 @@ def _auto_check_receiver(sender, instance, **kwargs):
 
     ct = ContentType.objects.get_for_model(instance)
 
+    from openwisp_monitoring.check.models import Check
+
     for class_string, name, auto_create_setting in app_settings.CHECK_CLASSES:
         if not getattr(app_settings, auto_create_setting):
             continue
-        
+
         if Check.objects.filter(
             content_type=ct,
             object_id=object_id,
-            name=name
+            name=name,
         ).exists():
             continue
 

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -120,6 +120,7 @@ def _auto_check_receiver(sender, instance, **kwargs):
 
     ct = ContentType.objects.get_for_model(instance)
 
+    # safe import to avoid circular dependency
     from openwisp_monitoring.check.models import Check
 
     for class_string, name, auto_create_setting in app_settings.CHECK_CLASSES:
@@ -129,7 +130,7 @@ def _auto_check_receiver(sender, instance, **kwargs):
         if Check.objects.filter(
             content_type=ct,
             object_id=object_id,
-            name=name,
+            check_type=class_string,
         ).exists():
             continue
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html)
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #649

## Description of Changes

Fixed duplicate monitoring check creation by ensuring idempotent behavior.

Previously, checks were created multiple times because validation was missing for each check type.
This resulted in duplicate entries and failing tests.

This fix:
- Adds per-check-type existence validation before creating checks
- Preserves async task execution using Celery
- Keeps the signal handler lightweight and aligned with project architecture

As a result, duplicate-check creation is prevented, and related test failures are resolved.

## Screenshot

Test results after applying the fix:

- All core tests pass successfully
- Remaining 4 errors are related to Selenium/WebDriver environment and are not related to this fix

<img width="502" height="105" alt="image" src="https://github.com/user-attachments/assets/920901fd-c562-41dc-8dd2-46e5af4e3b4f" />
