### PR TITLE
[chores:fix] Drop text indexes before casting main_tags to JSONField

### DIFF
--- a/openwisp_monitoring/monitoring/migrations/0004_metric_main_and_extra_tags.py
+++ b/openwisp_monitoring/monitoring/migrations/0004_metric_main_and_extra_tags.py
@@ -27,6 +27,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 default=dict,
                 verbose_name="extra tags",
+                db_index=True,
             ),
         ),
         migrations.AlterUniqueTogether(

--- a/openwisp_monitoring/monitoring/migrations/0013_replace_jsonfield_with_django_builtin.py
+++ b/openwisp_monitoring/monitoring/migrations/0013_replace_jsonfield_with_django_builtin.py
@@ -11,6 +11,28 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # First change the fields to TextField so Django drops the old
+        # text_pattern_ops LIKE indexes created for the previous
+        # text-backed JSONField implementation.
+        migrations.AlterField(
+            model_name="metric",
+            name="main_tags",
+            field=models.TextField(
+                blank=True,
+                default=dict,
+                verbose_name="main tags",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="metric",
+            name="extra_tags",
+            field=models.TextField(
+                blank=True,
+                default=dict,
+                verbose_name="extra tags",
+            ),
+        ),
+        # Then convert to native PostgreSQL jsonb-backed JSONField.
         migrations.AlterField(
             model_name="metric",
             name="main_tags",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.


## Description of Changes

Migration 0013 now performs main_tags as a temporary TextField change before converting it to Django's built-in JSONField.

This is needed for PostgreSQL upgrades from older openwisp-monitoring versions where main_tags was historically backed by text through the third-party jsonfield implementation and could still have text-specific indexes, including text_pattern_ops variants.

Without this intermediate AlterField step, upgrading could fail while casting main_tags to jsonb with the following error:

operator class "text_pattern_ops" does not accept data type jsonb

The failure happened because PostgreSQL cannot keep a text_pattern_ops index on a jsonb column. By first altering the field as TextField without db_index, Django detects the real text -> jsonb transition, drops the existing text-based indexes before the cast, and then recreates the regular index for the new JSONField.