### PR TITLE
[tests] Fixed iperf3 tests failing in isolation

### DIFF
--- a/openwisp_monitoring/check/tests/test_iperf3.py
+++ b/openwisp_monitoring/check/tests/test_iperf3.py
@@ -59,9 +59,11 @@ class TestIperf3(
         "iperf3.openwisptestserver2.com",
     ]
     charts_qs = Chart.objects.exclude(
+        configuration__in=["gen_wifi_clients", "general_traffic"]
+    )
+    metrics_qs = Metric.objects.exclude(
         configuration__in=["general_clients", "general_traffic"]
     )
-    metrics_qs = Metric.objects.exclude(key__in=["general_clients", "general_traffic"])
 
     @classmethod
     def setUpClass(cls):
@@ -523,7 +525,7 @@ class TestIperf3(
             mock_exec_command.side_effect = [(RESULT_FAIL, 1), (RESULT_FAIL, 1)]
             result = self._perform_iperf3_check()
             self._assert_iperf3_fail_result(result)
-            self.assertEqual(Chart.objects.count(), 6)
+            self.assertEqual(self.charts_qs.count(), 6)
             self.assertEqual(self.metrics_qs.count(), 1)
             self.assertEqual(mock_warn.call_count, 2)
             self.assertEqual(mock_exec_command.call_count, 2)


### PR DESCRIPTION
## Closes #817

### Problem

The iperf3 test suite passes when executed together with the rest of the test suite but fails when executed in isolation.

The failure is caused by incorrect assumptions regarding seeded monitoring metrics and charts created during migrations:

* `charts_qs` excludes `general_clients`, while the actual chart configuration is `gen_wifi_clients`.
* `metrics_qs` filters on the `key` field, while the seeded objects are identified by their `configuration`.
* One assertion uses `Chart.objects.count()` instead of the filtered queryset, causing seeded charts to be counted.

### Solution

* Update `charts_qs` to exclude `gen_wifi_clients`.
* Update `metrics_qs` to exclude objects using the `configuration` field.
* Replace the raw `Chart.objects.count()` assertion with `self.charts_qs.count()`.

### Testing

```bash
python tests/manage.py test openwisp_monitoring.check.tests.test_iperf3
```

Result:

```text
Ran 11 tests

OK
```
