### PR TITLE
[change] Add 5G signal data on device admin status tab

### DIFF
--- a/openwisp_monitoring/device/templates/admin/monitoring/device/change_form.html
+++ b/openwisp_monitoring/device/templates/admin/monitoring/device/change_form.html
@@ -324,6 +324,26 @@
                           </div>
                       </div>
                       {% endif %}
+                      {% if interface.mobile.signal.5g %}
+                      <div class="form-row">
+                          <label>{% trans 'Signal Power' %} (5G):</label>
+                          <div class="readonly">
+                              {{ interface.mobile.signal.5g.rsrp }} dBm
+                          </div>
+                      </div>
+                      <div class="form-row">
+                          <label>{% trans 'Signal Quality' %} (5G):</label>
+                          <div class="readonly">
+                              {{ interface.mobile.signal.5g.rsrq }} dB
+                          </div>
+                      </div>
+                      <div class="form-row">
+                          <label>{% trans 'Signal to noise ratio' %} (5G):</label>
+                          <div class="readonly">
+                              {{ interface.mobile.signal.5g.snr }} dB
+                          </div>
+                      </div>
+                      {% endif %}
                       {% if interface.mobile.signal.umts %}
                       <div class="form-row">
                           <label>{% trans 'Signal Strength' %} (UMTS):</label>

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -501,6 +501,43 @@ class TestAdmin(
         self.assertContains(r1, "Signal Quality (LTE)")
         self.assertContains(r1, "Signal to noise ratio (LTE)")
 
+    def test_interface_5g_mobile_admin(self):
+        d = self._create_device(organization=self._create_org())
+        self._post_data(
+            d.id,
+            d.key,
+            {
+                "type": "DeviceMonitoring",
+                "interfaces": [
+                    {
+                        "name": "mobile0",
+                        "mac": "00:00:00:00:00:00",
+                        "mtu": 1900,
+                        "multicast": True,
+                        "txqueuelen": 1000,
+                        "type": "modem-manager",
+                        "up": True,
+                        "mobile": {
+                            "connection_status": "connected",
+                            "imei": "300000001234567",
+                            "manufacturer": "Sierra Wireless, Incorporated",
+                            "model": "MC7430",
+                            "operator_code": "50502",
+                            "operator_name": "YES OPTUS",
+                            "power_status": "on",
+                            "signal": {"5g": {"rsrp": -75, "rsrq": -8, "snr": 13}},
+                        },
+                    }
+                ],
+            },
+        )
+        url = reverse("admin:config_device_change", args=[d.id])
+        r1 = self.client.get(url, follow=True)
+        self.assertEqual(r1.status_code, 200)
+        self.assertContains(r1, "Signal Power (5G)")
+        self.assertContains(r1, "Signal Quality (5G)")
+        self.assertContains(r1, "Signal to noise ratio (5G)")
+
     def test_uuid_bug(self):
         dd = self.create_test_data(no_resources=True)
         uuid = str(dd.pk).replace("-", "")

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -805,6 +805,54 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
                 {"lte": {"rsrp": -75.00, "rsrq": -8.00, "rssi": -51.00, "snr": 13.00}},
             )
 
+    def test_5g_mobile_properties(self):
+        org = self._create_org()
+        device = self._create_device(organization=org)
+        data = {
+            "type": "DeviceMonitoring",
+            "interfaces": [
+                {
+                    "name": "mobile0",
+                    "mac": "00:00:00:00:00:00",
+                    "mtu": 1900,
+                    "multicast": True,
+                    "txqueuelen": 1000,
+                    "type": "modem-manager",
+                    "up": True,
+                    "mobile": {
+                        "connection_status": "connected",
+                        "imei": "300000001234567",
+                        "manufacturer": "Sierra Wireless, Incorporated",
+                        "model": "MC7430",
+                        "operator_code": "50502",
+                        "operator_name": "YES OPTUS",
+                        "power_status": "on",
+                        "signal": {"5g": {"rsrp": -75, "rsrq": -8, "snr": 13}},
+                    },
+                }
+            ],
+        }
+        response = self._post_data(device.id, device.key, data)
+        self.assertEqual(response.status_code, 200)
+        mobile_data = DeviceData(pk=device.pk).data["interfaces"][0]["mobile"]
+        with self.subTest("check mobile interface static properties"):
+            self.assertEqual(mobile_data["connection_status"], "connected")
+            self.assertEqual(mobile_data["imei"], "300000001234567")
+            self.assertEqual(mobile_data["model"], "MC7430")
+            self.assertEqual(mobile_data["operator_code"], "50502")
+            self.assertEqual(mobile_data["operator_name"], "YES OPTUS")
+            self.assertEqual(mobile_data["power_status"], "on")
+        with self.subTest("ensure signal data is converted to float"):
+            # ensure numbers are stored as floats,
+            # lua cannot be forced to send floats so we need to force it
+            self.assertIsInstance(mobile_data["signal"]["5g"]["rsrp"], float)
+            self.assertIsInstance(mobile_data["signal"]["5g"]["rsrq"], float)
+            self.assertIsInstance(mobile_data["signal"]["5g"]["snr"], float)
+            self.assertDictEqual(
+                mobile_data["signal"],
+                {"5g": {"rsrp": -75.00, "rsrq": -8.00, "snr": 13.00}},
+            )
+
     def test_empty_mobile_signal_data(self):
         org = self._create_org()
         device = self._create_device(organization=org)


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes
This adds 5G mobile signal metrics on device admin status tab, duplicating what is done for LTE, minus Signal Strength (rssi - see #779)
