### PR TITLE
[chores] Refactored URL patterns to use Django's UUID converter

### DIFF
--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -300,11 +300,12 @@ class DeviceAdmin(BaseDeviceAdmin, NestedModelAdmin):
     def get_extra_context(self, pk=None):
         ctx = super().get_extra_context(pk)
         if pk:
-            device_data = DeviceData(pk=uuid.UUID(pk))
+            device_pk = uuid.UUID(pk)
+            device_data = DeviceData(pk=device_pk)
             api_url = reverse(
                 "monitoring:api_device_metric",
                 urlconf=MONITORING_API_URLCONF,
-                args=[pk],
+                args=[device_pk],
             )
             if MONITORING_API_BASEURL:
                 api_url = urljoin(MONITORING_API_BASEURL, api_url)

--- a/openwisp_monitoring/device/api/urls.py
+++ b/openwisp_monitoring/device/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from . import views
 
@@ -15,13 +15,13 @@ urlpatterns = [
         views.device_metric_list,
         name="api_device_metric_list",
     ),
-    re_path(
-        r"^api/v1/monitoring/device/(?P<pk>[^/]+)/$",
+    path(
+        "api/v1/monitoring/device/<uuid:pk>/",
         views.device_metric,
         name="api_device_metric",
     ),
-    re_path(
-        r"^api/v1/monitoring/device/(?P<pk>[^/]+)/nearby-devices/$",
+    path(
+        "api/v1/monitoring/device/<uuid:pk>/nearby-devices/",
         views.monitoring_nearby_device_list,
         name="api_monitoring_nearby_device_list",
     ),
@@ -30,8 +30,8 @@ urlpatterns = [
         views.monitoring_geojson_location_list,
         name="api_location_geojson",
     ),
-    re_path(
-        r"^api/v1/monitoring/location/(?P<pk>[^/]+)/device/$",
+    path(
+        "api/v1/monitoring/location/<uuid:pk>/device/",
         views.monitoring_location_device_list,
         name="api_location_device_list",
     ),
@@ -40,13 +40,13 @@ urlpatterns = [
         views.wifi_session_list,
         name="api_wifi_session_list",
     ),
-    re_path(
-        r"^api/v1/monitoring/wifi-session/(?P<pk>[^/]+)/$",
+    path(
+        "api/v1/monitoring/wifi-session/<uuid:pk>/",
         views.wifi_session_detail,
         name="api_wifi_session_detail",
     ),
-    re_path(
-        r"^api/v1/monitoring/location/(?P<pk>[^/]+)/indoor-coordinates/$",
+    path(
+        "api/v1/monitoring/location/<uuid:pk>/indoor-coordinates/",
         views.monitoring_indoor_coordinates_list,
         name="api_indoor_coordinates_list",
     ),

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from datetime import datetime
 
 from cache_memoize import cache_memoize
@@ -73,10 +72,6 @@ WifiSession = load_model("device_monitoring", "WifiSession")
 
 def get_device_args_rewrite(view, pk):
     """Use only the PK parameter for calculating the cache key"""
-    try:
-        pk = uuid.UUID(pk)
-    except ValueError:
-        return pk
     return pk.hex
 
 
@@ -130,7 +125,7 @@ class DeviceMetricView(
     def invalidate_get_device_cache(cls, instance, **kwargs):
         """Called from signal receiver which performs cache invalidation"""
         view = cls()
-        view.get_object.invalidate(view, str(instance.pk))
+        view.get_object.invalidate(view, instance.pk)
         logger.debug(f"invalidated view cache for device ID {instance.pk}")
 
     @classmethod
@@ -144,11 +139,6 @@ class DeviceMetricView(
         cls._get_charts.invalidate(None, None, pk)
 
     def get(self, request, pk):
-        # ensure valid UUID
-        try:
-            pk = str(uuid.UUID(pk))
-        except ValueError:
-            return Response({"detail": "not found"}, status=404)
         self.instance = self.get_object(pk)
         response = super().get(request, pk)
         if not request.query_params.get("csv"):

--- a/openwisp_monitoring/device/static/monitoring/js/device-map.js
+++ b/openwisp_monitoring/device/static/monitoring/js/device-map.js
@@ -14,11 +14,12 @@
   };
   const STATUS_COLORS = window._owGeoMapConfig.STATUS_COLORS;
   const STATUS_LABELS = window._owGeoMapConfig.labels;
+  const uuidPlaceholder = "00000000-0000-0000-0000-000000000000";
   const getIndoorCoordinatesUrl = function (pk) {
-    return window._owGeoMapConfig.indoorCoordinatesUrl.replace("000", pk);
+    return window._owGeoMapConfig.indoorCoordinatesUrl.replace(uuidPlaceholder, pk);
   };
   const getLocationDeviceUrl = function (pk) {
-    return window._owGeoMapConfig.locationDeviceUrl.replace("000", pk);
+    return window._owGeoMapConfig.locationDeviceUrl.replace(uuidPlaceholder, pk);
   };
   const escapeHtml = function (text) {
     if (!text) return "";

--- a/openwisp_monitoring/device/static/monitoring/js/floorplan.js
+++ b/openwisp_monitoring/device/static/monitoring/js/floorplan.js
@@ -53,7 +53,7 @@
   if (indoorMapId) {
     const { fragmentLocationId, fragmentFloor } = indoorMapId;
     const floorplanUrl = window._owGeoMapConfig.indoorCoordinatesUrl.replace(
-      "000",
+      "00000000-0000-0000-0000-000000000000",
       fragmentLocationId,
     );
     openFloorPlan(floorplanUrl, fragmentLocationId, fragmentFloor);
@@ -87,7 +87,7 @@
       if (indoorMapId) {
         const { fragmentLocationId, fragmentFloor } = indoorMapId;
         const floorplanUrl = window._owGeoMapConfig.indoorCoordinatesUrl.replace(
-          "000",
+          "00000000-0000-0000-0000-000000000000",
           fragmentLocationId,
         );
         openFloorPlan(floorplanUrl, fragmentLocationId, fragmentFloor);

--- a/openwisp_monitoring/device/templates/admin/map/base_map.html
+++ b/openwisp_monitoring/device/templates/admin/map/base_map.html
@@ -10,8 +10,8 @@
   );
   window._owGeoMapConfig = {
     geoJsonUrl: "{% url 'monitoring:api_location_geojson' %}",
-    locationDeviceUrl: "{% url 'monitoring:api_location_device_list' '000' %}",
-    indoorCoordinatesUrl: "{% url 'monitoring:api_indoor_coordinates_list' '000' %}",
+    locationDeviceUrl: "{% url 'monitoring:api_location_device_list' '00000000-0000-0000-0000-000000000000' %}",
+    indoorCoordinatesUrl: "{% url 'monitoring:api_indoor_coordinates_list' '00000000-0000-0000-0000-000000000000' %}",
     labels
   };
 </script>

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -31,6 +31,7 @@ WifiClient = load_model("device_monitoring", "WifiClient")
 WifiSession = load_model("device_monitoring", "WifiSession")
 User = get_user_model()
 Check = load_model("check", "Check")
+ZERO_UUID = "00000000-0000-0000-0000-000000000000"
 # needed for config.geo
 Device = load_model("config", "Device")
 DeviceLocation = load_model("geo", "DeviceLocation")
@@ -145,13 +146,23 @@ class TestAdmin(
         self.assertContains(
             response, f'geoJsonUrl: "{reverse("monitoring:api_location_geojson")}"'
         )
-        self.assertTrue(
+        self.assertContains(
             response,
-            f'locationDeviceUrl: "{reverse("monitoring:api_location_device_list", args=["00000000-0000-0000-0000-000000000000"])}"',
+            'locationDeviceUrl: "{0}"'.format(
+                reverse(
+                    "monitoring:api_location_device_list",
+                    args=[ZERO_UUID],
+                )
+            ),
         )
-        self.assertTrue(
+        self.assertContains(
             response,
-            f'indoorCoordinatesUrl: "{reverse("monitoring:api_indoor_coordinates_list", args=["00000000-0000-0000-0000-000000000000"])}"',
+            'indoorCoordinatesUrl: "{0}"'.format(
+                reverse(
+                    "monitoring:api_indoor_coordinates_list",
+                    args=[ZERO_UUID],
+                )
+            ),
         )
 
     def test_wifisession_dashboard_chart_query(self):
@@ -1486,13 +1497,23 @@ class TestMapPageAdmin(TestGeoMixin, DeviceMonitoringTestCase):
         self.assertContains(
             response, f'geoJsonUrl: "{reverse("monitoring:api_location_geojson")}"'
         )
-        self.assertTrue(
+        self.assertContains(
             response,
-            f'locationDeviceUrl: "{reverse("monitoring:api_location_device_list", args=["00000000-0000-0000-0000-000000000000"])}"',
+            'locationDeviceUrl: "{0}"'.format(
+                reverse(
+                    "monitoring:api_location_device_list",
+                    args=[ZERO_UUID],
+                )
+            ),
         )
-        self.assertTrue(
+        self.assertContains(
             response,
-            f'indoorCoordinatesUrl: "{reverse("monitoring:api_indoor_coordinates_list", args=["00000000-0000-0000-0000-000000000000"])}"',
+            'indoorCoordinatesUrl: "{0}"'.format(
+                reverse(
+                    "monitoring:api_indoor_coordinates_list",
+                    args=[ZERO_UUID],
+                )
+            ),
         )
 
     def test_mappage_admin_media_files(self):

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -147,11 +147,11 @@ class TestAdmin(
         )
         self.assertTrue(
             response,
-            f'locationDeviceUrl: "{reverse("monitoring:api_location_device_list", args=["000"])}"',
+            f'locationDeviceUrl: "{reverse("monitoring:api_location_device_list", args=["00000000-0000-0000-0000-000000000000"])}"',
         )
         self.assertTrue(
             response,
-            f'indoorCoordinatesUrl: "{reverse("monitoring:api_indoor_coordinates_list", args=["000"])}"',
+            f'indoorCoordinatesUrl: "{reverse("monitoring:api_indoor_coordinates_list", args=["00000000-0000-0000-0000-000000000000"])}"',
         )
 
     def test_wifisession_dashboard_chart_query(self):
@@ -1488,11 +1488,11 @@ class TestMapPageAdmin(TestGeoMixin, DeviceMonitoringTestCase):
         )
         self.assertTrue(
             response,
-            f'locationDeviceUrl: "{reverse("monitoring:api_location_device_list", args=["000"])}"',
+            f'locationDeviceUrl: "{reverse("monitoring:api_location_device_list", args=["00000000-0000-0000-0000-000000000000"])}"',
         )
         self.assertTrue(
             response,
-            f'indoorCoordinatesUrl: "{reverse("monitoring:api_indoor_coordinates_list", args=["000"])}"',
+            f'indoorCoordinatesUrl: "{reverse("monitoring:api_indoor_coordinates_list", args=["00000000-0000-0000-0000-000000000000"])}"',
         )
 
     def test_mappage_admin_media_files(self):

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -172,8 +172,9 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         # Add 1 for general metric and chart
         self.assertEqual(self.metric_queryset.count(), 0)
         self.assertEqual(self.chart_queryset.count(), 0)
+        device_id = d.id
         d.delete(check_deactivated=False)
-        r = self._post_data(d.id, d.key, data)
+        r = self._post_data(device_id, d.key, data)
         self.assertEqual(r.status_code, 404)
 
     def test_200_create(self):
@@ -410,13 +411,13 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         dd = self.create_test_data()
         d = self.device_model.objects.get(pk=dd.pk)
         with self.assertNumQueries(17):
-            r = self.client.get(self._url(d.pk.hex, d.key))
+            r = self.client.get(self._url(d.pk, d.key))
         with self.assertNumQueries(16):
-            r = self.client.get(self._url(d.pk.hex, d.key))
+            r = self.client.get(self._url(d.pk, d.key))
         self.assertEqual(r.status_code, 200)
 
         with self.subTest("Test device metrics 200 without the device key"):
-            r1 = self.client.get(self._url(d.pk.hex))
+            r1 = self.client.get(self._url(d.pk))
             self.assertEqual(r1.status_code, 200)
             for key in self._RESPONSE_KEYS:
                 self.assertIn(key, r.data.keys())
@@ -527,7 +528,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         m = self._create_object_metric(content_object=d, name="applications")
         self._create_chart(metric=m, configuration="histogram")
         self._create_multiple_measurements(create=False, no_resources=True, count=2)
-        r = self.client.get(self._url(d.pk.hex, d.key))
+        r = self.client.get(self._url(d.pk, d.key))
         self.assertEqual(r.status_code, 200)
         self.assertTrue(len(r.data["x"]) > 50)
 
@@ -539,7 +540,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         self.assertIsInstance(r.data["charts"], list)
 
     def test_get_device_metrics_404(self):
-        r = self.client.get(self._url("WRONG", "MADEUP"))
+        r = self.client.get(self._url(uuid4(), "MADEUP"))
         self.assertEqual(r.status_code, 404)
 
     def test_get_device_metrics_401(self):
@@ -645,7 +646,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         c.save()
         # Add 1 for general chart
         self.assertEqual(self.chart_queryset.count(), 1)
-        response = self.client.get(self._url(d.pk.hex, d.key))
+        response = self.client.get(self._url(d.pk, d.key))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["charts"], [])
 
@@ -689,7 +690,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         c = self._create_chart(metric=m, test_data=None)
         c.configuration = "invalid"
         c.save()
-        response = self.client.get(self._url(d.pk.hex, d.key))
+        response = self.client.get(self._url(d.pk, d.key))
         self.assertEqual(response.status_code, 200)
 
     @tag("flaky_with_udp_writes")
@@ -725,7 +726,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
     def test_get_device_status_200(self):
         dd = self.create_test_data(no_resources=True)
         d = self.device_model.objects.get(pk=dd.pk)
-        url = self._url(d.pk.hex, d.key)
+        url = self._url(d.pk, d.key)
         # status not requested
         r = self.client.get(url)
         self.assertEqual(r.status_code, 200)
@@ -987,7 +988,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             {"umts": {"ecio": 2, "rscp": -14, "rssi": -80}}
         )
         self._post_data(device.id, device.key, data)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(charts[0]["summary"]["signal_strength"], -51.0)
@@ -1044,7 +1045,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         }
         response = self._post_data(device.id, device.key, data)
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(charts[0]["summary"]["signal_power"], -70.0)
@@ -1083,7 +1084,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         }
         response = self._post_data(device.id, device.key, data)
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(len(charts), 3)
@@ -1123,7 +1124,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         }
         response = self._post_data(device.id, device.key, data)
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(len(charts), 3)
@@ -1163,7 +1164,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         }
         response = self._post_data(device.id, device.key, data)
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(len(charts), 3)
@@ -1205,7 +1206,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         }
         response = self._post_data(device.id, device.key, data)
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(len(charts), 3)
@@ -1245,7 +1246,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         }
         response = self._post_data(device.id, device.key, data)
         self.assertEqual(response.status_code, 200)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         charts = response.data["charts"]
         self.assertEqual(len(charts), 2)
@@ -1280,7 +1281,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             ],
         }
         self._post_data(device.id, device.key, data)
-        response = self.client.get(self._url(device.pk.hex, device.key))
+        response = self.client.get(self._url(device.pk, device.key))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["charts"], [])
         dd = DeviceData(name=device.name, pk=device.pk)

--- a/openwisp_monitoring/device/tests/test_transactions.py
+++ b/openwisp_monitoring/device/tests/test_transactions.py
@@ -48,7 +48,7 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
         del data["interfaces"]
         self._delete_non_ping_checks()
         d.monitoring.update_status("critical")
-        url = reverse("monitoring:api_device_metric", args=[d.pk.hex])
+        url = reverse("monitoring:api_device_metric", args=[d.pk])
         url = "{0}?key={1}".format(url, d.key)
         with patch.object(Check, "perform_check") as mock:
             self._post_data(d.id, d.key, data)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Spotted this defect while working on #815.

## Description of Changes

Dropped permissive regex url patterns in favour the Django's UUID URL pattern and dropped obsolete invalid UUID error handling logic.