### PR TITLE
[fix] Preserved text -> jsonb migration for JSONField fields #798

### DIFF
--- a/openwisp_monitoring/check/migrations/0001_initial_squashed_0002_check_unique_together.py
+++ b/openwisp_monitoring/check/migrations/0001_initial_squashed_0002_check_unique_together.py
@@ -65,7 +65,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "params",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text="parameters needed to perform the check",

--- a/openwisp_monitoring/monitoring/migrations/0004_metric_main_and_extra_tags.py
+++ b/openwisp_monitoring/monitoring/migrations/0004_metric_main_and_extra_tags.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="metric",
             name="main_tags",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 db_index=True,
                 default=dict,
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="metric",
             name="extra_tags",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 default=dict,
                 verbose_name="extra tags",

--- a/tests/openwisp2/sample_check/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_check/migrations/0001_initial.py
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "params",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text="parameters needed to perform the check",

--- a/tests/openwisp2/sample_monitoring/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_monitoring/migrations/0001_initial.py
@@ -102,7 +102,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "main_tags",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         db_index=True,
                         default=dict,
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "extra_tags",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         verbose_name="extra tags",


### PR DESCRIPTION




## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N?A I have updated the documentation.

## Reference to Existing Issue

Closes #798

## Description of Changes

Historical migrations were updated to use models.TextField instead of models.JSONField for fields originally backed by the third-party jsonfield library.

The original jsonfield.fields.JSONField inherited from TextField and stored values as PostgreSQL text. Replacing historical migration definitions with models.JSONField caused Django to interpret the migration transition as JSONField -> JSONField, resulting in a no-op migration and preventing PostgreSQL columns from being converted to jsonb.

By preserving the historical field semantics as TextField, Django can correctly detect the transition from text -> jsonb and generate the required ALTER COLUMN ... TYPE jsonb migration SQL during upgrades.