### PR TITLE
[chores:fix] Fixed collection of metrics via hex UUID path

### DIFF
--- a/openwisp_monitoring/device/api/urls.py
+++ b/openwisp_monitoring/device/api/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
         name="api_device_metric_list",
     ),
     path(
-        "api/v1/monitoring/device/<uuid:pk>/",
+        "api/v1/monitoring/device/<uuid_any:pk>/",
         views.device_metric,
         name="api_device_metric",
     ),

--- a/openwisp_monitoring/device/api/urls.py
+++ b/openwisp_monitoring/device/api/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
         name="api_device_metric_list",
     ),
     path(
+        # uuid_any is registered by openwisp-controller
         "api/v1/monitoring/device/<uuid_any:pk>/",
         views.device_metric,
         name="api_device_metric",

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -180,6 +180,13 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
     def test_200_create(self):
         self.create_test_data(no_resources=True)
 
+    def test_200_create_uuid_without_dashes(self):
+        organization = self._create_org()
+        device = self._create_device(organization=organization)
+        data = {"type": "DeviceMonitoring", "interfaces": []}
+        response = self._post_data(device.pk.hex, device.key, data)
+        self.assertEqual(response.status_code, 200)
+
     @patch("openwisp_monitoring.device.tasks.write_device_metrics.delay")
     def test_background_write(self, mocked_task):
         device = self._create_device(organization=self._create_org())


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Fixing regression introduced in #816.

## Description of Changes

The recent change to url patterns introduced a regression. A similar fix to the same issue was done recently to OpenWISP Controller, the best solution is to reuse the same solution also in OpenWISP Monitoring.
