### PR TITLE
[feature] Add support for elasticsearch TSDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,9 @@ jobs:
             spatialite-bin \
             libsqlite3-mod-spatialite
           pip install -U pip wheel setuptools
-          pip install -r requirements-test.txt
-          pip install -U -I -e .
+          # Resolve test dependencies against the matrix Django version from the start.
+          pip install -r requirements-test.txt "${{ matrix.django-version }}"
+          pip install -U -e .
           pip install -U "${{ matrix.django-version }}"
           sudo npm install -g prettier
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
             tsdb: influxdb2
           - python-version: "3.13"
             django-version: django~=5.2.0
+            tsdb: elasticsearch
+          - python-version: "3.13"
+            django-version: django~=5.2.0
             tsdb: influxdb
             udp: true
           - python-version: "3.13"
@@ -105,6 +108,8 @@ jobs:
 
           if [ "${{ matrix.tsdb }}" = "influxdb2" ]; then
             url="http://localhost:8087/health"
+          elif [ "${{ matrix.tsdb }}" = "elasticsearch" ]; then
+            url="http://localhost:9200"
           else
             url="http://localhost:8086/query?q=SHOW%20DATABASES"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,14 +109,17 @@ jobs:
           if [ "${{ matrix.tsdb }}" = "influxdb2" ]; then
             url="http://localhost:8087/health"
           elif [ "${{ matrix.tsdb }}" = "elasticsearch" ]; then
-            url="http://localhost:9200"
+            url="http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=2s&filter_path=status"
           else
             url="http://localhost:8086/query?q=SHOW%20DATABASES"
           fi
 
           for attempt in $(seq 1 30); do
-            if curl -fsS "$url" >/dev/null 2>&1; then
-              exit 0
+            if response=$(curl -fsS "$url" 2>/dev/null); then
+              if [ "${{ matrix.tsdb }}" != "elasticsearch" ] || \
+                printf "%s" "$response" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"(yellow|green)"'; then
+                exit 0
+              fi
             fi
             sleep 2
           done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ x-timeseries:
   org: &timeseries_org ${INFLUXDB2_ORG:-openwisp}
   token: &influxdb2_token ${INFLUXDB2_TOKEN:-openwisp-token}
   influxdb2-port: &influxdb2_port ${INFLUXDB2_PORT:-8086}
+  elasticsearch-port: &elasticsearch_port ${ELASTICSEARCH_PORT:-9200}
 
 services:
   monitoring:
@@ -26,6 +27,8 @@ services:
       INFLUXDB2_ORG: *timeseries_org
       INFLUXDB2_TOKEN: *influxdb2_token
       INFLUXDB2_UDP_HOST: telegraf
+      ELASTICSEARCH_NAME: *timeseries_database
+      ELASTICSEARCH_URL: http://elasticsearch:9200
 
   influxdb:
     image: influxdb:1.8-alpine
@@ -58,6 +61,19 @@ services:
       DOCKER_INFLUXDB_INIT_BUCKET: *timeseries_database
       DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: *influxdb2_token
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION:-9.4.3}
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    ports:
+      - target: 9200
+        published: *elasticsearch_port
+        protocol: tcp
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+
   # for UDP support on InfluxDB 2.x
   telegraf:
     image: telegraf:1.31-alpine
@@ -84,3 +100,4 @@ services:
 volumes:
   influxdb-data: {}
   influxdb2-data: {}
+  elasticsearch-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
     ports:
       - target: 9200
         published: *elasticsearch_port
+        host_ip: 127.0.0.1
         protocol: tcp
     environment:
       discovery.type: single-node

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -11,7 +11,7 @@ Dependencies
 ------------
 
 - Python >= 3.11
-- InfluxDB 1.x or InfluxDB 2.x
+- InfluxDB 1.x, InfluxDB 2.x, or Elasticsearch 9.x
 - fping
 - OpenSSL
 
@@ -64,6 +64,12 @@ well:
 Setup and activate a virtual-environment. (we'll be using `virtualenv
 <https://pypi.org/project/virtualenv/>`_)
 
+If you want to use Elasticsearch 9.x instead, start ``elasticsearch``:
+
+.. code-block:: shell
+
+    docker compose up -d redis elasticsearch
+
 .. code-block:: shell
 
     python -m virtualenv env
@@ -107,6 +113,60 @@ credentials, you can override the defaults with:
     export INFLUXDB2_TOKEN=openwisp-token
     export INFLUXDB2_BUCKET=openwisp2
     export REDIS_HOST=localhost
+
+If you are using Elasticsearch 9.x, export the following environment
+variable before running migrations, celery, or the development server:
+
+.. code-block:: shell
+
+    export TIMESERIES_BACKEND=elasticsearch
+
+If you are using the ``elasticsearch`` and ``redis`` containers provided
+in this repository's ``docker-compose.yml``, no additional variables are
+needed because the default values in ``tests/openwisp2/settings.py``
+already match that setup.
+
+If you are not using the provided containers, or if you changed ports or
+credentials, you can override the defaults with:
+
+.. code-block:: shell
+
+    # Optional overrides for non-default setups
+    export ELASTICSEARCH_URL=http://localhost:9200
+    export ELASTICSEARCH_NAME=openwisp2
+    export REDIS_HOST=localhost
+
+For Elastic Cloud, use ``ELASTICSEARCH_CLOUD_ID`` instead of
+``ELASTICSEARCH_URL``:
+
+.. code-block:: shell
+
+    export ELASTICSEARCH_CLOUD_ID=<cloud-id>
+    export ELASTICSEARCH_API_KEY=<api-key>
+
+If your cluster requires authentication, use one of these methods:
+
+.. code-block:: shell
+
+    # API key authentication
+    export ELASTICSEARCH_API_KEY=<api-key>
+
+    # Bearer token authentication
+    export ELASTICSEARCH_BEARER_AUTH=<bearer-token>
+
+    # Username and password authentication
+    export ELASTICSEARCH_USER=elastic
+    export ELASTICSEARCH_PASSWORD=<password>
+
+For TLS-enabled clusters, use:
+
+.. code-block:: shell
+
+    export ELASTICSEARCH_CA_CERTS=/path/to/http_ca.crt
+    export ELASTICSEARCH_SSL_ASSERT_FINGERPRINT=<fingerprint>
+
+Elasticsearch index templates, refresh behavior, retry policy, and
+lifecycle settings are managed by the backend.
 
 Install WebDriver for Chromium for your browser version from
 https://chromedriver.chromium.org/home and extract ``chromedriver`` to one

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -114,8 +114,8 @@ credentials, you can override the defaults with:
     export INFLUXDB2_BUCKET=openwisp2
     export REDIS_HOST=localhost
 
-If you are using Elasticsearch 9.x, export the following environment
-variable before running migrations, celery, or the development server:
+If you are using Elasticsearch 9.x, the only required environment variable
+for local development is:
 
 .. code-block:: shell
 
@@ -126,25 +126,29 @@ in this repository's ``docker-compose.yml``, no additional variables are
 needed because the default values in ``tests/openwisp2/settings.py``
 already match that setup.
 
-If you are not using the provided containers, or if you changed ports or
-credentials, you can override the defaults with:
+Optional Elasticsearch connection overrides are:
 
 .. code-block:: shell
 
-    # Optional overrides for non-default setups
-    export ELASTICSEARCH_URL=http://localhost:9200
+    # Defaults to openwisp2
     export ELASTICSEARCH_NAME=openwisp2
-    export REDIS_HOST=localhost
 
-For Elastic Cloud, use ``ELASTICSEARCH_CLOUD_ID`` instead of
-``ELASTICSEARCH_URL``:
+    # Defaults to localhost and 9200
+    export ELASTICSEARCH_HOST=localhost
+    export ELASTICSEARCH_PORT=9200
+
+    # Defaults to http://<ELASTICSEARCH_HOST>:<ELASTICSEARCH_PORT>
+    export ELASTICSEARCH_URL=http://localhost:9200
+
+If ``ELASTICSEARCH_CLOUD_ID`` is set, it is used instead of
+``ELASTICSEARCH_URL`` or ``ELASTICSEARCH_HOST``/``ELASTICSEARCH_PORT``:
 
 .. code-block:: shell
 
     export ELASTICSEARCH_CLOUD_ID=<cloud-id>
-    export ELASTICSEARCH_API_KEY=<api-key>
 
-If your cluster requires authentication, use one of these methods:
+Advanced authentication and TLS settings are unset by default. If your
+cluster requires authentication, use one of these methods:
 
 .. code-block:: shell
 
@@ -158,15 +162,25 @@ If your cluster requires authentication, use one of these methods:
     export ELASTICSEARCH_USER=elastic
     export ELASTICSEARCH_PASSWORD=<password>
 
+When multiple authentication methods are configured, the backend uses them
+in this order: ``ELASTICSEARCH_API_KEY``, ``ELASTICSEARCH_BEARER_AUTH``,
+then ``ELASTICSEARCH_USER``/``ELASTICSEARCH_PASSWORD``.
+
 For TLS-enabled clusters, use:
 
 .. code-block:: shell
 
     export ELASTICSEARCH_CA_CERTS=/path/to/http_ca.crt
     export ELASTICSEARCH_SSL_ASSERT_FINGERPRINT=<fingerprint>
+    export ELASTICSEARCH_VERIFY_CERTS=true
+
+``ELASTICSEARCH_VERIFY_CERTS`` is passed to the Elasticsearch client only
+when explicitly set; otherwise the client default is used.
 
 Elasticsearch index templates, refresh behavior, retry policy, and
 lifecycle settings are managed by the backend.
+
+Elasticsearch uses HTTP/TCP only, so no UDP or Telegraf service is needed.
 
 Install WebDriver for Chromium for your browser version from
 https://chromedriver.chromium.org/home and extract ``chromedriver`` to one

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -162,6 +162,9 @@ cluster requires authentication, use one of these methods:
     export ELASTICSEARCH_USER=elastic
     export ELASTICSEARCH_PASSWORD=<password>
 
+``ELASTICSEARCH_USER`` and ``ELASTICSEARCH_PASSWORD`` must be configured
+together.
+
 When multiple authentication methods are configured, the backend uses them
 in this order: ``ELASTICSEARCH_API_KEY``, ``ELASTICSEARCH_BEARER_AUTH``,
 then ``ELASTICSEARCH_USER``/``ELASTICSEARCH_PASSWORD``.

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -169,16 +169,20 @@ When multiple authentication methods are configured, the backend uses them
 in this order: ``ELASTICSEARCH_API_KEY``, ``ELASTICSEARCH_BEARER_AUTH``,
 then ``ELASTICSEARCH_USER``/``ELASTICSEARCH_PASSWORD``.
 
-For TLS-enabled clusters, use:
+For self-managed TLS-enabled clusters, configure an HTTPS endpoint and the
+required certificate options:
 
 .. code-block:: shell
 
+    export ELASTICSEARCH_URL=https://<host>:<port>
     export ELASTICSEARCH_CA_CERTS=/path/to/http_ca.crt
     export ELASTICSEARCH_SSL_ASSERT_FINGERPRINT=<fingerprint>
     export ELASTICSEARCH_VERIFY_CERTS=true
 
 ``ELASTICSEARCH_VERIFY_CERTS`` is passed to the Elasticsearch client only
-when explicitly set; otherwise the client default is used.
+when explicitly set; otherwise the client default is used. Elastic Cloud
+deployments can use ``ELASTICSEARCH_CLOUD_ID`` instead of configuring the
+URL.
 
 Elasticsearch index templates, refresh behavior, retry policy, and
 lifecycle settings are managed by the backend.
@@ -223,13 +227,15 @@ Run tests with (make sure you have the :ref:`selenium dependencies
     TIMESERIES_UDP=1 ./runtests  # InfluxDB 1.x over UDP
     TSDB=influxdb2 ./runtests  # InfluxDB 2.x over HTTP
     TSDB=influxdb2 TIMESERIES_UDP=1 ./runtests  # InfluxDB 2.x over UDP (via Telegraf)
+    TSDB=elasticsearch ./runtests  # Elasticsearch over HTTP
 
 The ``./runtests`` script is the main test entry point. By default it runs
-the InfluxDB test flow. Set ``TSDB=influxdb2`` to run the InfluxDB 2.x
-test flow instead. Set ``TIMESERIES_UDP=1`` to run the UDP flow for the
-selected backend. When using ``TSDB=influxdb2 TIMESERIES_UDP=1``, Telegraf
-must be running because InfluxDB 2.x does not support UDP natively. Using
-``--parallel`` is not supported in this module.
+the InfluxDB test flow. Set ``TSDB=influxdb2`` or ``TSDB=elasticsearch``
+to run the corresponding backend test flow instead. Set
+``TIMESERIES_UDP=1`` to run the UDP flow for an InfluxDB backend. When
+using ``TSDB=influxdb2 TIMESERIES_UDP=1``, Telegraf must be running
+because InfluxDB 2.x does not support UDP natively. Using ``--parallel``
+is not supported in this module.
 
 Run quality assurance tests with:
 
@@ -285,9 +291,10 @@ Run the docker container:
 
     docker compose up
 
-By default, the Docker setup uses InfluxDB 1.8. To use InfluxDB 2.9
-instead, run:
+By default, the Docker setup uses InfluxDB 1.8. To use another supported
+backend instead, run one of the following:
 
 .. code-block:: shell
 
     TIMESERIES_BACKEND=influxdb2 docker compose up
+    TIMESERIES_BACKEND=elasticsearch docker compose up

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -289,12 +289,12 @@ Run the docker container:
 
 .. code-block:: shell
 
-    docker compose up
+    docker compose up monitoring
 
 By default, the Docker setup uses InfluxDB 1.8. To use another supported
 backend instead, run one of the following:
 
 .. code-block:: shell
 
-    TIMESERIES_BACKEND=influxdb2 docker compose up
-    TIMESERIES_BACKEND=elasticsearch docker compose up
+    TIMESERIES_BACKEND=influxdb2 docker compose up monitoring
+    TIMESERIES_BACKEND=elasticsearch docker compose up monitoring

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -69,6 +69,23 @@ Alternative ``influxdb2`` backend configuration:
         },
     }
 
+Alternative ``elasticsearch`` backend configuration:
+
+.. code-block:: python
+
+    TIMESERIES_DATABASE = {
+        "BACKEND": "openwisp_monitoring.db.backends.elasticsearch",
+        "NAME": "openwisp2",
+        "URL": "https://localhost:9200",
+        "API_KEY": "openwisp-api-key",
+        "CA_CERTS": "/etc/elasticsearch/certs/http_ca.crt",
+        "OPTIONS": {
+            "refresh": "wait_for",
+            "read_size": 10000,
+            "terms_size": 1000,
+        },
+    }
+
 The following table describes the keys available in the
 ``TIMESERIES_DATABASE`` setting:
 
@@ -88,6 +105,39 @@ The following table describes the keys available in the
              :ref:`timeseries_backend_options` for available options
 ============ =============================================================
 
+The ``elasticsearch`` backend uses ``URL``, or ``HOST`` and ``PORT``, to
+connect to the cluster, and ``NAME`` as the name of the data streams
+created by OpenWISP. It also supports the following additional keys:
+
+========================== ==============================================
+**Key**                    ``Description``
+``CLOUD_ID``               Elastic Cloud identifier, used instead of
+                           ``URL`` or ``HOST`` and ``PORT``
+``API_KEY``                Elasticsearch API key
+``BEARER_AUTH``            Elasticsearch bearer token
+``CA_CERTS``               Path to the CA certificate used to verify the
+                           TLS certificate of Elasticsearch
+``SSL_ASSERT_FINGERPRINT`` SHA-256 fingerprint of the TLS certificate of
+                           Elasticsearch, which can be used instead of
+                           ``CA_CERTS``
+``VERIFY_CERTS``           Boolean, passed to the Elasticsearch client
+                           only when configured, otherwise the default of
+                           the client is used
+========================== ==============================================
+
+``API_KEY``, ``BEARER_AUTH``, and ``USER`` with ``PASSWORD`` are
+alternative authentication methods, which are used in this order when more
+than one is configured. ``USER`` and ``PASSWORD`` must be configured
+together.
+
+.. important::
+
+    Use an ``https://`` URL whenever Elasticsearch credentials are
+    configured: API keys, bearer tokens, and passwords sent over
+    ``http://`` can be read by anyone with access to the network. The
+    backend logs a warning when credentials are configured on an
+    ``http://`` URL.
+
 .. _timeseries_backend_options:
 
 Timeseries Database Options
@@ -104,6 +154,15 @@ Timeseries Database Options
 ``udp_port``   Timeseries database port for writing data using UDP on the
                ``influxdb`` backend, or Telegraf listener port for the
                ``influxdb2`` backend
+``refresh``    Refresh policy applied to writes and deletions. Available
+               only for the ``elasticsearch`` backend. Defaults to
+               ``wait_for``
+``read_size``  Number of documents read from Elasticsearch in a single
+               request. Available only for the ``elasticsearch`` backend.
+               Defaults to ``10000``
+``terms_size`` Maximum number of groups returned by charts which group
+               data by tag. Available only for the ``elasticsearch``
+               backend. Defaults to ``1000``
 ============== ===========================================================
 
 The ``influxdb2`` backend supports UDP writes only through Telegraf.
@@ -181,6 +240,12 @@ forwards the data to InfluxDB 2.x over HTTP.
           bucket = "openwisp2"
           bucket_tag = "bucket"
           exclude_bucket_tag = true
+
+The ``elasticsearch`` backend writes over HTTP only and does not support
+UDP writes. It also accepts the ``http_compress``, ``max_retries``,
+``request_timeout``, and ``retry_on_timeout`` options, which are passed to
+the Elasticsearch client unchanged: when these are not configured, the
+defaults of the client are used.
 
 .. _openwisp_monitoring_default_retention_policy:
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -156,7 +156,10 @@ Timeseries Database Options
                ``influxdb2`` backend
 ``refresh``    Refresh policy applied to writes and deletions. Available
                only for the ``elasticsearch`` backend. Defaults to
-               ``wait_for``
+               ``wait_for``, which keeps alert tolerance queries
+               consistent by waiting until new points are searchable.
+               Overriding it can improve write throughput, but may delay
+               or miss alert transitions
 ``read_size``  Number of documents read from Elasticsearch in a single
                request. Available only for the ``elasticsearch`` backend.
                Defaults to ``10000``

--- a/openwisp_monitoring/db/backends/__init__.py
+++ b/openwisp_monitoring/db/backends/__init__.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .base import BackendQueryBundle, BaseTimeseriesClient
 
-BUILTIN_BACKENDS = ["influxdb", "influxdb2"]
+BUILTIN_BACKENDS = ["influxdb", "influxdb2", "elasticsearch"]
 
 
 def get_timeseries_database():

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -111,7 +111,7 @@ class BaseTimeseriesClient(ABC):
         default_query = self.queries.default_chart_query
         resolver = getattr(default_query, "resolve", None)
         if callable(resolver):
-            return resolver(has_object_scope=has_object_scope)
+            return resolver()
         if isinstance(default_query, str):
             return default_query
         if isinstance(default_query, (list, tuple)):
@@ -126,6 +126,15 @@ class BaseTimeseriesClient(ABC):
         raise ImproperlyConfigured(
             "Unsupported default_chart_query descriptor for the selected backend."
         )
+
+    def _normalize_chart_window(self, time_value, group_map=None):
+        if group_map and time_value in group_map:
+            return group_map[time_value]
+        if isinstance(time_value, (int, float)) or (
+            isinstance(time_value, str) and time_value.isdigit()
+        ):
+            return f"{max(int(time_value), 1)}m"
+        return time_value
 
     @abstractmethod
     def create_database(self) -> None:

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -16,6 +16,7 @@ ChartQueryParams = dict[str, Any]
 class BatchWritePayload(TypedDict, total=False):
     name: str
     values: TimeseriesFields
+    operation_id: str
     tags: TimeseriesTags
     timestamp: Any
     database: str | None
@@ -83,6 +84,7 @@ class BaseTimeseriesClient(ABC):
     backend_name = None
     client_error = Exception
     required_settings = ("BACKEND", "NAME")
+    requires_write_operation_id = False
     queries: BackendQueryBundle | None = None
 
     @classmethod

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -123,7 +123,7 @@ class BaseTimeseriesClient(ABC):
         default_query = self.queries.default_chart_query
         resolver = getattr(default_query, "resolve", None)
         if callable(resolver):
-            return resolver()
+            return resolver(has_object_scope=has_object_scope)
         if isinstance(default_query, str):
             return default_query
         if isinstance(default_query, (list, tuple)):

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -108,6 +109,15 @@ class BaseTimeseriesClient(ABC):
 
     def validate_chart_config(self, chart_config: Mapping[str, Any]) -> None:
         pass
+
+    def _normalize_chart_window(self, time_value, group_map=None):
+        if group_map and time_value in group_map:
+            return group_map[time_value]
+        if isinstance(time_value, (int, float)):
+            return f"{max(int(time_value), 1)}m"
+        if isinstance(time_value, str) and re.fullmatch(r"\d+", time_value):
+            return f"{max(int(time_value), 1)}m"
+        return time_value
 
     def get_default_chart_query(self, has_object_scope: bool = False) -> str:
         default_query = self.queries.default_chart_query

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -197,7 +197,10 @@ class BaseTimeseriesClient(ABC):
 
     @abstractmethod
     def delete_metric_data(
-        self, key: str | None = None, tags: TimeseriesTags | None = None
+        self,
+        key: str | None = None,
+        tags: TimeseriesTags | None = None,
+        timestamp: Any = None,
     ) -> None:
         pass
 

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -2,7 +2,7 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Self, TypedDict
+from typing import Any, TypedDict
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError
@@ -34,7 +34,7 @@ class BackendQueryBundle:
     device_data_query: str
     summary_query: Mapping[str, Mapping[str, str]] | None = None
 
-    def validate(self, backend_name: str) -> Self:
+    def validate(self, backend_name: str) -> "BackendQueryBundle":
         if not isinstance(self.chart_query, Mapping):
             raise ImproperlyConfigured(
                 "Backend query bundle must define chart_query as a mapping."
@@ -99,7 +99,7 @@ class BaseTimeseriesClient(ABC):
                 )
         return config
 
-    def attach_queries(self, queries: BackendQueryBundle) -> Self:
+    def attach_queries(self, queries: BackendQueryBundle) -> "BaseTimeseriesClient":
         self.queries = queries
         return self
 

--- a/openwisp_monitoring/db/backends/base.py
+++ b/openwisp_monitoring/db/backends/base.py
@@ -127,15 +127,6 @@ class BaseTimeseriesClient(ABC):
             "Unsupported default_chart_query descriptor for the selected backend."
         )
 
-    def _normalize_chart_window(self, time_value, group_map=None):
-        if group_map and time_value in group_map:
-            return group_map[time_value]
-        if isinstance(time_value, (int, float)) or (
-            isinstance(time_value, str) and time_value.isdigit()
-        ):
-            return f"{max(int(time_value), 1)}m"
-        return time_value
-
     @abstractmethod
     def create_database(self) -> None:
         pass

--- a/openwisp_monitoring/db/backends/elasticsearch/__init__.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/__init__.py
@@ -1,0 +1,12 @@
+from ..base import BackendQueryBundle
+from .client import DatabaseClient
+from .queries import chart_query, default_chart_query, device_data_query, summary_query
+
+queries = BackendQueryBundle(
+    chart_query=chart_query,
+    default_chart_query=default_chart_query,
+    device_data_query=device_data_query,
+    summary_query=summary_query,
+)
+
+__all__ = ["DatabaseClient", "queries"]

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -1,0 +1,1264 @@
+import logging
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.utils.dateparse import parse_datetime
+from django.utils.functional import cached_property
+from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
+from elasticsearch import ApiError, Elasticsearch, NotFoundError, TransportError
+from elasticsearch.helpers import bulk
+
+from openwisp_monitoring.utils import retry
+
+from ...exceptions import TimeseriesWriteException
+from .. import TIMESERIES_DB
+from ..base import (
+    BaseTimeseriesClient,
+    BatchWritePayload,
+    ChartQueryParams,
+    FieldSelection,
+    TimeseriesFields,
+    TimeseriesPoint,
+    TimeseriesTags,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _SafeFormatDict(dict):
+    def __missing__(self, key):
+        return "{" + key + "}"
+
+
+SeriesTags = dict[str, Any]
+SeriesTagSet = frozenset[tuple[str, Any]]
+SeriesKey = tuple[str, SeriesTags | None]
+SeriesCache = dict[tuple[str, SeriesTagSet], list[TimeseriesPoint]]
+
+
+class QueryResultSet:
+    """ResultSet-like wrapper for Elasticsearch search responses."""
+
+    def __init__(
+        self, response: Mapping[str, Any], precision: str | None = "s"
+    ) -> None:
+        self.response = response
+        self.precision = precision
+        self._points: list[TimeseriesPoint] | None = None
+        self._series_cache: SeriesCache | None = None
+
+    def get(self, key, default=None):
+        return self.response.get(key, default)
+
+    def _normalize_time(self, value):
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str):
+            dt = parse_datetime(value)
+            if dt is None:
+                return value
+        else:
+            return value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        if self.precision is None:
+            return dt.isoformat().replace("+00:00", "Z")
+        timestamp = dt.timestamp()
+        if self.precision == "s":
+            return int(timestamp)
+        if self.precision == "ms":
+            return int(timestamp * 1000)
+        if self.precision == "u":
+            return int(timestamp * 1000000)
+        if self.precision == "ns":
+            return int(timestamp * 1000000000)
+        return timestamp
+
+    def _hits(self) -> list[Mapping[str, Any]]:
+        return self.response.get("hits", {}).get("hits", [])
+
+    def _build_points(self) -> list[TimeseriesPoint]:
+        if self._points is not None:
+            return self._points
+        points = []
+        for hit in self._hits():
+            document = hit.get("_source") or {}
+            base_point = {
+                "time": self._normalize_time(document.get("@timestamp")),
+                "__raw_time": document.get("@timestamp"),
+                "_measurement": document.get("measurement", "results"),
+            }
+            base_point.update(document.get("tags") or {})
+            fields = document.get("fields") or {}
+            if not fields:
+                points.append(base_point)
+                continue
+            for field_name, field_value in fields.items():
+                points.append(
+                    {
+                        **base_point,
+                        "_field": field_name,
+                        "_value": field_value,
+                    }
+                )
+        self._points = points
+        return points
+
+    def _group_by_measurement_tags(self) -> SeriesCache:
+        if self._series_cache is not None:
+            return self._series_cache
+        series_dict: SeriesCache = {}
+        special_fields = {"_measurement", "_field", "_value", "time", "__raw_time"}
+        for point in self._build_points():
+            measurement = point.get("_measurement", "results")
+            tags = {
+                key: value for key, value in point.items() if key not in special_fields
+            }
+            tags_key = frozenset(tags.items()) if tags else frozenset()
+            series_dict.setdefault((measurement, tags_key), []).append(point)
+        self._series_cache = series_dict
+        return series_dict
+
+    def get_points(
+        self, measurement: str | None = None, tags: TimeseriesTags | None = None
+    ) -> Iterator[TimeseriesPoint]:
+        for (
+            series_measurement,
+            series_tags_frozen,
+        ), points in self._group_by_measurement_tags().items():
+            series_tags = dict(series_tags_frozen) if series_tags_frozen else {}
+            if measurement is not None and measurement != series_measurement:
+                continue
+            if tags is not None and not self._tag_matches(series_tags, tags):
+                continue
+            yield from points
+
+    def keys(self) -> list[SeriesKey]:
+        return [
+            (measurement, dict(tags_frozen) if tags_frozen else None)
+            for measurement, tags_frozen in self._group_by_measurement_tags().keys()
+        ]
+
+    def items(self) -> list[tuple[SeriesKey, Iterator[TimeseriesPoint]]]:
+        items = []
+        for (
+            measurement,
+            tags_frozen,
+        ), points in self._group_by_measurement_tags().items():
+            tags = dict(tags_frozen) if tags_frozen else None
+            items.append(((measurement, tags), (point for point in points)))
+        return items
+
+    @staticmethod
+    def _tag_matches(series_tags: TimeseriesTags, filter_tags: TimeseriesTags) -> bool:
+        for tag_name, tag_value in filter_tags.items():
+            if series_tags.get(tag_name) != tag_value:
+                return False
+        return True
+
+    def __iter__(self) -> Iterator[TimeseriesPoint]:
+        yield from self.get_points()
+
+    def __len__(self) -> int:
+        return len(self.keys())
+
+    def __repr__(self) -> str:
+        items = []
+        for key, points in self.items():
+            items.append("'%s': %s" % (key, list(points)))
+        return "ResultSet({%s})" % ", ".join(items)
+
+
+class DatabaseClient(BaseTimeseriesClient):
+    backend_name = "elasticsearch"
+    client_error = TransportError
+    required_settings = ("BACKEND", "NAME")
+    _OPERATORS = ("=", "!=", "<", ">", "<=", ">=")
+    _AGGREGATE = (
+        "avg",
+        "cardinality",
+        "count",
+        "date_histogram",
+        "extended_stats",
+        "histogram",
+        "max",
+        "min",
+        "percentiles",
+        "stats",
+        "sum",
+        "terms",
+        "value_count",
+    )
+    _DURATION_PATTERN = re.compile(r"(?:\d+[smhdw])+")
+    _DURATION_PART_PATTERN = re.compile(r"(\d+)([smhdw])")
+    _DEFAULT_ROLLOVER_SECONDS = 30 * 24 * 60 * 60
+    _CHART_FILTERS = (
+        "content_type",
+        "object_id",
+        "ifname",
+        "organization_id",
+        "location_id",
+        "floorplan_id",
+    )
+
+    @classmethod
+    def validate_settings(cls, config: Mapping[str, Any] | None) -> Mapping[str, Any]:
+        super().validate_settings(config)
+        has_cloud_id = bool(config.get("CLOUD_ID"))
+        has_url = bool(config.get("URL"))
+        has_host_port = all(config.get(field) for field in ("HOST", "PORT"))
+        if not has_cloud_id and not has_url and not has_host_port:
+            raise ImproperlyConfigured(
+                'Elasticsearch TIMESERIES_DATABASE must define "CLOUD_ID", '
+                '"URL", or both "HOST" and "PORT".'
+            )
+        return config
+
+    def __init__(self, db_name: str | None = None) -> None:
+        self.db_name = db_name or TIMESERIES_DB["NAME"]
+        self._ensured_streams = set()
+
+    @property
+    def use_udp(self) -> bool:
+        return False
+
+    @cached_property
+    def db(self) -> Elasticsearch:
+        return Elasticsearch(**self._get_client_kwargs())
+
+    @property
+    def options(self) -> Mapping[str, Any]:
+        return TIMESERIES_DB.get("OPTIONS", {})
+
+    @property
+    def refresh(self):
+        return self.options.get("refresh", "wait_for")
+
+    def _get_client_kwargs(self) -> dict[str, Any]:
+        kwargs = {}
+        if TIMESERIES_DB.get("CLOUD_ID"):
+            kwargs["cloud_id"] = TIMESERIES_DB["CLOUD_ID"]
+        else:
+            url = TIMESERIES_DB.get("URL")
+            if not url:
+                url = f"http://{TIMESERIES_DB['HOST']}:{TIMESERIES_DB['PORT']}"
+            kwargs["hosts"] = [url]
+        if TIMESERIES_DB.get("API_KEY"):
+            kwargs["api_key"] = TIMESERIES_DB["API_KEY"]
+        elif TIMESERIES_DB.get("BEARER_AUTH"):
+            kwargs["bearer_auth"] = TIMESERIES_DB["BEARER_AUTH"]
+        elif TIMESERIES_DB.get("USER") and TIMESERIES_DB.get("PASSWORD"):
+            kwargs["basic_auth"] = (
+                TIMESERIES_DB["USER"],
+                TIMESERIES_DB["PASSWORD"],
+            )
+        for setting_name, kwarg_name in (
+            ("CA_CERTS", "ca_certs"),
+            ("SSL_ASSERT_FINGERPRINT", "ssl_assert_fingerprint"),
+            ("VERIFY_CERTS", "verify_certs"),
+        ):
+            if setting_name in TIMESERIES_DB:
+                kwargs[kwarg_name] = TIMESERIES_DB[setting_name]
+        for option_name in (
+            "http_compress",
+            "max_retries",
+            "request_timeout",
+            "retry_on_timeout",
+        ):
+            if option_name in self.options:
+                kwargs[option_name] = self.options[option_name]
+        return kwargs
+
+    def _get_retention_policy_name(self, retention_policy=None) -> str:
+        if not retention_policy or retention_policy == "autogen":
+            return "autogen"
+        return str(retention_policy)
+
+    def _get_stream_name(self, retention_policy=None) -> str:
+        retention_policy = self._get_retention_policy_name(retention_policy)
+        if retention_policy == "autogen":
+            return self.db_name
+        return f"{self.db_name}-{retention_policy}"
+
+    def _get_policy_name(self, retention_policy=None) -> str:
+        return f"{self.db_name}-{self._get_retention_policy_name(retention_policy)}-ilm"
+
+    def _get_template_name(self, retention_policy=None) -> str:
+        return f"{self._get_stream_name(retention_policy)}-template"
+
+    def _is_own_stream(self, name: str) -> bool:
+        return name == self.db_name or name.startswith(f"{self.db_name}-")
+
+    def _is_not_found(self, exception: Exception) -> bool:
+        return isinstance(exception, NotFoundError) or (
+            isinstance(exception, ApiError)
+            and getattr(exception, "status_code", None) == 404
+        )
+
+    def _is_resource_exists(self, exception: Exception) -> bool:
+        if not isinstance(exception, ApiError):
+            return False
+        if getattr(exception, "status_code", None) != 400:
+            return False
+        return "resource_already_exists_exception" in str(exception)
+
+    def _response_body(self, response):
+        return getattr(response, "body", response)
+
+    def _duration_to_seconds(self, duration: str | None) -> int | None:
+        if duration is None:
+            return None
+        if not isinstance(duration, str) or not self._DURATION_PATTERN.fullmatch(
+            duration
+        ):
+            raise ValueError(f'Invalid duration "{duration}"')
+        mapping = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+        return sum(
+            int(value) * mapping[unit]
+            for value, unit in self._DURATION_PART_PATTERN.findall(duration)
+        )
+
+    def _build_lifecycle_policy(self, duration: str | None = None) -> dict[str, Any]:
+        duration_seconds = self._duration_to_seconds(duration)
+        rollover_seconds = duration_seconds or self._DEFAULT_ROLLOVER_SECONDS
+        rollover_seconds = min(rollover_seconds, self._DEFAULT_ROLLOVER_SECONDS)
+        policy = {
+            "phases": {
+                "hot": {
+                    "actions": {
+                        "rollover": {
+                            "max_age": f"{rollover_seconds}s",
+                            "max_primary_shard_size": self.options.get(
+                                "rollover_max_primary_shard_size", "50gb"
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+        if duration_seconds:
+            policy["phases"]["delete"] = {
+                "min_age": f"{duration_seconds}s",
+                "actions": {"delete": {}},
+            }
+        return policy
+
+    def _put_lifecycle_policy(self, name: str, policy: Mapping[str, Any]) -> None:
+        try:
+            self.db.ilm.put_lifecycle(name=name, policy=policy)
+        except TypeError:
+            self.db.ilm.put_lifecycle(name=name, body={"policy": policy})
+
+    def _build_index_template_body(self, retention_policy=None) -> dict[str, Any]:
+        stream_name = self._get_stream_name(retention_policy)
+        return {
+            "index_patterns": [stream_name],
+            "data_stream": {},
+            "priority": self.options.get("template_priority", 500),
+            "template": {
+                "settings": {
+                    "index.mode": "time_series",
+                    "index.lifecycle.name": self._get_policy_name(retention_policy),
+                    "index.routing_path": ["measurement", "tags.*"],
+                },
+                "mappings": {
+                    "dynamic": True,
+                    "dynamic_templates": [
+                        {
+                            "tag_values": {
+                                "path_match": "tags.*",
+                                "mapping": {
+                                    "type": "keyword",
+                                    "time_series_dimension": True,
+                                    "ignore_above": 2048,
+                                },
+                            }
+                        },
+                        {
+                            "field_strings": {
+                                "path_match": "fields.*",
+                                "match_mapping_type": "string",
+                                "mapping": {
+                                    "type": "keyword",
+                                    "ignore_above": 8192,
+                                },
+                            }
+                        },
+                        {
+                            "field_longs": {
+                                "path_match": "fields.*",
+                                "match_mapping_type": "long",
+                                "mapping": {
+                                    "type": "double",
+                                    "time_series_metric": "gauge",
+                                },
+                            }
+                        },
+                        {
+                            "field_doubles": {
+                                "path_match": "fields.*",
+                                "match_mapping_type": "double",
+                                "mapping": {
+                                    "type": "double",
+                                    "time_series_metric": "gauge",
+                                },
+                            }
+                        },
+                    ],
+                    "properties": {
+                        "@timestamp": {"type": "date"},
+                        "measurement": {
+                            "type": "keyword",
+                            "time_series_dimension": True,
+                        },
+                        "openwisp_doc_count": {
+                            "type": "long",
+                            "time_series_metric": "gauge",
+                        },
+                        "tags": {"type": "object", "dynamic": True},
+                        "fields": {"type": "object", "dynamic": True},
+                    },
+                },
+                "lifecycle": {"enabled": True},
+            },
+            "_meta": {"description": "OpenWISP Monitoring Elasticsearch TSDS data"},
+        }
+
+    def _put_index_template(self, retention_policy=None) -> None:
+        name = self._get_template_name(retention_policy)
+        body = self._build_index_template_body(retention_policy)
+        try:
+            self.db.indices.put_index_template(name=name, **body)
+        except TypeError:
+            self.db.indices.put_index_template(name=name, body=body)
+
+    def _data_stream_exists(self, name: str) -> bool:
+        try:
+            self.db.indices.get_data_stream(name=name)
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return False
+            raise
+        return True
+
+    def _ensure_data_stream_resources(
+        self, retention_policy=None, duration: str | None = None
+    ):
+        stream_name = self._get_stream_name(retention_policy)
+        cache_key = (stream_name, duration)
+        if cache_key in self._ensured_streams:
+            return
+        self._put_lifecycle_policy(
+            self._get_policy_name(retention_policy),
+            self._build_lifecycle_policy(duration),
+        )
+        self._put_index_template(retention_policy)
+        if not self._data_stream_exists(stream_name):
+            try:
+                self.db.indices.create_data_stream(name=stream_name)
+            except Exception as exception:
+                if not self._is_resource_exists(exception):
+                    raise
+        self._ensured_streams.add(cache_key)
+
+    @retry
+    def create_database(self) -> None:
+        self._ensure_data_stream_resources()
+        logger.debug('Created Elasticsearch data stream "%s"', self.db_name)
+
+    @retry
+    def drop_database(self) -> None:
+        for stream_name in self._get_data_stream_names():
+            try:
+                self.db.indices.delete_data_stream(name=stream_name)
+            except Exception as exception:
+                if not self._is_not_found(exception):
+                    raise
+        self._delete_index_templates()
+        self._delete_lifecycle_policies()
+        self._ensured_streams = set()
+        logger.debug('Dropped Elasticsearch data streams for "%s"', self.db_name)
+
+    def _get_data_stream_names(self) -> list[str]:
+        try:
+            response = self.db.indices.get_data_stream(name=f"{self.db_name}*")
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return []
+            raise
+        response = self._response_body(response)
+        return [
+            stream["name"]
+            for stream in response.get("data_streams", [])
+            if self._is_own_stream(stream["name"])
+        ]
+
+    def _delete_index_templates(self) -> None:
+        try:
+            response = self.db.indices.get_index_template(
+                name=f"{self.db_name}*-template"
+            )
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return
+            raise
+        response = self._response_body(response)
+        template_names = [
+            template["name"]
+            for template in response.get("index_templates", [])
+            if template["name"] == self._get_template_name()
+            or (
+                template["name"].startswith(f"{self.db_name}-")
+                and template["name"].endswith("-template")
+            )
+        ]
+        for template_name in template_names:
+            try:
+                self.db.indices.delete_index_template(name=template_name)
+            except Exception as exception:
+                if not self._is_not_found(exception):
+                    raise
+
+    def _delete_lifecycle_policies(self) -> None:
+        for policy_name in self._get_lifecycle_policy_names():
+            try:
+                self.db.ilm.delete_lifecycle(name=policy_name)
+            except Exception as exception:
+                if not self._is_not_found(exception):
+                    raise
+
+    def _get_lifecycle_policy_names(self) -> list[str]:
+        try:
+            response = self.db.ilm.get_lifecycle(name=f"{self.db_name}-*-ilm")
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return []
+            raise
+        response = self._response_body(response)
+        return [
+            name
+            for name in response.keys()
+            if name.startswith(f"{self.db_name}-") and name.endswith("-ilm")
+        ]
+
+    @retry
+    def create_or_alter_retention_policy(self, name: str, duration: str) -> None:
+        self._ensure_data_stream_resources(retention_policy=name, duration=duration)
+        logger.debug(
+            'Created/updated Elasticsearch retention policy "%s" with duration %s',
+            name,
+            duration,
+        )
+
+    @retry
+    def get_list_retention_policies(self) -> list[TimeseriesPoint]:
+        policies = []
+        for policy_name in self._get_lifecycle_policy_names():
+            retention_policy = policy_name[len(self.db_name) + 1 : -len("-ilm")]
+            try:
+                body = self.db.ilm.get_lifecycle(name=policy_name)
+            except Exception as exception:
+                if self._is_not_found(exception):
+                    continue
+                raise
+            body = self._response_body(body)
+            phases = body.get(policy_name, {}).get("policy", {}).get("phases", {})
+            duration = "0s"
+            if "delete" in phases:
+                duration = phases["delete"].get("min_age", duration)
+            policies.append(
+                {
+                    "name": retention_policy,
+                    "default": retention_policy == "autogen",
+                    "duration": duration,
+                    "replication": 1,
+                }
+            )
+        return sorted(policies, key=lambda item: (not item["default"], item["name"]))
+
+    def _get_timestamp(self, timestamp=None) -> str:
+        timestamp = timestamp or now()
+        if isinstance(timestamp, datetime):
+            return timestamp.isoformat()
+        return timestamp
+
+    def _normalize_time(self, value, precision="s"):
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str):
+            dt = parse_datetime(value)
+            if dt is None:
+                return value
+        else:
+            return value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        if precision is None:
+            return dt.isoformat().replace("+00:00", "Z")
+        timestamp = dt.timestamp()
+        if precision == "s":
+            return int(timestamp)
+        if precision == "ms":
+            return int(timestamp * 1000)
+        if precision == "u":
+            return int(timestamp * 1000000)
+        if precision == "ns":
+            return int(timestamp * 1000000000)
+        return timestamp
+
+    def _clean_operator(self, op: str) -> str:
+        if op not in self._OPERATORS:
+            message = _(
+                'Invalid operator "%(operator)s" passed.\n'
+                "Valid operators are: %(operators)s"
+            ) % {"operator": op, "operators": ", ".join(self._OPERATORS)}
+            raise self.client_error(message)
+        return op
+
+    def _check_database_kwarg(self, database) -> None:
+        if database and database != self.db_name:
+            logger.warning(
+                'Parameter "database" is ignored in Elasticsearch. '
+                'Using data stream namespace "%s"',
+                self.db_name,
+            )
+
+    def _build_document(self, name, values, **kwargs) -> dict[str, Any]:
+        return {
+            "@timestamp": self._get_timestamp(kwargs.get("timestamp")),
+            "measurement": name,
+            "openwisp_doc_count": 1,
+            "tags": dict(kwargs.get("tags") or {}),
+            "fields": dict(values or {}),
+        }
+
+    def _handle_write_exception(self, exception) -> None:
+        logger.warning("Error writing to Elasticsearch: %s", exception)
+        raise TimeseriesWriteException from exception
+
+    def write(self, name: str, values: TimeseriesFields, **kwargs: Any) -> None:
+        self._check_database_kwarg(kwargs.get("database"))
+        retention_policy = kwargs.get("retention_policy")
+        try:
+            self._ensure_data_stream_resources(retention_policy)
+            document = self._build_document(name, values, **kwargs)
+            self.db.index(
+                index=self._get_stream_name(retention_policy),
+                document=document,
+                op_type="create",
+                refresh=self.refresh,
+            )
+        except Exception as exception:
+            self._handle_write_exception(exception)
+
+    def batch_write(self, metric_data: Sequence[BatchWritePayload]) -> None:
+        try:
+            actions = []
+            for data in metric_data:
+                self._check_database_kwarg(data.get("database"))
+                retention_policy = data.get("retention_policy")
+                self._ensure_data_stream_resources(retention_policy)
+                actions.append(
+                    {
+                        "_op_type": "create",
+                        "_index": self._get_stream_name(retention_policy),
+                        "_source": self._build_document(
+                            data.get("name"),
+                            data.get("values"),
+                            tags=data.get("tags"),
+                            timestamp=data.get("timestamp"),
+                        ),
+                    }
+                )
+            if not actions:
+                return
+            bulk(self.db, actions, refresh=self.refresh)
+        except Exception as exception:
+            self._handle_write_exception(exception)
+
+    def _empty_search_response(self) -> dict[str, Any]:
+        return {"hits": {"total": {"value": 0}, "hits": []}}
+
+    @retry
+    def query(
+        self, query, precision: str | None = None, **kwargs: Any
+    ) -> QueryResultSet:
+        if not isinstance(query, Mapping):
+            raise self.client_error("Elasticsearch queries must be dictionaries.")
+        query = deepcopy(query)
+        index = (
+            kwargs.get("index")
+            or query.pop("__index", None)
+            or query.pop("index", None)
+            or self._get_stream_name(query.pop("__retention_policy", None))
+        )
+        for key in list(query.keys()):
+            if key.startswith("__openwisp_"):
+                query.pop(key)
+        try:
+            response = self.db.search(index=index, body=query)
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return QueryResultSet(
+                    self._empty_search_response(), precision=precision
+                )
+            logger.warning("Error querying Elasticsearch: %s", exception)
+            raise
+        return QueryResultSet(self._response_body(response), precision=precision)
+
+    def _normalize_fields(self, fields, extra_fields=None):
+        if isinstance(fields, str):
+            fields = [fields]
+        else:
+            fields = list(fields)
+        if extra_fields and extra_fields != "*":
+            if isinstance(extra_fields, str):
+                extra_fields = [extra_fields]
+            fields.extend(extra_fields)
+        elif extra_fields == "*":
+            fields = ["*"]
+        return fields
+
+    def _build_measurement_filter(self, key):
+        measurements = [item.strip() for item in key.split(",") if item.strip()]
+        if not measurements:
+            return None
+        if len(measurements) == 1:
+            return {"term": {"measurement": measurements[0]}}
+        return {"terms": {"measurement": measurements}}
+
+    def _build_field_filter(self, field, op, value):
+        op = self._clean_operator(op)
+        field_name = f"fields.{field}"
+        if op == "=":
+            return {"term": {field_name: value}}
+        if op == "!=":
+            return {"bool": {"must_not": [{"term": {field_name: value}}]}}
+        range_operator = {">": "gt", ">=": "gte", "<": "lt", "<=": "lte"}[op]
+        return {"range": {field_name: {range_operator: value}}}
+
+    def _build_base_query(
+        self,
+        key: str | None = None,
+        tags: TimeseriesTags | None = None,
+        since=None,
+        where: Sequence[Sequence[Any]] | None = None,
+    ) -> dict[str, Any]:
+        filters = []
+        measurement_filter = self._build_measurement_filter(key) if key else None
+        if measurement_filter:
+            filters.append(measurement_filter)
+        if since:
+            filters.append(
+                {"range": {"@timestamp": {"gte": self._get_timestamp(since)}}}
+            )
+        if tags:
+            for tag_key, tag_value in tags.items():
+                filters.append({"term": {f"tags.{tag_key}": tag_value}})
+        if where:
+            for field, op, value in where:
+                filters.append(self._build_field_filter(field, op, value))
+        if not filters:
+            return {"match_all": {}}
+        return {"bool": {"filter": filters}}
+
+    def _document_to_point(
+        self,
+        document: Mapping[str, Any],
+        fields: Sequence[str] | None = None,
+        precision: str | None = "s",
+        include_tags: bool = True,
+    ) -> TimeseriesPoint:
+        point = {
+            "time": self._normalize_time(
+                document.get("@timestamp"), precision=precision
+            )
+        }
+        if include_tags:
+            point.update(document.get("tags") or {})
+        values = document.get("fields") or {}
+        if not fields or fields == ["*"]:
+            point.update(values)
+            return point
+        for field in fields:
+            if field in values:
+                point[field] = values[field]
+        return point
+
+    def _get_hits(self, response) -> list[Mapping[str, Any]]:
+        if isinstance(response, QueryResultSet):
+            response = response.response
+        return response.get("hits", {}).get("hits", [])
+
+    def _count_distinct_read(
+        self,
+        key,
+        tags,
+        field,
+        since=None,
+        where=None,
+        retention_policy=None,
+        limit=None,
+        precision="s",
+    ) -> list[TimeseriesPoint]:
+        response = self.query(
+            {
+                "size": 0,
+                "query": self._build_base_query(
+                    key=key, tags=tags, since=since, where=where
+                ),
+                "aggs": {"count": {"cardinality": {"field": f"fields.{field}"}}},
+                "__retention_policy": retention_policy,
+            },
+            precision=precision,
+        )
+        value = response.get("aggregations", {}).get("count", {}).get("value", 0)
+        points = [{"count": value, "time": None}]
+        return points[: int(limit)] if limit else points
+
+    def read(
+        self,
+        key: str,
+        fields: FieldSelection,
+        tags: TimeseriesTags | None,
+        **kwargs: Any,
+    ) -> list[TimeseriesPoint]:
+        distinct_fields = kwargs.get("distinct_fields", [])
+        count_fields = kwargs.get("count_fields", [])
+        where = kwargs.get("where", [])
+        supports_count_distinct = (
+            len(distinct_fields) == 1
+            and len(count_fields) == 1
+            and distinct_fields[0] == count_fields[0]
+        )
+        if (distinct_fields or count_fields) and not supports_count_distinct:
+            raise NotImplementedError(
+                "Elasticsearch read() currently supports only single-field "
+                "COUNT(DISTINCT(field)) queries."
+            )
+        retention_policy = kwargs.get("retention_policy")
+        limit = kwargs.get("limit")
+        precision = kwargs.get("precision", "s")
+        if supports_count_distinct:
+            return self._count_distinct_read(
+                key=key,
+                tags=tags,
+                field=distinct_fields[0],
+                since=kwargs.get("since"),
+                where=where,
+                retention_policy=retention_policy,
+                limit=limit,
+                precision=precision,
+            )
+        fields = self._normalize_fields(fields, kwargs.get("extra_fields"))
+        order = kwargs.get("order") or kwargs.get("order_by")
+        if order in (None, "time"):
+            sort = [{"@timestamp": {"order": "asc"}}]
+        elif order == "-time":
+            sort = [{"@timestamp": {"order": "desc"}}]
+        else:
+            message = _(
+                'Invalid order "%(order)s" passed.\n'
+                'You may pass "time" / "-time" to get result sorted '
+                "in ascending /descending order respectively."
+            ) % {"order": order}
+            raise self.client_error(message)
+        query = {
+            "query": self._build_base_query(
+                key=key,
+                tags=tags,
+                since=kwargs.get("since"),
+                where=where,
+            ),
+            "sort": sort,
+            "__retention_policy": retention_policy,
+        }
+        if limit:
+            query["size"] = int(limit)
+        else:
+            query["size"] = int(self.options.get("read_size", 10000))
+        response = self.query(query, precision=precision)
+        return [
+            self._document_to_point(
+                hit.get("_source", {}),
+                fields=fields,
+                precision=precision,
+            )
+            for hit in self._get_hits(response)
+        ]
+
+    def _format_query_mapping(self, value, params):
+        if isinstance(value, str):
+            return value.format_map(_SafeFormatDict(params))
+        if isinstance(value, Mapping):
+            return {
+                key: self._format_query_mapping(item, params)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self._format_query_mapping(item, params) for item in value]
+        return value
+
+    def _is_openwisp_query(self, query, query_type=None) -> bool:
+        if not isinstance(query, Mapping):
+            return False
+        current_type = query.get("__openwisp_query_type")
+        if query_type is None:
+            return bool(current_type)
+        return current_type == query_type
+
+    def _build_tag_filter(self, field, value):
+        if value in (None, "", "__all__"):
+            return None
+        tag_field = f"tags.{field}"
+        if isinstance(value, (list, tuple)):
+            values = [str(item) for item in value if item != "__all__"]
+            if not values:
+                return None
+            return {"terms": {tag_field: values}}
+        return {"term": {tag_field: str(value)}}
+
+    def _build_chart_base_query(self, params):
+        filters = []
+        measurement_filter = self._build_measurement_filter(params.get("key"))
+        if measurement_filter:
+            filters.append(measurement_filter)
+        time_filter = {}
+        if params.get("time"):
+            time_filter["gte"] = self._get_timestamp(params["time"])
+        if params.get("end_date"):
+            time_filter["lte"] = self._get_timestamp(params["end_date"])
+        if time_filter:
+            filters.append({"range": {"@timestamp": time_filter}})
+        for field in self._CHART_FILTERS:
+            tag_filter = self._build_tag_filter(field, params.get(field))
+            if tag_filter:
+                filters.append(tag_filter)
+        if not filters:
+            return {"match_all": {}}
+        return {"bool": {"filter": filters}}
+
+    def _normalize_chart_window(self, time, group_map):
+        return str(group_map.get(time, time) or "1d")
+
+    def _format_chart_metrics(self, query, params):
+        format_params = {**params}
+        metrics = self._format_query_mapping(query.get("metrics", []), format_params)
+        return [metric for metric in metrics if metric.get("field")]
+
+    def _build_metric_aggregation(self, metric):
+        field = f"fields.{metric['field']}"
+        aggregation = metric.get("agg", "avg")
+        if aggregation == "sum":
+            return {"sum": {"field": field}}
+        if aggregation == "cardinality":
+            return {"cardinality": {"field": field}}
+        if aggregation == "mode":
+            return {"terms": {"field": field, "size": 1}}
+        return {"avg": {"field": field}}
+
+    def _build_metric_aggregations(self, metrics):
+        return {
+            metric["name"]: self._build_metric_aggregation(metric) for metric in metrics
+        }
+
+    def _build_chart_query(
+        self,
+        query,
+        params,
+        time,
+        group_map,
+        summary=False,
+        timezone=None,
+    ):
+        metrics = self._format_chart_metrics(query, params)
+        body = {
+            "size": 0,
+            "query": self._build_chart_base_query(params),
+            "__index": self._get_stream_name(params.get("retention_policy")),
+            "__openwisp_query_type": "chart",
+            "__openwisp_metrics": metrics,
+            "__openwisp_summary": summary,
+            "__openwisp_aggregate": True,
+        }
+        metric_aggs = self._build_metric_aggregations(metrics)
+        if summary:
+            body["aggs"] = metric_aggs
+            return body
+        histogram = {
+            "field": "@timestamp",
+            "fixed_interval": self._normalize_chart_window(time, group_map),
+            "min_doc_count": 0,
+        }
+        if timezone:
+            histogram["time_zone"] = timezone
+        body["aggs"] = {
+            "timeseries": {
+                "date_histogram": histogram,
+                "aggs": metric_aggs,
+            }
+        }
+        return body
+
+    def _normalize_raw_chart_fields(self, query, params, fields=None):
+        if fields:
+            return list(fields)
+        field = self._format_query_mapping(query.get("field"), params)
+        if not field or field == "{fields}":
+            return ["*"]
+        return [field]
+
+    def _build_raw_chart_query(self, query, params, fields=None):
+        selected_fields = self._normalize_raw_chart_fields(query, params, fields)
+        return {
+            "size": int(self.options.get("read_size", 10000)),
+            "query": self._build_chart_base_query(params),
+            "sort": [{"@timestamp": {"order": "asc"}}],
+            "__index": self._get_stream_name(params.get("retention_policy")),
+            "__openwisp_query_type": "raw_chart",
+            "__openwisp_fields": selected_fields,
+            "__openwisp_aggregate": False,
+        }
+
+    def validate_query(self, query) -> bool:
+        if not isinstance(query, Mapping):
+            raise ValidationError(
+                {"configuration": _("Elasticsearch queries must be dictionaries.")}
+            )
+        if not query:
+            return False
+        if self._is_openwisp_query(query):
+            return bool(query.get("aggregate", query.get("__openwisp_aggregate", True)))
+        validation_query = query.get("query", {"match_all": {}})
+        try:
+            response = self.db.indices.validate_query(
+                index=self._get_stream_name(),
+                body={"query": validation_query},
+                explain=True,
+            )
+        except Exception as exception:
+            if not self._is_not_found(exception):
+                raise
+            return self._is_aggregate(query)
+        response = self._response_body(response)
+        if not response.get("valid", False):
+            message = response.get("error") or _("Invalid Elasticsearch query")
+            raise ValidationError({"configuration": message})
+        return self._is_aggregate(query)
+
+    def _is_aggregate(self, query) -> bool:
+        if not isinstance(query, Mapping):
+            return False
+        if self._is_openwisp_query(query):
+            return bool(query.get("aggregate", query.get("__openwisp_aggregate", True)))
+        aggregations = query.get("aggs") or query.get("aggregations")
+        if not isinstance(aggregations, Mapping):
+            return False
+        return self._contains_aggregate(aggregations)
+
+    def _contains_aggregate(self, value) -> bool:
+        if isinstance(value, Mapping):
+            if any(key in self._AGGREGATE for key in value.keys()):
+                return True
+            return any(self._contains_aggregate(item) for item in value.values())
+        if isinstance(value, list):
+            return any(self._contains_aggregate(item) for item in value)
+        return False
+
+    def get_query(
+        self,
+        chart_type: str,
+        params: ChartQueryParams,
+        time: Any,
+        group_map: Mapping[Any, str],
+        summary: bool = False,
+        fields: Sequence[str] | None = None,
+        query: Mapping[str, Any] | None = None,
+        timezone: str | None = settings.TIME_ZONE,
+    ) -> Mapping[str, Any]:
+        if not query:
+            query = self.get_default_chart_query(
+                has_object_scope=bool(params.get("object_id"))
+            )
+        if self._is_openwisp_query(query, "chart"):
+            return self._build_chart_query(
+                query,
+                params,
+                time,
+                group_map,
+                summary=summary,
+                timezone=timezone,
+            )
+        if self._is_openwisp_query(query, "raw_chart"):
+            return self._build_raw_chart_query(query, params, fields=fields)
+        format_params = {
+            **params,
+            "time": params.get("time", time),
+            "window": group_map.get(time, time),
+            "timezone": timezone or "UTC",
+            "fields": ",".join(fields or []),
+        }
+        formatted_query = self._format_query_mapping(query, format_params)
+        if "index" not in formatted_query and "__index" not in formatted_query:
+            formatted_query["__index"] = self._get_stream_name(
+                params.get("retention_policy")
+            )
+        return formatted_query
+
+    def _get_top_fields(
+        self,
+        query: str | None,
+        params: ChartQueryParams,
+        chart_type: str,
+        group_map: Mapping[Any, str],
+        number: int,
+        time: Any,
+        timezone: str | None = settings.TIME_ZONE,
+    ) -> list[str]:
+        if number <= 0:
+            return []
+        search = {
+            "size": int(self.options.get("top_fields_read_size", 10000)),
+            "_source": ["fields"],
+            "query": self._build_chart_base_query(params),
+            "__index": self._get_stream_name(params.get("retention_policy")),
+        }
+        response = self.query(search, precision="s")
+        totals = {}
+        for hit in self._get_hits(response):
+            fields = (hit.get("_source") or {}).get("fields") or {}
+            for field, value in fields.items():
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    continue
+                totals[field] = totals.get(field, 0) + value
+        sorted_fields = sorted(totals.items(), key=lambda item: item[1], reverse=True)
+        return [field for field, _value in sorted_fields[:number]]
+
+    def _round_chart_value(self, value):
+        if value >= 0:
+            return float(int(value + 0.5))
+        return float(int(value - 0.5))
+
+    def _extract_chart_metric_value(self, aggregation, metric):
+        metric_aggregation = aggregation.get(metric["name"], {})
+        if metric.get("agg") == "mode":
+            buckets = metric_aggregation.get("buckets", [])
+            value = buckets[0]["key"] if buckets else None
+        else:
+            value = metric_aggregation.get("value")
+        if value is None:
+            return None
+        if metric.get("scale") is not None:
+            value *= metric["scale"]
+        if metric.get("round"):
+            value = self._round_chart_value(value)
+        return value
+
+    def _build_chart_point(self, aggregation, metrics, time_value=None):
+        point = {"time": time_value}
+        for metric in metrics:
+            point[metric["name"]] = self._extract_chart_metric_value(
+                aggregation, metric
+            )
+        return point
+
+    def _format_histogram_time(self, bucket, precision):
+        if "key" not in bucket:
+            return None
+        value = datetime.fromtimestamp(bucket["key"] / 1000, tz=timezone.utc)
+        return self._normalize_time(value, precision=precision)
+
+    def _get_chart_points(self, response, query, precision="s"):
+        metrics = query.get("__openwisp_metrics", [])
+        aggregations = response.get("aggregations", {})
+        if query.get("__openwisp_summary"):
+            return [self._build_chart_point(aggregations, metrics)]
+        buckets = aggregations.get("timeseries", {}).get("buckets", [])
+        return [
+            self._build_chart_point(
+                bucket,
+                metrics,
+                time_value=self._format_histogram_time(bucket, precision),
+            )
+            for bucket in buckets
+        ]
+
+    def get_list_query(
+        self, query: Mapping[str, Any], precision: str = "s"
+    ) -> list[TimeseriesPoint]:
+        if (
+            isinstance(query, Mapping)
+            and query.get("_openwisp_query_type") == "device_data"
+        ):
+            return self.read(
+                key=query["measurement"],
+                fields="data",
+                tags={"pk": query["pk"]},
+                retention_policy=query["retention_policy"],
+                limit=1,
+                order="-time",
+                precision=precision,
+            )
+        if self._is_openwisp_query(query, "chart"):
+            response = self.query(query, precision=precision)
+            return self._get_chart_points(response, query, precision=precision)
+        response = self.query(query, precision=precision)
+        fields = query.get("__openwisp_fields") if isinstance(query, Mapping) else None
+        return [
+            self._document_to_point(
+                hit.get("_source", {}),
+                fields=fields,
+                precision=precision,
+                include_tags=False,
+            )
+            for hit in self._get_hits(response)
+        ]
+
+    def get_device_data_query(
+        self,
+        retention_policy: str,
+        measurement: str,
+        pk: str,
+    ) -> Mapping[str, str]:
+        return {
+            "_openwisp_query_type": "device_data",
+            "retention_policy": retention_policy,
+            "measurement": measurement,
+            "pk": str(pk),
+        }
+
+    @retry
+    def _delete_by_query(self, query: Mapping[str, Any]) -> None:
+        refresh = self.refresh
+        if refresh == "wait_for":
+            refresh = True
+        for stream_name in self._get_data_stream_names():
+            try:
+                self.db.delete_by_query(
+                    index=stream_name,
+                    body={"query": query},
+                    conflicts="proceed",
+                    refresh=bool(refresh),
+                )
+            except Exception as exception:
+                if not self._is_not_found(exception):
+                    raise
+
+    @retry
+    def delete_series(
+        self, key: str | None = None, tags: TimeseriesTags | None = None
+    ) -> None:
+        if not key and not tags:
+            raise ValueError("delete_series requires at least one of key or tags")
+        self._delete_by_query(self._build_base_query(key=key, tags=tags))
+
+    def delete_metric_data(
+        self, key: str | None = None, tags: TimeseriesTags | None = None
+    ) -> None:
+        self._delete_by_query(self._build_base_query(key=key, tags=tags))

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
@@ -582,10 +583,42 @@ class DatabaseClient(BaseTimeseriesClient):
             )
         return sorted(policies, key=lambda item: (not item["default"], item["name"]))
 
-    def _get_timestamp(self, timestamp=None) -> str:
-        timestamp = timestamp or now()
+    def _get_timezone(self, timezone_name=None):
+        if not timezone_name:
+            return timezone.utc
+        try:
+            return ZoneInfo(str(timezone_name))
+        except Exception:
+            return timezone.utc
+
+    def _parse_timestamp(self, timestamp):
         if isinstance(timestamp, datetime):
-            return timestamp.isoformat()
+            return timestamp
+        if not isinstance(timestamp, str):
+            return None
+        parsed = parse_datetime(timestamp)
+        if parsed is not None:
+            return parsed
+        if "T" not in timestamp and " " in timestamp:
+            timestamp = timestamp.replace(" ", "T", 1)
+            parsed = parse_datetime(timestamp)
+            if parsed is not None:
+                return parsed
+        return None
+
+    def _serialize_timestamp(self, timestamp, timezone_name=None):
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=self._get_timezone(timezone_name))
+        timestamp = timestamp.astimezone(timezone.utc)
+        return timestamp.isoformat().replace("+00:00", "Z")
+
+    def _get_timestamp(self, timestamp=None, timezone_name=None) -> str:
+        timestamp = timestamp or now()
+        parsed_timestamp = self._parse_timestamp(timestamp)
+        if parsed_timestamp is not None:
+            return self._serialize_timestamp(
+                parsed_timestamp, timezone_name=timezone_name
+            )
         return timestamp
 
     def _normalize_time(self, value, precision="s"):
@@ -645,9 +678,9 @@ class DatabaseClient(BaseTimeseriesClient):
     def write(self, name: str, values: TimeseriesFields, **kwargs: Any) -> None:
         self._check_database_kwarg(kwargs.get("database"))
         retention_policy = kwargs.get("retention_policy")
+        self._ensure_data_stream_resources(retention_policy)
+        document = self._build_document(name, values, **kwargs)
         try:
-            self._ensure_data_stream_resources(retention_policy)
-            document = self._build_document(name, values, **kwargs)
             self.db.index(
                 index=self._get_stream_name(retention_policy),
                 document=document,
@@ -658,27 +691,36 @@ class DatabaseClient(BaseTimeseriesClient):
             self._handle_write_exception(exception)
 
     def batch_write(self, metric_data: Sequence[BatchWritePayload]) -> None:
-        try:
-            actions = []
-            for data in metric_data:
-                self._check_database_kwarg(data.get("database"))
-                retention_policy = data.get("retention_policy")
+        actions = []
+        ensured_retention_policies = set()
+        checked_databases = set()
+        for data in metric_data:
+            database = data.get("database")
+            if database not in checked_databases:
+                self._check_database_kwarg(database)
+                checked_databases.add(database)
+            retention_policy = data.get("retention_policy")
+            if retention_policy not in ensured_retention_policies:
                 self._ensure_data_stream_resources(retention_policy)
-                actions.append(
-                    {
-                        "_op_type": "create",
-                        "_index": self._get_stream_name(retention_policy),
-                        "_source": self._build_document(
-                            data.get("name"),
-                            data.get("values"),
-                            tags=data.get("tags"),
-                            timestamp=data.get("timestamp"),
-                        ),
-                    }
-                )
-            if not actions:
-                return
-            bulk(self.db, actions, refresh=self.refresh)
+                ensured_retention_policies.add(retention_policy)
+            actions.append(
+                {
+                    "_op_type": "create",
+                    "_index": self._get_stream_name(retention_policy),
+                    "_source": self._build_document(
+                        data.get("name"),
+                        data.get("values"),
+                        tags=data.get("tags"),
+                        timestamp=data.get("timestamp"),
+                    ),
+                }
+            )
+        if not actions:
+            return
+        try:
+            bulk(
+                self.db, actions, refresh=self.refresh
+            )  # https://elasticsearch-py.readthedocs.io/en/v8.12.1/helpers.html#bulk-helpers
         except Exception as exception:
             self._handle_write_exception(exception)
 
@@ -924,16 +966,20 @@ class DatabaseClient(BaseTimeseriesClient):
             return {"terms": {tag_field: values}}
         return {"term": {tag_field: str(value)}}
 
-    def _build_chart_base_query(self, params):
+    def _build_chart_base_query(self, params, timezone_name=None):
         filters = []
         measurement_filter = self._build_measurement_filter(params.get("key"))
         if measurement_filter:
             filters.append(measurement_filter)
         time_filter = {}
         if params.get("time"):
-            time_filter["gte"] = self._get_timestamp(params["time"])
+            time_filter["gte"] = self._get_timestamp(
+                params["time"], timezone_name=timezone_name
+            )
         if params.get("end_date"):
-            time_filter["lte"] = self._get_timestamp(params["end_date"])
+            time_filter["lte"] = self._get_timestamp(
+                params["end_date"], timezone_name=timezone_name
+            )
         if time_filter:
             filters.append({"range": {"@timestamp": time_filter}})
         for field in self._CHART_FILTERS:
@@ -980,7 +1026,7 @@ class DatabaseClient(BaseTimeseriesClient):
         metrics = self._format_chart_metrics(query, params)
         body = {
             "size": 0,
-            "query": self._build_chart_base_query(params),
+            "query": self._build_chart_base_query(params, timezone_name=timezone),
             "__index": self._get_stream_name(params.get("retention_policy")),
             "__openwisp_query_type": "chart",
             "__openwisp_metrics": metrics,
@@ -1014,11 +1060,11 @@ class DatabaseClient(BaseTimeseriesClient):
             return ["*"]
         return [field]
 
-    def _build_raw_chart_query(self, query, params, fields=None):
+    def _build_raw_chart_query(self, query, params, fields=None, timezone=None):
         selected_fields = self._normalize_raw_chart_fields(query, params, fields)
         return {
             "size": int(self.options.get("read_size", 10000)),
-            "query": self._build_chart_base_query(params),
+            "query": self._build_chart_base_query(params, timezone_name=timezone),
             "sort": [{"@timestamp": {"order": "asc"}}],
             "__index": self._get_stream_name(params.get("retention_policy")),
             "__openwisp_query_type": "raw_chart",
@@ -1096,7 +1142,9 @@ class DatabaseClient(BaseTimeseriesClient):
                 timezone=timezone,
             )
         if self._is_openwisp_query(query, "raw_chart"):
-            return self._build_raw_chart_query(query, params, fields=fields)
+            return self._build_raw_chart_query(
+                query, params, fields=fields, timezone=timezone
+            )
         format_params = {
             **params,
             "time": params.get("time", time),
@@ -1126,7 +1174,7 @@ class DatabaseClient(BaseTimeseriesClient):
         search = {
             "size": int(self.options.get("top_fields_read_size", 10000)),
             "_source": ["fields"],
-            "query": self._build_chart_base_query(params),
+            "query": self._build_chart_base_query(params, timezone_name=timezone),
             "__index": self._get_stream_name(params.get("retention_policy")),
         }
         response = self.query(search, precision="s")

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -1016,17 +1016,32 @@ class DatabaseClient(BaseTimeseriesClient):
             "__retention_policy": retention_policy,
             "size": int(self.options.get("read_size", 10000)),
         }
+        where_fields = [condition[0] for condition in where]
+        projection_fields = fields
+        filter_only_fields = set()
+        if fields != ["*"]:
+            projection_fields = list(dict.fromkeys([*fields, *where_fields]))
+            filter_only_fields = set(where_fields) - set(fields)
         response = self.query(query, precision=precision)
         points = [
             self._document_to_point(
                 hit.get("_source", {}),
-                fields=fields,
+                fields=projection_fields,
                 precision=precision,
                 include_tags=False,
             )
             for hit in self._get_hits(response)
         ]
         points = self._filter_points(self._merge_points_by_time(points), where)
+        if filter_only_fields:
+            points = [
+                {
+                    field: value
+                    for field, value in point.items()
+                    if field not in filter_only_fields
+                }
+                for point in points
+            ]
         return points[: int(limit)] if limit else points
 
     def _format_query_mapping(self, value, params):
@@ -1084,8 +1099,14 @@ class DatabaseClient(BaseTimeseriesClient):
             return {"match_all": {}}
         return {"bool": {"filter": filters}}
 
-    def _normalize_chart_window(self, time, group_map):
-        return str(group_map.get(time, time) or "1d")
+    def _normalize_chart_window(self, time_value, group_map=None):
+        if group_map and time_value in group_map:
+            return group_map[time_value]
+        if isinstance(time_value, (int, float)):
+            return f"{max(int(time_value), 1)}m"
+        if isinstance(time_value, str) and re.fullmatch(r"\d+", time_value):
+            return f"{max(int(time_value), 1)}m"
+        return time_value
 
     def _format_chart_metrics(self, query, params, fields=None):
         format_params = {**params}

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -207,6 +207,9 @@ class DatabaseClient(BaseTimeseriesClient):
     _DEFAULT_ROLLOVER_SECONDS = 30 * 24 * 60 * 60
     _PIT_KEEP_ALIVE = "1m"
     _DISTINCT_PAGE_SIZE = 1000
+    # highest precision supported by the cardinality aggregation,
+    # counts below this threshold are exact
+    _CARDINALITY_PRECISION = 40000
     # Wins over broad external templates that may also match OpenWISP streams.
     _OPENWISP_INDEX_TEMPLATE_PRIORITY = 500
     _RESOURCE_METADATA_KEY = "openwisp_monitoring"
@@ -1094,6 +1097,7 @@ class DatabaseClient(BaseTimeseriesClient):
         tags: TimeseriesTags | None = None,
         since=None,
         where: Sequence[Sequence[Any]] | None = None,
+        timestamp=None,
     ) -> dict[str, Any]:
         filters = []
         measurement_filter = self._build_measurement_filter(key) if key else None
@@ -1102,6 +1106,18 @@ class DatabaseClient(BaseTimeseriesClient):
         if since:
             filters.append(
                 {"range": {"@timestamp": {"gte": self._get_timestamp(since)}}}
+            )
+        if timestamp is not None:
+            serialized_timestamp = self._get_timestamp(timestamp)
+            filters.append(
+                {
+                    "range": {
+                        "@timestamp": {
+                            "gte": serialized_timestamp,
+                            "lte": serialized_timestamp,
+                        }
+                    }
+                }
             )
         if tags:
             for tag_key, tag_value in tags.items():
@@ -1310,11 +1326,11 @@ class DatabaseClient(BaseTimeseriesClient):
         return current_type == query_type
 
     def _build_tag_filter(self, field, value):
-        if value in (None, "", "__all__"):
+        if value in (None, ""):
             return None
         tag_field = f"tags.{field}"
         if isinstance(value, (list, tuple)):
-            values = [str(item) for item in value if item != "__all__"]
+            values = [str(item) for item in value]
             if not values:
                 return None
             return {"terms": {tag_field: values}}
@@ -1367,20 +1383,44 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _build_metric_aggregation(self, metric):
         aggregation = metric.get("agg", "avg")
-        field_type = "keyword" if aggregation == "cardinality" else "numeric"
-        field = self._get_indexed_field_path(metric["field"], field_type)
+        field = self._get_metric_field_path(metric)
         if aggregation == "sum":
             metric_aggregation = {"sum": {"field": field}}
         elif aggregation == "cardinality":
-            metric_aggregation = {"cardinality": {"field": field}}
+            metric_aggregation = {
+                "cardinality": {
+                    "field": field,
+                    "precision_threshold": self._CARDINALITY_PRECISION,
+                }
+            }
         elif aggregation == "mode":
             metric_aggregation = {"terms": {"field": field, "size": 1}}
+        elif aggregation == "last":
+            metric_aggregation = {
+                "top_metrics": {
+                    "metrics": {"field": field},
+                    "sort": [
+                        {"@timestamp": "desc"},
+                        {
+                            "openwisp_write_sequence": {
+                                "order": "desc",
+                                "unmapped_type": "long",
+                            }
+                        },
+                    ],
+                }
+            }
         else:
             metric_aggregation = {"avg": {"field": field}}
         return {
             "filter": {"exists": {"field": field}},
             "aggs": {"value": metric_aggregation},
         }
+
+    @classmethod
+    def _get_metric_field_path(cls, metric):
+        field_type = "keyword" if metric.get("agg") == "cardinality" else "numeric"
+        return cls._get_indexed_field_path(metric["field"], field_type)
 
     def _build_metric_aggregations(self, metrics):
         return {
@@ -1448,11 +1488,7 @@ class DatabaseClient(BaseTimeseriesClient):
     ):
         metric = self._format_query_mapping(query["metric"], params)
         group_by = query["group_by"]
-        base_params = {
-            key: value
-            for key, value in params.items()
-            if key not in ("content_type", "object_id", group_by)
-        }
+        base_params = {key: value for key, value in params.items() if key != group_by}
         body = {
             "size": 0,
             "query": self._build_chart_base_query(base_params, timezone_name=timezone),
@@ -1462,6 +1498,7 @@ class DatabaseClient(BaseTimeseriesClient):
             "__openwisp_group_by": group_by,
             "__openwisp_summary": summary,
             "__openwisp_cumulative": bool(query.get("cumulative")),
+            "__openwisp_fill": query.get("fill"),
             "__openwisp_aggregate": True,
         }
         group_aggs = {
@@ -1682,6 +1719,13 @@ class DatabaseClient(BaseTimeseriesClient):
         if metric.get("agg") == "mode":
             buckets = metric_aggregation.get("buckets", [])
             value = buckets[0]["key"] if buckets else None
+        elif metric.get("agg") == "last":
+            rows = metric_aggregation.get("top", [])
+            value = (
+                rows[0].get("metrics", {}).get(self._get_metric_field_path(metric))
+                if rows
+                else None
+            )
         else:
             value = metric_aggregation.get("value")
         if value is None:
@@ -1786,6 +1830,8 @@ class DatabaseClient(BaseTimeseriesClient):
                 point[bucket["key"]] = self._extract_grouped_chart_value(bucket, metric)
             return [point]
         totals = {}
+        previous_values = {}
+        fill_previous = query.get("__openwisp_fill") == "previous"
         points = []
         for bucket in aggregations.get("timeseries", {}).get("buckets", []):
             point = {"time": self._format_histogram_time(bucket, precision)}
@@ -1796,6 +1842,13 @@ class DatabaseClient(BaseTimeseriesClient):
                     totals[key] = totals.get(key, 0) + (value or 0)
                     value = totals[key]
                 point[key] = value
+            if fill_previous:
+                for key, value in point.items():
+                    if key != "time" and value is not None:
+                        previous_values[key] = value
+                for key, value in previous_values.items():
+                    if point.get(key) is None:
+                        point[key] = value
             if len(point) > 1:
                 points.append(point)
         return points
@@ -1933,6 +1986,16 @@ class DatabaseClient(BaseTimeseriesClient):
         self._delete_by_query(self._build_base_query(key=key, tags=tags))
 
     def delete_metric_data(
-        self, key: str | None = None, tags: TimeseriesTags | None = None
+        self,
+        key: str | None = None,
+        tags: TimeseriesTags | None = None,
+        timestamp: Any = None,
     ) -> None:
-        self._delete_by_query(self._build_base_query(key=key, tags=tags))
+        """Deletes metric data based on measurement and tags.
+
+        If ``timestamp`` is passed, only the data written at that specific
+        time is deleted.
+        """
+        self._delete_by_query(
+            self._build_base_query(key=key, tags=tags, timestamp=timestamp)
+        )

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -1399,15 +1399,7 @@ class DatabaseClient(BaseTimeseriesClient):
             metric_aggregation = {
                 "top_metrics": {
                     "metrics": {"field": field},
-                    "sort": [
-                        {"@timestamp": "desc"},
-                        {
-                            "openwisp_write_sequence": {
-                                "order": "desc",
-                                "unmapped_type": "long",
-                            }
-                        },
-                    ],
+                    "sort": {"@timestamp": "desc"},
                 }
             }
         else:

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -1488,7 +1488,12 @@ class DatabaseClient(BaseTimeseriesClient):
     ):
         metric = self._format_query_mapping(query["metric"], params)
         group_by = query["group_by"]
-        base_params = {key: value for key, value in params.items() if key != group_by}
+        excluded_params = {group_by}
+        if not query.get("object_scope", True):
+            excluded_params.update(("content_type", "object_id"))
+        base_params = {
+            key: value for key, value in params.items() if key not in excluded_params
+        }
         body = {
             "size": 0,
             "query": self._build_chart_base_query(base_params, timezone_name=timezone),

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -1022,6 +1022,7 @@ class DatabaseClient(BaseTimeseriesClient):
                 hit.get("_source", {}),
                 fields=fields,
                 precision=precision,
+                include_tags=False,
             )
             for hit in self._get_hits(response)
         ]
@@ -1401,6 +1402,15 @@ class DatabaseClient(BaseTimeseriesClient):
             )
         return point
 
+    @staticmethod
+    def _has_chart_values(points, metrics):
+        metric_names = [metric["name"] for metric in metrics]
+        return any(
+            point.get(metric_name) is not None
+            for point in points
+            for metric_name in metric_names
+        )
+
     def _format_histogram_time(self, bucket, precision):
         if "key" not in bucket:
             return None
@@ -1411,9 +1421,12 @@ class DatabaseClient(BaseTimeseriesClient):
         metrics = query.get("__openwisp_metrics", [])
         aggregations = response.get("aggregations", {})
         if query.get("__openwisp_summary"):
-            return [self._build_chart_point(aggregations, metrics)]
+            point = self._build_chart_point(aggregations, metrics)
+            if not self._has_chart_values([point], metrics):
+                return []
+            return [point]
         buckets = aggregations.get("timeseries", {}).get("buckets", [])
-        return [
+        points = [
             self._build_chart_point(
                 bucket,
                 metrics,
@@ -1421,6 +1434,9 @@ class DatabaseClient(BaseTimeseriesClient):
             )
             for bucket in buckets
         ]
+        if not self._has_chart_values(points, metrics):
+            return []
+        return points
 
     def _extract_grouped_chart_value(self, bucket, metric):
         return self._extract_chart_metric_value(

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -3,6 +3,9 @@ import re
 from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime, timezone
+from hashlib import sha1
+from itertools import count
+from json import dumps
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -224,6 +227,13 @@ class DatabaseClient(BaseTimeseriesClient):
     def __init__(self, db_name: str | None = None) -> None:
         self.db_name = db_name or TIMESERIES_DB["NAME"]
         self._ensured_streams = set()
+        self._write_sequence = count()
+
+    def reset(self, db_name: str | None = None) -> None:
+        super().reset(db_name=db_name)
+        self.__dict__.pop("db", None)
+        self._ensured_streams = set()
+        self._write_sequence = count()
 
     @property
     def use_udp(self) -> bool:
@@ -366,7 +376,13 @@ class DatabaseClient(BaseTimeseriesClient):
                 "settings": {
                     "index.mode": "time_series",
                     "index.lifecycle.name": self._get_policy_name(retention_policy),
-                    "index.routing_path": ["measurement", "tags.*"],
+                    "index.look_ahead_time": self.options.get("look_ahead_time", "2h"),
+                    "index.look_back_time": self.options.get("look_back_time", "7d"),
+                    "index.routing_path": [
+                        "measurement",
+                        "openwisp_series_id",
+                        "tags.*",
+                    ],
                 },
                 "mappings": {
                     "dynamic": True,
@@ -418,7 +434,15 @@ class DatabaseClient(BaseTimeseriesClient):
                             "type": "keyword",
                             "time_series_dimension": True,
                         },
+                        "openwisp_series_id": {
+                            "type": "keyword",
+                            "time_series_dimension": True,
+                        },
                         "openwisp_doc_count": {
+                            "type": "long",
+                            "time_series_metric": "gauge",
+                        },
+                        "openwisp_write_sequence": {
                             "type": "long",
                             "time_series_metric": "gauge",
                         },
@@ -466,6 +490,8 @@ class DatabaseClient(BaseTimeseriesClient):
             except Exception as exception:
                 if not self._is_resource_exists(exception):
                     raise
+                if not self._data_stream_exists(stream_name):
+                    raise
         self._ensured_streams.add(cache_key)
 
     @retry
@@ -481,6 +507,7 @@ class DatabaseClient(BaseTimeseriesClient):
             except Exception as exception:
                 if not self._is_not_found(exception):
                     raise
+        self._delete_indices()
         self._delete_index_templates()
         self._delete_lifecycle_policies()
         self._ensured_streams = set()
@@ -499,6 +526,31 @@ class DatabaseClient(BaseTimeseriesClient):
             for stream in response.get("data_streams", [])
             if self._is_own_stream(stream["name"])
         ]
+
+    def _get_index_names(self) -> list[str]:
+        try:
+            response = self.db.indices.get(
+                index=f"{self.db_name}*",
+                expand_wildcards="open,closed",
+            )
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return []
+            raise
+        response = self._response_body(response)
+        return [
+            index_name
+            for index_name in response.keys()
+            if self._is_own_stream(index_name)
+        ]
+
+    def _delete_indices(self) -> None:
+        for index_name in self._get_index_names():
+            try:
+                self.db.indices.delete(index=index_name)
+            except Exception as exception:
+                if not self._is_not_found(exception):
+                    raise
 
     def _delete_index_templates(self) -> None:
         try:
@@ -561,7 +613,9 @@ class DatabaseClient(BaseTimeseriesClient):
     def get_list_retention_policies(self) -> list[TimeseriesPoint]:
         policies = []
         for policy_name in self._get_lifecycle_policy_names():
-            retention_policy = policy_name[len(self.db_name) + 1 : -len("-ilm")]
+            start = len(self.db_name) + 1
+            end = -len("-ilm")
+            retention_policy = policy_name[start:end]
             try:
                 body = self.db.ilm.get_lifecycle(name=policy_name)
             except Exception as exception:
@@ -613,7 +667,8 @@ class DatabaseClient(BaseTimeseriesClient):
         return timestamp.isoformat().replace("+00:00", "Z")
 
     def _get_timestamp(self, timestamp=None, timezone_name=None) -> str:
-        timestamp = timestamp or now()
+        if timestamp is None:
+            timestamp = now()
         parsed_timestamp = self._parse_timestamp(timestamp)
         if parsed_timestamp is not None:
             return self._serialize_timestamp(
@@ -663,12 +718,16 @@ class DatabaseClient(BaseTimeseriesClient):
             )
 
     def _build_document(self, name, values, **kwargs) -> dict[str, Any]:
+        values = dict(values or {})
+        series_payload = dumps(values, sort_keys=True, default=str)
         return {
             "@timestamp": self._get_timestamp(kwargs.get("timestamp")),
             "measurement": name,
+            "openwisp_series_id": sha1(series_payload.encode()).hexdigest(),
             "openwisp_doc_count": 1,
+            "openwisp_write_sequence": next(self._write_sequence),
             "tags": dict(kwargs.get("tags") or {}),
-            "fields": dict(values or {}),
+            "fields": values,
         }
 
     def _handle_write_exception(self, exception) -> None:
@@ -718,9 +777,7 @@ class DatabaseClient(BaseTimeseriesClient):
         if not actions:
             return
         try:
-            bulk(
-                self.db, actions, refresh=self.refresh
-            )  # https://elasticsearch-py.readthedocs.io/en/v8.12.1/helpers.html#bulk-helpers
+            bulk(self.db, actions, refresh=self.refresh)
         except Exception as exception:
             self._handle_write_exception(exception)
 
@@ -785,6 +842,61 @@ class DatabaseClient(BaseTimeseriesClient):
         range_operator = {">": "gt", ">=": "gte", "<": "lt", "<=": "lte"}[op]
         return {"range": {field_name: {range_operator: value}}}
 
+    def _build_field_exists_filter(self, fields):
+        if not fields or fields == ["*"]:
+            return None
+        fields = [field for field in fields if field != "*"]
+        if not fields:
+            return None
+        filters = [{"exists": {"field": f"fields.{field}"}} for field in fields]
+        if len(filters) == 1:
+            return filters[0]
+        return {"bool": {"should": filters, "minimum_should_match": 1}}
+
+    def _add_filter(self, query, filter_query):
+        if not filter_query:
+            return query
+        if query == {"match_all": {}}:
+            return {"bool": {"filter": [filter_query]}}
+        query = deepcopy(query)
+        query.setdefault("bool", {}).setdefault("filter", []).append(filter_query)
+        return query
+
+    def _get_read_exists_fields(self, fields, where):
+        if fields == ["*"]:
+            exists_fields = []
+        else:
+            exists_fields = list(fields)
+        exists_fields.extend(condition[0] for condition in where)
+        if not exists_fields:
+            return ["*"]
+        return list(dict.fromkeys(exists_fields))
+
+    def _matches_where(self, point, where):
+        for field, op, value in where:
+            op = self._clean_operator(op)
+            point_value = point.get(field)
+            if point_value is None:
+                return False
+            if op == "=" and point_value != value:
+                return False
+            if op == "!=" and point_value == value:
+                return False
+            if op == ">" and not point_value > value:
+                return False
+            if op == ">=" and not point_value >= value:
+                return False
+            if op == "<" and not point_value < value:
+                return False
+            if op == "<=" and not point_value <= value:
+                return False
+        return True
+
+    def _filter_points(self, points, where):
+        if not where:
+            return points
+        return [point for point in points if self._matches_where(point, where)]
+
     def _build_base_query(
         self,
         key: str | None = None,
@@ -817,10 +929,10 @@ class DatabaseClient(BaseTimeseriesClient):
         precision: str | None = "s",
         include_tags: bool = True,
     ) -> TimeseriesPoint:
+        timestamp = document.get("@timestamp")
         point = {
-            "time": self._normalize_time(
-                document.get("@timestamp"), precision=precision
-            )
+            "time": self._normalize_time(timestamp, precision=precision),
+            "__openwisp_time_key": timestamp,
         }
         if include_tags:
             point.update(document.get("tags") or {})
@@ -901,9 +1013,15 @@ class DatabaseClient(BaseTimeseriesClient):
         fields = self._normalize_fields(fields, kwargs.get("extra_fields"))
         order = kwargs.get("order") or kwargs.get("order_by")
         if order in (None, "time"):
-            sort = [{"@timestamp": {"order": "asc"}}]
+            sort = [
+                {"@timestamp": {"order": "asc"}},
+                {"openwisp_write_sequence": {"order": "asc", "unmapped_type": "long"}},
+            ]
         elif order == "-time":
-            sort = [{"@timestamp": {"order": "desc"}}]
+            sort = [
+                {"@timestamp": {"order": "desc"}},
+                {"openwisp_write_sequence": {"order": "asc", "unmapped_type": "long"}},
+            ]
         else:
             message = _(
                 'Invalid order "%(order)s" passed.\n'
@@ -912,21 +1030,22 @@ class DatabaseClient(BaseTimeseriesClient):
             ) % {"order": order}
             raise self.client_error(message)
         query = {
-            "query": self._build_base_query(
-                key=key,
-                tags=tags,
-                since=kwargs.get("since"),
-                where=where,
+            "query": self._add_filter(
+                self._build_base_query(
+                    key=key,
+                    tags=tags,
+                    since=kwargs.get("since"),
+                ),
+                self._build_field_exists_filter(
+                    self._get_read_exists_fields(fields, where)
+                ),
             ),
             "sort": sort,
             "__retention_policy": retention_policy,
+            "size": int(self.options.get("read_size", 10000)),
         }
-        if limit:
-            query["size"] = int(limit)
-        else:
-            query["size"] = int(self.options.get("read_size", 10000))
         response = self.query(query, precision=precision)
-        return [
+        points = [
             self._document_to_point(
                 hit.get("_source", {}),
                 fields=fields,
@@ -934,6 +1053,8 @@ class DatabaseClient(BaseTimeseriesClient):
             )
             for hit in self._get_hits(response)
         ]
+        points = self._filter_points(self._merge_points_by_time(points), where)
+        return points[: int(limit)] if limit else points
 
     def _format_query_mapping(self, value, params):
         if isinstance(value, str):
@@ -993,21 +1114,34 @@ class DatabaseClient(BaseTimeseriesClient):
     def _normalize_chart_window(self, time, group_map):
         return str(group_map.get(time, time) or "1d")
 
-    def _format_chart_metrics(self, query, params):
+    def _format_chart_metrics(self, query, params, fields=None):
         format_params = {**params}
         metrics = self._format_query_mapping(query.get("metrics", []), format_params)
+        if fields:
+            selected_fields = set(fields)
+            metrics = [
+                metric
+                for metric in metrics
+                if metric.get("field") in selected_fields
+                or metric.get("name") in selected_fields
+            ]
         return [metric for metric in metrics if metric.get("field")]
 
     def _build_metric_aggregation(self, metric):
         field = f"fields.{metric['field']}"
         aggregation = metric.get("agg", "avg")
         if aggregation == "sum":
-            return {"sum": {"field": field}}
-        if aggregation == "cardinality":
-            return {"cardinality": {"field": field}}
-        if aggregation == "mode":
-            return {"terms": {"field": field, "size": 1}}
-        return {"avg": {"field": field}}
+            metric_aggregation = {"sum": {"field": field}}
+        elif aggregation == "cardinality":
+            metric_aggregation = {"cardinality": {"field": field}}
+        elif aggregation == "mode":
+            metric_aggregation = {"terms": {"field": field, "size": 1}}
+        else:
+            metric_aggregation = {"avg": {"field": field}}
+        return {
+            "filter": {"exists": {"field": field}},
+            "aggs": {"value": metric_aggregation},
+        }
 
     def _build_metric_aggregations(self, metrics):
         return {
@@ -1022,8 +1156,9 @@ class DatabaseClient(BaseTimeseriesClient):
         group_map,
         summary=False,
         timezone=None,
+        fields=None,
     ):
-        metrics = self._format_chart_metrics(query, params)
+        metrics = self._format_chart_metrics(query, params, fields=fields)
         body = {
             "size": 0,
             "query": self._build_chart_base_query(params, timezone_name=timezone),
@@ -1042,12 +1177,73 @@ class DatabaseClient(BaseTimeseriesClient):
             "fixed_interval": self._normalize_chart_window(time, group_map),
             "min_doc_count": 0,
         }
+        if params.get("time"):
+            histogram["extended_bounds"] = {
+                "min": self._get_timestamp(params["time"], timezone_name=timezone),
+                "max": self._get_timestamp(
+                    params.get("end_date") or now(), timezone_name=timezone
+                ),
+            }
         if timezone:
             histogram["time_zone"] = timezone
         body["aggs"] = {
             "timeseries": {
                 "date_histogram": histogram,
                 "aggs": metric_aggs,
+            }
+        }
+        return body
+
+    def _build_grouped_chart_query(
+        self,
+        query,
+        params,
+        time,
+        group_map,
+        summary=False,
+        timezone=None,
+    ):
+        metric = self._format_query_mapping(query["metric"], params)
+        group_by = query["group_by"]
+        base_params = {
+            key: value
+            for key, value in params.items()
+            if key not in ("content_type", "object_id", group_by)
+        }
+        body = {
+            "size": 0,
+            "query": self._build_chart_base_query(base_params, timezone_name=timezone),
+            "__index": self._get_stream_name(params.get("retention_policy")),
+            "__openwisp_query_type": "grouped_chart",
+            "__openwisp_metric": metric,
+            "__openwisp_group_by": group_by,
+            "__openwisp_summary": summary,
+            "__openwisp_cumulative": bool(query.get("cumulative")),
+            "__openwisp_aggregate": True,
+        }
+        group_aggs = {
+            "groups": {
+                "terms": {
+                    "field": f"tags.{group_by}",
+                    "size": int(self.options.get("terms_size", 1000)),
+                },
+                "aggs": {"value": self._build_metric_aggregation(metric)},
+            }
+        }
+        if summary:
+            body["aggs"] = group_aggs
+            return body
+        histogram = {
+            "field": "@timestamp",
+            "fixed_interval": self._normalize_chart_window(time, group_map),
+            "min_doc_count": 0,
+        }
+        if timezone:
+            histogram["time_zone"] = timezone
+        body["aggs"] = {
+            "timeseries": {
+                "date_histogram": histogram,
+                "aggs": group_aggs,
             }
         }
         return body
@@ -1064,7 +1260,10 @@ class DatabaseClient(BaseTimeseriesClient):
         selected_fields = self._normalize_raw_chart_fields(query, params, fields)
         return {
             "size": int(self.options.get("read_size", 10000)),
-            "query": self._build_chart_base_query(params, timezone_name=timezone),
+            "query": self._add_filter(
+                self._build_chart_base_query(params, timezone_name=timezone),
+                self._build_field_exists_filter(selected_fields),
+            ),
             "sort": [{"@timestamp": {"order": "asc"}}],
             "__index": self._get_stream_name(params.get("retention_policy")),
             "__openwisp_query_type": "raw_chart",
@@ -1140,6 +1339,16 @@ class DatabaseClient(BaseTimeseriesClient):
                 group_map,
                 summary=summary,
                 timezone=timezone,
+                fields=fields,
+            )
+        if self._is_openwisp_query(query, "grouped_chart"):
+            return self._build_grouped_chart_query(
+                query,
+                params,
+                time,
+                group_map,
+                summary=summary,
+                timezone=timezone,
             )
         if self._is_openwisp_query(query, "raw_chart"):
             return self._build_raw_chart_query(
@@ -1195,6 +1404,10 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _extract_chart_metric_value(self, aggregation, metric):
         metric_aggregation = aggregation.get(metric["name"], {})
+        if "doc_count" in metric_aggregation:
+            if metric_aggregation["doc_count"] == 0:
+                return None
+            metric_aggregation = metric_aggregation.get("value", {})
         if metric.get("agg") == "mode":
             buckets = metric_aggregation.get("buckets", [])
             value = buckets[0]["key"] if buckets else None
@@ -1237,6 +1450,51 @@ class DatabaseClient(BaseTimeseriesClient):
             for bucket in buckets
         ]
 
+    def _extract_grouped_chart_value(self, bucket, metric):
+        return self._extract_chart_metric_value(
+            {"value": bucket.get("value", {})}, metric
+        )
+
+    def _get_grouped_chart_points(self, response, query, precision="s"):
+        aggregations = response.get("aggregations", {})
+        metric = query["__openwisp_metric"]
+        if query.get("__openwisp_summary"):
+            point = {"time": None}
+            for bucket in aggregations.get("groups", {}).get("buckets", []):
+                point[bucket["key"]] = self._extract_grouped_chart_value(bucket, metric)
+            return [point]
+        totals = {}
+        points = []
+        for bucket in aggregations.get("timeseries", {}).get("buckets", []):
+            point = {"time": self._format_histogram_time(bucket, precision)}
+            for group_bucket in bucket.get("groups", {}).get("buckets", []):
+                value = self._extract_grouped_chart_value(group_bucket, metric)
+                key = group_bucket["key"]
+                if query.get("__openwisp_cumulative"):
+                    totals[key] = totals.get(key, 0) + (value or 0)
+                    value = totals[key]
+                point[key] = value
+            if len(point) > 1:
+                points.append(point)
+        return points
+
+    def _merge_points_by_time(self, points):
+        merged = {}
+        order = []
+        for point in points:
+            time_key = point.get("__openwisp_time_key", point.get("time"))
+            if time_key not in merged:
+                merged[time_key] = {"time": point.get("time")}
+                order.append(time_key)
+            merged[time_key].update(
+                {
+                    key: value
+                    for key, value in point.items()
+                    if key not in ("time", "__openwisp_time_key")
+                }
+            )
+        return [merged[time_key] for time_key in order]
+
     def get_list_query(
         self, query: Mapping[str, Any], precision: str = "s"
     ) -> list[TimeseriesPoint]:
@@ -1256,9 +1514,12 @@ class DatabaseClient(BaseTimeseriesClient):
         if self._is_openwisp_query(query, "chart"):
             response = self.query(query, precision=precision)
             return self._get_chart_points(response, query, precision=precision)
+        if self._is_openwisp_query(query, "grouped_chart"):
+            response = self.query(query, precision=precision)
+            return self._get_grouped_chart_points(response, query, precision=precision)
         response = self.query(query, precision=precision)
         fields = query.get("__openwisp_fields") if isinstance(query, Mapping) else None
-        return [
+        points = [
             self._document_to_point(
                 hit.get("_source", {}),
                 fields=fields,
@@ -1267,6 +1528,7 @@ class DatabaseClient(BaseTimeseriesClient):
             )
             for hit in self._get_hits(response)
         ]
+        return self._merge_points_by_time(points)
 
     def get_device_data_query(
         self,
@@ -1286,7 +1548,7 @@ class DatabaseClient(BaseTimeseriesClient):
         refresh = self.refresh
         if refresh == "wait_for":
             refresh = True
-        for stream_name in self._get_data_stream_names():
+        for stream_name in self._get_data_stream_names() + self._get_index_names():
             try:
                 self.db.delete_by_query(
                     index=stream_name,

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from itertools import count
 from typing import Any
+from urllib.parse import urlparse
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
@@ -205,6 +206,7 @@ class DatabaseClient(BaseTimeseriesClient):
     _DURATION_PART_PATTERN = re.compile(r"(\d+)([smhdw])")
     _DEFAULT_ROLLOVER_SECONDS = 30 * 24 * 60 * 60
     _PIT_KEEP_ALIVE = "1m"
+    _DISTINCT_PAGE_SIZE = 1000
     # Wins over broad external templates that may also match OpenWISP streams.
     _OPENWISP_INDEX_TEMPLATE_PRIORITY = 500
     _RESOURCE_METADATA_KEY = "openwisp_monitoring"
@@ -257,12 +259,25 @@ class DatabaseClient(BaseTimeseriesClient):
         )
         self._write_sequence = count()
 
+    def _close_cached_client(self) -> None:
+        client = self.__dict__.get("db")
+        close = getattr(client, "close", None)
+        try:
+            if callable(close):
+                close()
+        except Exception as exception:
+            logger.debug("Error while closing Elasticsearch client: %s", exception)
+
     def reset(self, db_name: str | None = None) -> None:
         if db_name is not None:
             self._validate_data_stream_name(db_name)
+        self._close_cached_client()
         super().reset(db_name=db_name)
         self.__dict__.pop("db", None)
         self._write_sequence = count()
+
+    def close(self) -> None:
+        self.reset()
 
     @property
     def use_udp(self) -> bool:
@@ -282,6 +297,7 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _get_client_kwargs(self) -> dict[str, Any]:
         kwargs = {}
+        url = None
         if TIMESERIES_DB.get("CLOUD_ID"):
             kwargs["cloud_id"] = TIMESERIES_DB["CLOUD_ID"]
         else:
@@ -297,6 +313,14 @@ class DatabaseClient(BaseTimeseriesClient):
             kwargs["basic_auth"] = (
                 TIMESERIES_DB["USER"],
                 TIMESERIES_DB["PASSWORD"],
+            )
+        credentials = kwargs.keys() & {"api_key", "bearer_auth", "basic_auth"}
+        if credentials and url and urlparse(url).scheme == "http":
+            logger.warning(
+                'Sending Elasticsearch credentials over insecure HTTP at "%s". '
+                'Consider switching TIMESERIES_DATABASE["URL"] to https:// when '
+                "running outside local development.",
+                url,
             )
         for setting_name, kwarg_name in (
             ("CA_CERTS", "ca_certs"),
@@ -909,6 +933,59 @@ class DatabaseClient(BaseTimeseriesClient):
                     )
         return hits
 
+    @retry
+    def _count_distinct_values(self, query, field_path) -> int:
+        """Count unique values by paging a composite aggregation."""
+        index, query = self._prepare_search_query(query)
+        query["size"] = 0
+        query["aggs"] = {
+            "distinct": {
+                "composite": {
+                    "size": self._DISTINCT_PAGE_SIZE,
+                    "sources": [{"value": {"terms": {"field": field_path}}}],
+                }
+            }
+        }
+        pit_id = None
+        count = 0
+        after_key = None
+        try:
+            response = self.db.open_point_in_time(
+                index=index,
+                keep_alive=self._PIT_KEEP_ALIVE,
+            )
+            pit_id = self._response_body(response)["id"]
+            while True:
+                body = deepcopy(query)
+                body["pit"] = {
+                    "id": pit_id,
+                    "keep_alive": self._PIT_KEEP_ALIVE,
+                }
+                if after_key is not None:
+                    body["aggs"]["distinct"]["composite"]["after"] = after_key
+                response = self._response_body(self.db.search(body=body))
+                pit_id = response.get("pit_id", pit_id)
+                aggregation = response.get("aggregations", {}).get("distinct", {})
+                buckets = aggregation.get("buckets", [])
+                count += len(buckets)
+                after_key = aggregation.get("after_key")
+                if after_key is None or len(buckets) < self._DISTINCT_PAGE_SIZE:
+                    break
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return 0
+            logger.warning("Error querying Elasticsearch: %s", exception)
+            raise
+        finally:
+            if pit_id is not None:
+                try:
+                    self.db.close_point_in_time(id=pit_id)
+                except Exception as exception:
+                    logger.warning(
+                        "Error closing Elasticsearch point in time: %s", exception
+                    )
+        return count
+
     def _normalize_fields(self, fields, extra_fields=None):
         if isinstance(fields, str):
             fields = [fields]
@@ -1081,24 +1158,15 @@ class DatabaseClient(BaseTimeseriesClient):
         limit=None,
         precision="s",
     ) -> list[TimeseriesPoint]:
-        response = self.query(
+        value = self._count_distinct_values(
             {
-                "size": 0,
                 "query": self._build_base_query(
                     key=key, tags=tags, since=since, where=where
                 ),
-                "aggs": {
-                    "count": {
-                        "cardinality": {
-                            "field": self._get_indexed_field_path(field, "keyword")
-                        }
-                    }
-                },
                 "__retention_policy": retention_policy,
             },
-            precision=precision,
+            self._get_indexed_field_path(field, "keyword"),
         )
-        value = response.get("aggregations", {}).get("count", {}).get("value", 0)
         points = [{"count": value, "time": None}]
         return points[: int(limit)] if limit else points
 
@@ -1272,15 +1340,6 @@ class DatabaseClient(BaseTimeseriesClient):
         if not filters:
             return {"match_all": {}}
         return {"bool": {"filter": filters}}
-
-    def _normalize_chart_window(self, time_value, group_map=None):
-        if group_map and time_value in group_map:
-            return group_map[time_value]
-        if isinstance(time_value, (int, float)):
-            return f"{max(int(time_value), 1)}m"
-        if isinstance(time_value, str) and re.fullmatch(r"\d+", time_value):
-            return f"{max(int(time_value), 1)}m"
-        return time_value
 
     def _format_chart_metrics(self, query, params, fields=None):
         format_params = {**params}
@@ -1611,7 +1670,7 @@ class DatabaseClient(BaseTimeseriesClient):
         metric_aggregation = aggregation.get(metric["name"], {})
         if "doc_count" in metric_aggregation:
             if metric_aggregation["doc_count"] == 0:
-                return 0 if metric.get("agg") == "cardinality" else None
+                return None
             metric_aggregation = metric_aggregation.get("value", {})
         if metric.get("agg") == "mode":
             buckets = metric_aggregation.get("buckets", [])
@@ -1643,6 +1702,20 @@ class DatabaseClient(BaseTimeseriesClient):
             for metric_name in metric_names
         )
 
+    @staticmethod
+    def _fill_empty_cardinality_values(points, metrics):
+        # COUNT(DISTINCT) reports 0 for empty buckets on the InfluxDB backends.
+        # This is only applied to charts which have data, so that charts without
+        # any data are left empty instead of being rendered as a flat zero line.
+        metric_names = [
+            metric["name"] for metric in metrics if metric.get("agg") == "cardinality"
+        ]
+        for point in points:
+            for metric_name in metric_names:
+                if point.get(metric_name) is None:
+                    point[metric_name] = 0
+        return points
+
     def _format_histogram_time(self, bucket, precision):
         if "key" not in bucket:
             return None
@@ -1656,7 +1729,7 @@ class DatabaseClient(BaseTimeseriesClient):
             point = self._build_chart_point(aggregations, metrics)
             if not self._has_chart_values([point], metrics):
                 return []
-            return [point]
+            return self._fill_empty_cardinality_values([point], metrics)
         buckets = aggregations.get("timeseries", {}).get("buckets", [])
         points = [
             self._build_chart_point(
@@ -1668,7 +1741,7 @@ class DatabaseClient(BaseTimeseriesClient):
         ]
         if not self._has_chart_values(points, metrics):
             return []
-        return points
+        return self._fill_empty_cardinality_values(points, metrics)
 
     def _extract_grouped_chart_value(self, bucket, metric):
         return self._extract_chart_metric_value(
@@ -1823,7 +1896,7 @@ class DatabaseClient(BaseTimeseriesClient):
             refresh = True
         for stream_name in self._get_data_stream_names() + self._get_index_names():
             try:
-                self.db.delete_by_query(
+                response = self.db.delete_by_query(
                     index=stream_name,
                     body={"query": query},
                     conflicts="proceed",
@@ -1832,6 +1905,18 @@ class DatabaseClient(BaseTimeseriesClient):
             except Exception as exception:
                 if not self._is_not_found(exception):
                     raise
+                continue
+            body = self._response_body(response)
+            if not isinstance(body, Mapping):
+                continue
+            if (
+                body.get("timed_out")
+                or body.get("failures")
+                or body.get("version_conflicts")
+            ):
+                raise TimeseriesWriteException(
+                    f'Incomplete deletion on "{stream_name}": {body}'
+                )
 
     def delete_series(
         self, key: str | None = None, tags: TimeseriesTags | None = None

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -42,6 +42,31 @@ SeriesTags = dict[str, Any]
 SeriesTagSet = frozenset[tuple[str, Any]]
 SeriesKey = tuple[str, SeriesTags | None]
 SeriesCache = dict[tuple[str, SeriesTagSet], list[TimeseriesPoint]]
+_TIMESTAMP_PRECISION_MULTIPLIERS = {
+    "s": 1,
+    "ms": 1000,
+    "u": 1000000,
+    "ns": 1000000000,
+}
+
+
+def _normalize_datetime(value: datetime, precision="s"):
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    if precision is None:
+        return value.isoformat().replace("+00:00", "Z")
+    timestamp = value.timestamp()
+    multiplier = _TIMESTAMP_PRECISION_MULTIPLIERS.get(precision)
+    return int(timestamp * multiplier) if multiplier else timestamp
+
+
+def _normalize_timestamp_value(value, precision="s"):
+    if isinstance(value, datetime):
+        return _normalize_datetime(value, precision=precision)
+    if isinstance(value, str):
+        parsed = parse_datetime(value)
+        return _normalize_datetime(parsed, precision=precision) if parsed else value
+    return value
 
 
 class QueryResultSet:
@@ -59,28 +84,7 @@ class QueryResultSet:
         return self.response.get(key, default)
 
     def _normalize_time(self, value):
-        if isinstance(value, datetime):
-            dt = value
-        elif isinstance(value, str):
-            dt = parse_datetime(value)
-            if dt is None:
-                return value
-        else:
-            return value
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        if self.precision is None:
-            return dt.isoformat().replace("+00:00", "Z")
-        timestamp = dt.timestamp()
-        if self.precision == "s":
-            return int(timestamp)
-        if self.precision == "ms":
-            return int(timestamp * 1000)
-        if self.precision == "u":
-            return int(timestamp * 1000000)
-        if self.precision == "ns":
-            return int(timestamp * 1000000000)
-        return timestamp
+        return _normalize_timestamp_value(value, precision=self.precision)
 
     def _hits(self) -> list[Mapping[str, Any]]:
         return self.response.get("hits", {}).get("hits", [])
@@ -181,6 +185,8 @@ class DatabaseClient(BaseTimeseriesClient):
     backend_name = "elasticsearch"
     client_error = TransportError
     required_settings = ("BACKEND", "NAME")
+    _INVALID_DATA_STREAM_NAME = re.compile(r'[\\/*?"<>| ,#:]')
+    _MAX_DATA_STREAM_NAME_BYTES = 255
     _OPERATORS = ("=", "!=", "<", ">", "<=", ">=")
     _AGGREGATE = (
         "avg",
@@ -200,6 +206,8 @@ class DatabaseClient(BaseTimeseriesClient):
     _DURATION_PATTERN = re.compile(r"(?:\d+[smhdw])+")
     _DURATION_PART_PATTERN = re.compile(r"(\d+)([smhdw])")
     _DEFAULT_ROLLOVER_SECONDS = 30 * 24 * 60 * 60
+    # Wins over broad external templates that may also match OpenWISP streams.
+    _OPENWISP_INDEX_TEMPLATE_PRIORITY = 500
     _CHART_FILTERS = (
         "content_type",
         "object_id",
@@ -212,6 +220,12 @@ class DatabaseClient(BaseTimeseriesClient):
     @classmethod
     def validate_settings(cls, config: Mapping[str, Any] | None) -> Mapping[str, Any]:
         super().validate_settings(config)
+        try:
+            cls._validate_data_stream_name(config["NAME"])
+        except ValueError as exception:
+            raise ImproperlyConfigured(
+                '"NAME" must be a valid Elasticsearch data stream name.'
+            ) from exception
         has_cloud_id = bool(config.get("CLOUD_ID"))
         has_url = bool(config.get("URL"))
         has_host_port = all(config.get(field) for field in ("HOST", "PORT"))
@@ -220,17 +234,28 @@ class DatabaseClient(BaseTimeseriesClient):
                 'Elasticsearch TIMESERIES_DATABASE must define "CLOUD_ID", '
                 '"URL", or both "HOST" and "PORT".'
             )
+        if not isinstance(config.get("OPTIONS", {}), Mapping):
+            raise ImproperlyConfigured('"OPTIONS" must be a mapping.')
+        if "VERIFY_CERTS" in config and not isinstance(config["VERIFY_CERTS"], bool):
+            raise ImproperlyConfigured('"VERIFY_CERTS" must be a boolean.')
+        uses_basic_auth = not config.get("API_KEY") and not config.get("BEARER_AUTH")
+        if uses_basic_auth and bool(config.get("USER")) != bool(config.get("PASSWORD")):
+            raise ImproperlyConfigured(
+                '"USER" and "PASSWORD" must be configured together.'
+            )
         return config
 
     def __init__(self, db_name: str | None = None) -> None:
-        self.db_name = db_name or TIMESERIES_DB["NAME"]
-        self._ensured_streams = set()
+        self.db_name = self._validate_data_stream_name(
+            TIMESERIES_DB["NAME"] if db_name is None else db_name
+        )
         self._write_sequence = count()
 
     def reset(self, db_name: str | None = None) -> None:
+        if db_name is not None:
+            self._validate_data_stream_name(db_name)
         super().reset(db_name=db_name)
         self.__dict__.pop("db", None)
-        self._ensured_streams = set()
         self._write_sequence = count()
 
     @property
@@ -284,6 +309,21 @@ class DatabaseClient(BaseTimeseriesClient):
                 kwargs[option_name] = self.options[option_name]
         return kwargs
 
+    @classmethod
+    def _validate_data_stream_name(cls, name: str) -> str:
+        invalid = (
+            not isinstance(name, str)
+            or not name
+            or name != name.lower()
+            or name.startswith(("-", "_", "+", "."))
+            or name in {".", ".."}
+            or cls._INVALID_DATA_STREAM_NAME.search(name)
+            or len(name.encode()) > cls._MAX_DATA_STREAM_NAME_BYTES
+        )
+        if invalid:
+            raise ValueError(f'Invalid Elasticsearch data stream name "{name}"')
+        return name
+
     def _get_retention_policy_name(self, retention_policy=None) -> str:
         if not retention_policy or retention_policy == "autogen":
             return "autogen"
@@ -293,7 +333,7 @@ class DatabaseClient(BaseTimeseriesClient):
         retention_policy = self._get_retention_policy_name(retention_policy)
         if retention_policy == "autogen":
             return self.db_name
-        return f"{self.db_name}-{retention_policy}"
+        return self._validate_data_stream_name(f"{self.db_name}-{retention_policy}")
 
     def _get_policy_name(self, retention_policy=None) -> str:
         return f"{self.db_name}-{self._get_retention_policy_name(retention_policy)}-ilm"
@@ -301,7 +341,7 @@ class DatabaseClient(BaseTimeseriesClient):
     def _get_template_name(self, retention_policy=None) -> str:
         return f"{self._get_stream_name(retention_policy)}-template"
 
-    def _is_own_stream(self, name: str) -> bool:
+    def _is_own_resource_name(self, name: str) -> bool:
         return name == self.db_name or name.startswith(f"{self.db_name}-")
 
     def _is_not_found(self, exception: Exception) -> bool:
@@ -315,7 +355,11 @@ class DatabaseClient(BaseTimeseriesClient):
             return False
         if getattr(exception, "status_code", None) != 400:
             return False
-        return "resource_already_exists_exception" in str(exception)
+        body = self._response_body(exception)
+        error = body.get("error", {}) if isinstance(body, Mapping) else {}
+        if isinstance(error, Mapping):
+            return error.get("type") == "resource_already_exists_exception"
+        return error == "resource_already_exists_exception"
 
     def _response_body(self, response):
         return getattr(response, "body", response)
@@ -335,8 +379,11 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _build_lifecycle_policy(self, duration: str | None = None) -> dict[str, Any]:
         duration_seconds = self._duration_to_seconds(duration)
-        rollover_seconds = duration_seconds or self._DEFAULT_ROLLOVER_SECONDS
-        rollover_seconds = min(rollover_seconds, self._DEFAULT_ROLLOVER_SECONDS)
+        # Bound retention overshoot and backing-index size for long-lived policies.
+        rollover_seconds = min(
+            duration_seconds or self._DEFAULT_ROLLOVER_SECONDS,
+            self._DEFAULT_ROLLOVER_SECONDS,
+        )
         policy = {
             "phases": {
                 "hot": {
@@ -359,17 +406,14 @@ class DatabaseClient(BaseTimeseriesClient):
         return policy
 
     def _put_lifecycle_policy(self, name: str, policy: Mapping[str, Any]) -> None:
-        try:
-            self.db.ilm.put_lifecycle(name=name, policy=policy)
-        except TypeError:
-            self.db.ilm.put_lifecycle(name=name, body={"policy": policy})
+        self.db.ilm.put_lifecycle(name=name, policy=policy)
 
     def _build_index_template_body(self, retention_policy=None) -> dict[str, Any]:
         stream_name = self._get_stream_name(retention_policy)
         return {
             "index_patterns": [stream_name],
             "data_stream": {},
-            "priority": self.options.get("template_priority", 500),
+            "priority": self._OPENWISP_INDEX_TEMPLATE_PRIORITY,
             "template": {
                 "settings": {
                     "index.lifecycle.name": self._get_policy_name(retention_policy),
@@ -425,7 +469,6 @@ class DatabaseClient(BaseTimeseriesClient):
                         "fields": {"type": "object", "dynamic": True},
                     },
                 },
-                "lifecycle": {"enabled": True},
             },
             "_meta": {
                 "description": "OpenWISP Monitoring Elasticsearch data stream data"
@@ -435,10 +478,7 @@ class DatabaseClient(BaseTimeseriesClient):
     def _put_index_template(self, retention_policy=None) -> None:
         name = self._get_template_name(retention_policy)
         body = self._build_index_template_body(retention_policy)
-        try:
-            self.db.indices.put_index_template(name=name, **body)
-        except TypeError:
-            self.db.indices.put_index_template(name=name, body=body)
+        self.db.indices.put_index_template(name=name, **body)
 
     def _data_stream_exists(self, name: str) -> bool:
         try:
@@ -451,11 +491,8 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _ensure_data_stream_resources(
         self, retention_policy=None, duration: str | None = None
-    ):
+    ) -> None:
         stream_name = self._get_stream_name(retention_policy)
-        cache_key = (stream_name, duration)
-        if cache_key in self._ensured_streams:
-            return
         self._put_lifecycle_policy(
             self._get_policy_name(retention_policy),
             self._build_lifecycle_policy(duration),
@@ -469,7 +506,6 @@ class DatabaseClient(BaseTimeseriesClient):
                     raise
                 if not self._data_stream_exists(stream_name):
                     raise
-        self._ensured_streams.add(cache_key)
 
     @retry
     def create_database(self) -> None:
@@ -487,7 +523,6 @@ class DatabaseClient(BaseTimeseriesClient):
         self._delete_indices()
         self._delete_index_templates()
         self._delete_lifecycle_policies()
-        self._ensured_streams = set()
         logger.debug('Dropped Elasticsearch data streams for "%s"', self.db_name)
 
     def _get_data_stream_names(self) -> list[str]:
@@ -501,7 +536,7 @@ class DatabaseClient(BaseTimeseriesClient):
         return [
             stream["name"]
             for stream in response.get("data_streams", [])
-            if self._is_own_stream(stream["name"])
+            if self._is_own_resource_name(stream["name"])
         ]
 
     def _get_index_names(self) -> list[str]:
@@ -518,7 +553,7 @@ class DatabaseClient(BaseTimeseriesClient):
         return [
             index_name
             for index_name in response.keys()
-            if self._is_own_stream(index_name)
+            if self._is_own_resource_name(index_name)
         ]
 
     def _delete_indices(self) -> None:
@@ -530,25 +565,11 @@ class DatabaseClient(BaseTimeseriesClient):
                     raise
 
     def _delete_index_templates(self) -> None:
-        try:
-            response = self.db.indices.get_index_template(
-                name=f"{self.db_name}*-template"
-            )
-        except Exception as exception:
-            if self._is_not_found(exception):
-                return
-            raise
-        response = self._response_body(response)
-        template_names = [
-            template["name"]
-            for template in response.get("index_templates", [])
-            if template["name"] == self._get_template_name()
-            or (
-                template["name"].startswith(f"{self.db_name}-")
-                and template["name"].endswith("-template")
-            )
-        ]
-        for template_name in template_names:
+        template_patterns = (
+            self._get_template_name(),
+            f"{self.db_name}-*-template",
+        )
+        for template_name in template_patterns:
             try:
                 self.db.indices.delete_index_template(name=template_name)
             except Exception as exception:
@@ -563,22 +584,31 @@ class DatabaseClient(BaseTimeseriesClient):
                 if not self._is_not_found(exception):
                     raise
 
-    def _get_lifecycle_policy_names(self) -> list[str]:
+    def _get_lifecycle_policies(self) -> dict[str, Any]:
+        pattern = f"{self.db_name}-*-ilm"
         try:
-            response = self.db.ilm.get_lifecycle(name=f"{self.db_name}-*-ilm")
+            response = self.db.ilm.get_lifecycle(name=pattern)
         except Exception as exception:
             if self._is_not_found(exception):
-                return []
+                return {}
             raise
         response = self._response_body(response)
-        return [
-            name
-            for name in response.keys()
+        return {
+            name: policy
+            for name, policy in response.items()
             if name.startswith(f"{self.db_name}-") and name.endswith("-ilm")
-        ]
+        }
+
+    def _get_lifecycle_policy_names(self) -> list[str]:
+        return list(self._get_lifecycle_policies())
+
+    def create_or_alter_retention_policy(self, name: str, duration: str) -> None:
+        self._get_stream_name(name)
+        self._duration_to_seconds(duration)
+        self._create_or_alter_retention_policy(name, duration)
 
     @retry
-    def create_or_alter_retention_policy(self, name: str, duration: str) -> None:
+    def _create_or_alter_retention_policy(self, name: str, duration: str) -> None:
         self._ensure_data_stream_resources(retention_policy=name, duration=duration)
         logger.debug(
             'Created/updated Elasticsearch retention policy "%s" with duration %s',
@@ -588,19 +618,13 @@ class DatabaseClient(BaseTimeseriesClient):
 
     @retry
     def get_list_retention_policies(self) -> list[TimeseriesPoint]:
+        """Return ES ILM policies in an InfluxDB-compatible shape."""
         policies = []
-        for policy_name in self._get_lifecycle_policy_names():
-            start = len(self.db_name) + 1
-            end = -len("-ilm")
-            retention_policy = policy_name[start:end]
-            try:
-                body = self.db.ilm.get_lifecycle(name=policy_name)
-            except Exception as exception:
-                if self._is_not_found(exception):
-                    continue
-                raise
-            body = self._response_body(body)
-            phases = body.get(policy_name, {}).get("policy", {}).get("phases", {})
+        prefix = f"{self.db_name}-"
+        suffix = "-ilm"
+        for policy_name, policy in self._get_lifecycle_policies().items():
+            retention_policy = policy_name.removeprefix(prefix).removesuffix(suffix)
+            phases = policy.get("policy", {}).get("phases", {})
             duration = "0s"
             if "delete" in phases:
                 duration = phases["delete"].get("min_age", duration)
@@ -654,28 +678,7 @@ class DatabaseClient(BaseTimeseriesClient):
         return timestamp
 
     def _normalize_time(self, value, precision="s"):
-        if isinstance(value, datetime):
-            dt = value
-        elif isinstance(value, str):
-            dt = parse_datetime(value)
-            if dt is None:
-                return value
-        else:
-            return value
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        if precision is None:
-            return dt.isoformat().replace("+00:00", "Z")
-        timestamp = dt.timestamp()
-        if precision == "s":
-            return int(timestamp)
-        if precision == "ms":
-            return int(timestamp * 1000)
-        if precision == "u":
-            return int(timestamp * 1000000)
-        if precision == "ns":
-            return int(timestamp * 1000000000)
-        return timestamp
+        return _normalize_timestamp_value(value, precision=precision)
 
     def _clean_operator(self, op: str) -> str:
         if op not in self._OPERATORS:
@@ -711,7 +714,6 @@ class DatabaseClient(BaseTimeseriesClient):
     def write(self, name: str, values: TimeseriesFields, **kwargs: Any) -> None:
         self._check_database_kwarg(kwargs.get("database"))
         retention_policy = kwargs.get("retention_policy")
-        self._ensure_data_stream_resources(retention_policy)
         document = self._build_document(name, values, **kwargs)
         try:
             self.db.index(
@@ -725,7 +727,6 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def batch_write(self, metric_data: Sequence[BatchWritePayload]) -> None:
         actions = []
-        ensured_retention_policies = set()
         checked_databases = set()
         for data in metric_data:
             database = data.get("database")
@@ -733,9 +734,6 @@ class DatabaseClient(BaseTimeseriesClient):
                 self._check_database_kwarg(database)
                 checked_databases.add(database)
             retention_policy = data.get("retention_policy")
-            if retention_policy not in ensured_retention_policies:
-                self._ensure_data_stream_resources(retention_policy)
-                ensured_retention_policies.add(retention_policy)
             actions.append(
                 {
                     "_op_type": "create",
@@ -1534,7 +1532,6 @@ class DatabaseClient(BaseTimeseriesClient):
                 if not self._is_not_found(exception):
                     raise
 
-    @retry
     def delete_series(
         self, key: str | None = None, tags: TimeseriesTags | None = None
     ) -> None:

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -3,9 +3,7 @@ import re
 from collections.abc import Iterator, Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime, timezone
-from hashlib import sha1
 from itertools import count
-from json import dumps
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -374,15 +372,7 @@ class DatabaseClient(BaseTimeseriesClient):
             "priority": self.options.get("template_priority", 500),
             "template": {
                 "settings": {
-                    "index.mode": "time_series",
                     "index.lifecycle.name": self._get_policy_name(retention_policy),
-                    "index.look_ahead_time": self.options.get("look_ahead_time", "2h"),
-                    "index.look_back_time": self.options.get("look_back_time", "7d"),
-                    "index.routing_path": [
-                        "measurement",
-                        "openwisp_series_id",
-                        "tags.*",
-                    ],
                 },
                 "mappings": {
                     "dynamic": True,
@@ -392,7 +382,6 @@ class DatabaseClient(BaseTimeseriesClient):
                                 "path_match": "tags.*",
                                 "mapping": {
                                     "type": "keyword",
-                                    "time_series_dimension": True,
                                     "ignore_above": 2048,
                                 },
                             }
@@ -413,7 +402,6 @@ class DatabaseClient(BaseTimeseriesClient):
                                 "match_mapping_type": "long",
                                 "mapping": {
                                     "type": "double",
-                                    "time_series_metric": "gauge",
                                 },
                             }
                         },
@@ -423,28 +411,15 @@ class DatabaseClient(BaseTimeseriesClient):
                                 "match_mapping_type": "double",
                                 "mapping": {
                                     "type": "double",
-                                    "time_series_metric": "gauge",
                                 },
                             }
                         },
                     ],
                     "properties": {
                         "@timestamp": {"type": "date"},
-                        "measurement": {
-                            "type": "keyword",
-                            "time_series_dimension": True,
-                        },
-                        "openwisp_series_id": {
-                            "type": "keyword",
-                            "time_series_dimension": True,
-                        },
-                        "openwisp_doc_count": {
-                            "type": "long",
-                            "time_series_metric": "gauge",
-                        },
+                        "measurement": {"type": "keyword"},
                         "openwisp_write_sequence": {
                             "type": "long",
-                            "time_series_metric": "gauge",
                         },
                         "tags": {"type": "object", "dynamic": True},
                         "fields": {"type": "object", "dynamic": True},
@@ -452,7 +427,9 @@ class DatabaseClient(BaseTimeseriesClient):
                 },
                 "lifecycle": {"enabled": True},
             },
-            "_meta": {"description": "OpenWISP Monitoring Elasticsearch TSDS data"},
+            "_meta": {
+                "description": "OpenWISP Monitoring Elasticsearch data stream data"
+            },
         }
 
     def _put_index_template(self, retention_policy=None) -> None:
@@ -719,12 +696,9 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _build_document(self, name, values, **kwargs) -> dict[str, Any]:
         values = dict(values or {})
-        series_payload = dumps(values, sort_keys=True, default=str)
         return {
             "@timestamp": self._get_timestamp(kwargs.get("timestamp")),
             "measurement": name,
-            "openwisp_series_id": sha1(series_payload.encode()).hexdigest(),
-            "openwisp_doc_count": 1,
             "openwisp_write_sequence": next(self._write_sequence),
             "tags": dict(kwargs.get("tags") or {}),
             "fields": values,

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -198,6 +198,7 @@ class DatabaseClient(BaseTimeseriesClient):
         "max",
         "min",
         "percentiles",
+        "scripted_metric",
         "stats",
         "sum",
         "terms",
@@ -820,7 +821,23 @@ class DatabaseClient(BaseTimeseriesClient):
         fields = [field for field in fields if field != "*"]
         if not fields:
             return None
-        filters = [{"exists": {"field": f"fields.{field}"}} for field in fields]
+        filters = []
+        for field in fields:
+            field_name = f"fields.{field}"
+            field_filter = {"exists": {"field": field_name}}
+            # Large device snapshots are kept in _source but excluded from the
+            # index by ignore_above, which Elasticsearch records in _ignored.
+            if field == "data":
+                field_filter = {
+                    "bool": {
+                        "should": [
+                            field_filter,
+                            {"term": {"_ignored": field_name}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            filters.append(field_filter)
         if len(filters) == 1:
             return filters[0]
         return {"bool": {"should": filters, "minimum_should_match": 1}}
@@ -1374,21 +1391,55 @@ class DatabaseClient(BaseTimeseriesClient):
     ) -> list[str]:
         if number <= 0:
             return []
+        # Dynamic field names must be discovered and summed without fetching a
+        # capped set of matching documents into the application.
         search = {
-            "size": int(self.options.get("top_fields_read_size", 10000)),
-            "_source": ["fields"],
+            "size": 0,
             "query": self._build_chart_base_query(params, timezone_name=timezone),
+            "aggs": {
+                "top_fields": {
+                    "scripted_metric": {
+                        "init_script": "state.totals = [:]",
+                        "map_script": (
+                            "def values = params['_source']['fields']; "
+                            "if (values == null) return; "
+                            "for (def entry : values.entrySet()) { "
+                            "def value = entry.getValue(); "
+                            "if (value instanceof Number) { "
+                            "def name = entry.getKey(); "
+                            "state.totals[name] = state.totals.containsKey(name) "
+                            "? state.totals[name] + value : value; "
+                            "} "
+                            "}"
+                        ),
+                        "combine_script": "return state.totals",
+                        "reduce_script": (
+                            "Map totals = [:]; "
+                            "for (def shard : states) { "
+                            "if (shard == null) continue; "
+                            "for (def entry : shard.entrySet()) { "
+                            "def name = entry.getKey(); "
+                            "totals[name] = totals.containsKey(name) "
+                            "? totals[name] + entry.getValue() : entry.getValue(); "
+                            "} "
+                            "} "
+                            "return totals"
+                        ),
+                    }
+                }
+            },
             "__index": self._get_stream_name(params.get("retention_policy")),
         }
         response = self.query(search, precision="s")
-        totals = {}
-        for hit in self._get_hits(response):
-            fields = (hit.get("_source") or {}).get("fields") or {}
-            for field, value in fields.items():
-                if isinstance(value, bool) or not isinstance(value, (int, float)):
-                    continue
-                totals[field] = totals.get(field, 0) + value
-        sorted_fields = sorted(totals.items(), key=lambda item: item[1], reverse=True)
+        totals = (
+            response.get("aggregations", {}).get("top_fields", {}).get("value") or {}
+        )
+        totals = {
+            field: value
+            for field, value in totals.items()
+            if not isinstance(value, bool) and isinstance(value, (int, float))
+        }
+        sorted_fields = sorted(totals.items(), key=lambda item: (-item[1], item[0]))
         return [field for field, _value in sorted_fields[:number]]
 
     def _round_chart_value(self, value):
@@ -1464,8 +1515,30 @@ class DatabaseClient(BaseTimeseriesClient):
             {"value": bucket.get("value", {})}, metric
         )
 
+    def _warn_if_grouped_chart_truncated(self, aggregations, query):
+        if query.get("__openwisp_summary"):
+            groups = (aggregations.get("groups", {}),)
+        else:
+            groups = (
+                bucket.get("groups", {})
+                for bucket in aggregations.get("timeseries", {}).get("buckets", [])
+            )
+        omitted_documents = sum(
+            group.get("sum_other_doc_count", 0) or 0 for group in groups
+        )
+        if omitted_documents:
+            logger.warning(
+                'Elasticsearch grouped chart for tag "%s" omitted groups '
+                "containing %d document(s) because the terms_size limit (%d) "
+                "was reached.",
+                query.get("__openwisp_group_by"),
+                omitted_documents,
+                int(self.options.get("terms_size", 1000)),
+            )
+
     def _get_grouped_chart_points(self, response, query, precision="s"):
         aggregations = response.get("aggregations", {})
+        self._warn_if_grouped_chart_truncated(aggregations, query)
         metric = query["__openwisp_metric"]
         if query.get("__openwisp_summary"):
             point = {"time": None}
@@ -1509,7 +1582,7 @@ class DatabaseClient(BaseTimeseriesClient):
     ) -> list[TimeseriesPoint]:
         if (
             isinstance(query, Mapping)
-            and query.get("_openwisp_query_type") == "device_data"
+            and query.get("__openwisp_query_type") == "device_data"
         ):
             return self.read(
                 key=query["measurement"],
@@ -1546,7 +1619,7 @@ class DatabaseClient(BaseTimeseriesClient):
         pk: str,
     ) -> Mapping[str, str]:
         return {
-            "_openwisp_query_type": "device_data",
+            "__openwisp_query_type": "device_data",
             "retention_policy": retention_policy,
             "measurement": measurement,
             "pk": str(pk),

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from itertools import count
 from typing import Any
+from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
@@ -13,7 +14,13 @@ from django.utils.dateparse import parse_datetime
 from django.utils.functional import cached_property
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-from elasticsearch import ApiError, Elasticsearch, NotFoundError, TransportError
+from elasticsearch import (
+    ApiError,
+    ConflictError,
+    Elasticsearch,
+    NotFoundError,
+    TransportError,
+)
 from elasticsearch.helpers import bulk
 
 from openwisp_monitoring.utils import retry
@@ -48,6 +55,11 @@ _TIMESTAMP_PRECISION_MULTIPLIERS = {
     "u": 1000000,
     "ns": 1000000000,
 }
+_POINT_IDENTITY_FIELDS = (
+    "__openwisp_time_key",
+    "__openwisp_measurement_key",
+    "__openwisp_tags_key",
+)
 
 
 def _normalize_datetime(value: datetime, precision="s"):
@@ -185,30 +197,23 @@ class DatabaseClient(BaseTimeseriesClient):
     backend_name = "elasticsearch"
     client_error = TransportError
     required_settings = ("BACKEND", "NAME")
+    requires_write_operation_id = True
     _INVALID_DATA_STREAM_NAME = re.compile(r'[\\/*?"<>| ,#:]')
     _MAX_DATA_STREAM_NAME_BYTES = 255
     _OPERATORS = ("=", "!=", "<", ">", "<=", ">=")
-    _AGGREGATE = (
-        "avg",
-        "cardinality",
-        "count",
-        "date_histogram",
-        "extended_stats",
-        "histogram",
-        "max",
-        "min",
-        "percentiles",
-        "scripted_metric",
-        "stats",
-        "sum",
-        "terms",
-        "value_count",
-    )
     _DURATION_PATTERN = re.compile(r"(?:\d+[smhdw])+")
     _DURATION_PART_PATTERN = re.compile(r"(\d+)([smhdw])")
     _DEFAULT_ROLLOVER_SECONDS = 30 * 24 * 60 * 60
+    _PIT_KEEP_ALIVE = "1m"
     # Wins over broad external templates that may also match OpenWISP streams.
     _OPENWISP_INDEX_TEMPLATE_PRIORITY = 500
+    _RESOURCE_METADATA_KEY = "openwisp_monitoring"
+    _RESOURCE_DESCRIPTION = "OpenWISP Monitoring Elasticsearch data stream data"
+    _INDEXED_FIELD_PATHS = {
+        "keyword": "indexed_fields.keyword",
+        "numeric": "indexed_fields.numeric",
+        "boolean": "indexed_fields.boolean",
+    }
     _CHART_FILTERS = (
         "content_type",
         "object_id",
@@ -342,8 +347,15 @@ class DatabaseClient(BaseTimeseriesClient):
     def _get_template_name(self, retention_policy=None) -> str:
         return f"{self._get_stream_name(retention_policy)}-template"
 
-    def _is_own_resource_name(self, name: str) -> bool:
-        return name == self.db_name or name.startswith(f"{self.db_name}-")
+    def _build_resource_metadata(self) -> dict[str, Any]:
+        return {
+            "description": self._RESOURCE_DESCRIPTION,
+            self._RESOURCE_METADATA_KEY: {"database": self.db_name},
+        }
+
+    def _is_own_resource(self, resource: Mapping[str, Any]) -> bool:
+        metadata = resource.get("_meta", {})
+        return metadata.get(self._RESOURCE_METADATA_KEY) == {"database": self.db_name}
 
     def _is_not_found(self, exception: Exception) -> bool:
         return isinstance(exception, NotFoundError) or (
@@ -386,6 +398,7 @@ class DatabaseClient(BaseTimeseriesClient):
             self._DEFAULT_ROLLOVER_SECONDS,
         )
         policy = {
+            "_meta": self._build_resource_metadata(),
             "phases": {
                 "hot": {
                     "actions": {
@@ -397,7 +410,7 @@ class DatabaseClient(BaseTimeseriesClient):
                         }
                     }
                 }
-            }
+            },
         }
         if duration_seconds:
             policy["phases"]["delete"] = {
@@ -420,6 +433,8 @@ class DatabaseClient(BaseTimeseriesClient):
                     "index.lifecycle.name": self._get_policy_name(retention_policy),
                 },
                 "mappings": {
+                    "_meta": self._build_resource_metadata(),
+                    "_source": {"excludes": ["indexed_fields"]},
                     "dynamic": True,
                     "dynamic_templates": [
                         {
@@ -432,9 +447,8 @@ class DatabaseClient(BaseTimeseriesClient):
                             }
                         },
                         {
-                            "field_strings": {
-                                "path_match": "fields.*",
-                                "match_mapping_type": "string",
+                            "keyword_fields": {
+                                "path_match": "indexed_fields.keyword.*",
                                 "mapping": {
                                     "type": "keyword",
                                     "ignore_above": 8192,
@@ -442,20 +456,18 @@ class DatabaseClient(BaseTimeseriesClient):
                             }
                         },
                         {
-                            "field_longs": {
-                                "path_match": "fields.*",
-                                "match_mapping_type": "long",
+                            "numeric_fields": {
+                                "path_match": "indexed_fields.numeric.*",
                                 "mapping": {
                                     "type": "double",
                                 },
                             }
                         },
                         {
-                            "field_doubles": {
-                                "path_match": "fields.*",
-                                "match_mapping_type": "double",
+                            "boolean_fields": {
+                                "path_match": "indexed_fields.boolean.*",
                                 "mapping": {
-                                    "type": "double",
+                                    "type": "boolean",
                                 },
                             }
                         },
@@ -467,13 +479,13 @@ class DatabaseClient(BaseTimeseriesClient):
                             "type": "long",
                         },
                         "tags": {"type": "object", "dynamic": True},
-                        "fields": {"type": "object", "dynamic": True},
+                        # Preserve values in _source and index type-stable copies.
+                        "fields": {"type": "object", "enabled": False},
+                        "indexed_fields": {"type": "object", "dynamic": True},
                     },
                 },
             },
-            "_meta": {
-                "description": "OpenWISP Monitoring Elasticsearch data stream data"
-            },
+            "_meta": self._build_resource_metadata(),
         }
 
     def _put_index_template(self, retention_policy=None) -> None:
@@ -537,7 +549,7 @@ class DatabaseClient(BaseTimeseriesClient):
         return [
             stream["name"]
             for stream in response.get("data_streams", [])
-            if self._is_own_resource_name(stream["name"])
+            if self._is_own_resource(stream)
         ]
 
     def _get_index_names(self) -> list[str]:
@@ -553,8 +565,8 @@ class DatabaseClient(BaseTimeseriesClient):
         response = self._response_body(response)
         return [
             index_name
-            for index_name in response.keys()
-            if self._is_own_resource_name(index_name)
+            for index_name, index in response.items()
+            if self._is_own_resource(index.get("mappings", {}))
         ]
 
     def _delete_indices(self) -> None:
@@ -566,16 +578,29 @@ class DatabaseClient(BaseTimeseriesClient):
                     raise
 
     def _delete_index_templates(self) -> None:
-        template_patterns = (
-            self._get_template_name(),
-            f"{self.db_name}-*-template",
-        )
-        for template_name in template_patterns:
+        for template_name in self._get_index_template_names():
             try:
                 self.db.indices.delete_index_template(name=template_name)
             except Exception as exception:
                 if not self._is_not_found(exception):
                     raise
+
+    def _get_index_templates(self) -> dict[str, Any]:
+        try:
+            response = self.db.indices.get_index_template(name=f"{self.db_name}*")
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return {}
+            raise
+        response = self._response_body(response)
+        return {
+            item["name"]: item["index_template"]
+            for item in response.get("index_templates", [])
+            if self._is_own_resource(item["index_template"])
+        }
+
+    def _get_index_template_names(self) -> list[str]:
+        return list(self._get_index_templates())
 
     def _delete_lifecycle_policies(self) -> None:
         for policy_name in self._get_lifecycle_policy_names():
@@ -597,7 +622,9 @@ class DatabaseClient(BaseTimeseriesClient):
         return {
             name: policy
             for name, policy in response.items()
-            if name.startswith(f"{self.db_name}-") and name.endswith("-ilm")
+            if name.startswith(f"{self.db_name}-")
+            and name.endswith("-ilm")
+            and self._is_own_resource(policy.get("policy", {}))
         }
 
     def _get_lifecycle_policy_names(self) -> list[str]:
@@ -698,6 +725,27 @@ class DatabaseClient(BaseTimeseriesClient):
                 self.db_name,
             )
 
+    @classmethod
+    def _get_indexed_field_path(cls, field, field_type):
+        return f"{cls._INDEXED_FIELD_PATHS[field_type]}.{field}"
+
+    @staticmethod
+    def _get_indexed_field_type(value):
+        if isinstance(value, bool):
+            return "boolean"
+        if isinstance(value, (int, float)):
+            return "numeric"
+        if isinstance(value, str):
+            return "keyword"
+
+    def _build_indexed_fields(self, values):
+        indexed_fields = {}
+        for field, value in values.items():
+            field_type = self._get_indexed_field_type(value)
+            if field_type:
+                indexed_fields.setdefault(field_type, {})[field] = value
+        return indexed_fields
+
     def _build_document(self, name, values, **kwargs) -> dict[str, Any]:
         values = dict(values or {})
         return {
@@ -706,6 +754,7 @@ class DatabaseClient(BaseTimeseriesClient):
             "openwisp_write_sequence": next(self._write_sequence),
             "tags": dict(kwargs.get("tags") or {}),
             "fields": values,
+            "indexed_fields": self._build_indexed_fields(values),
         }
 
     def _handle_write_exception(self, exception) -> None:
@@ -719,10 +768,13 @@ class DatabaseClient(BaseTimeseriesClient):
         try:
             self.db.index(
                 index=self._get_stream_name(retention_policy),
+                id=kwargs.get("operation_id") or uuid4().hex,
                 document=document,
                 op_type="create",
                 refresh=self.refresh,
             )
+        except ConflictError:
+            return
         except Exception as exception:
             self._handle_write_exception(exception)
 
@@ -739,6 +791,7 @@ class DatabaseClient(BaseTimeseriesClient):
                 {
                     "_op_type": "create",
                     "_index": self._get_stream_name(retention_policy),
+                    "_id": data.get("operation_id") or uuid4().hex,
                     "_source": self._build_document(
                         data.get("name"),
                         data.get("values"),
@@ -750,22 +803,24 @@ class DatabaseClient(BaseTimeseriesClient):
         if not actions:
             return
         try:
-            bulk(self.db, actions, refresh=self.refresh)
+            bulk(
+                self.db,
+                actions,
+                refresh=self.refresh,
+                ignore_status=(409,),
+            )
         except Exception as exception:
             self._handle_write_exception(exception)
 
     def _empty_search_response(self) -> dict[str, Any]:
         return {"hits": {"total": {"value": 0}, "hits": []}}
 
-    @retry
-    def query(
-        self, query, precision: str | None = None, **kwargs: Any
-    ) -> QueryResultSet:
+    def _prepare_search_query(self, query, index=None):
         if not isinstance(query, Mapping):
             raise self.client_error("Elasticsearch queries must be dictionaries.")
         query = deepcopy(query)
         index = (
-            kwargs.get("index")
+            index
             or query.pop("__index", None)
             or query.pop("index", None)
             or self._get_stream_name(query.pop("__retention_policy", None))
@@ -773,6 +828,13 @@ class DatabaseClient(BaseTimeseriesClient):
         for key in list(query.keys()):
             if key.startswith("__openwisp_"):
                 query.pop(key)
+        return index, query
+
+    @retry
+    def query(
+        self, query, precision: str | None = None, **kwargs: Any
+    ) -> QueryResultSet:
+        index, query = self._prepare_search_query(query, kwargs.get("index"))
         try:
             response = self.db.search(index=index, body=query)
         except Exception as exception:
@@ -783,6 +845,69 @@ class DatabaseClient(BaseTimeseriesClient):
             logger.warning("Error querying Elasticsearch: %s", exception)
             raise
         return QueryResultSet(self._response_body(response), precision=precision)
+
+    @retry
+    def _get_paginated_hits(self, query, should_stop=None):
+        """Read stable hit pages until exhausted or a logical limit is complete."""
+        index, query = self._prepare_search_query(query)
+        page_size = int(query.get("size", self.options.get("read_size", 10000)))
+        if page_size <= 0:
+            return []
+        query["size"] = page_size
+        sort = list(query.get("sort") or [])
+        # PIT keeps this shard-level tie-breaker stable across search_after pages.
+        if not any(
+            item == "_shard_doc" or isinstance(item, Mapping) and "_shard_doc" in item
+            for item in sort
+        ):
+            sort.append({"_shard_doc": "asc"})
+        query["sort"] = sort
+        pit_id = None
+        hits = []
+        search_after = None
+        try:
+            response = self.db.open_point_in_time(
+                index=index,
+                keep_alive=self._PIT_KEEP_ALIVE,
+            )
+            pit_id = self._response_body(response)["id"]
+            while True:
+                body = deepcopy(query)
+                body["pit"] = {
+                    "id": pit_id,
+                    "keep_alive": self._PIT_KEEP_ALIVE,
+                }
+                if search_after is not None:
+                    body["search_after"] = search_after
+                response = self._response_body(self.db.search(body=body))
+                pit_id = response.get("pit_id", pit_id)
+                page = self._get_hits(response)
+                if not page:
+                    break
+                hits.extend(page)
+                if should_stop and should_stop(hits):
+                    break
+                if len(page) < page_size:
+                    break
+                search_after = page[-1].get("sort")
+                if search_after is None:
+                    raise self.client_error(
+                        "Elasticsearch paginated search response is missing sort values."
+                    )
+        except Exception as exception:
+            if self._is_not_found(exception):
+                return []
+            logger.warning("Error querying Elasticsearch: %s", exception)
+            raise
+        finally:
+            if pit_id is not None:
+                try:
+                    self.db.close_point_in_time(id=pit_id)
+                except Exception as exception:
+                    logger.warning(
+                        "Error closing Elasticsearch point in time: %s", exception
+                    )
+        return hits
 
     def _normalize_fields(self, fields, extra_fields=None):
         if isinstance(fields, str):
@@ -807,7 +932,8 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _build_field_filter(self, field, op, value):
         op = self._clean_operator(op)
-        field_name = f"fields.{field}"
+        field_type = self._get_indexed_field_type(value) or "keyword"
+        field_name = self._get_indexed_field_path(field, field_type)
         if op == "=":
             return {"term": {field_name: value}}
         if op == "!=":
@@ -823,21 +949,20 @@ class DatabaseClient(BaseTimeseriesClient):
             return None
         filters = []
         for field in fields:
-            field_name = f"fields.{field}"
-            field_filter = {"exists": {"field": field_name}}
-            # Large device snapshots are kept in _source but excluded from the
-            # index by ignore_above, which Elasticsearch records in _ignored.
-            if field == "data":
-                field_filter = {
+            keyword_path = self._get_indexed_field_path(field, "keyword")
+            type_filters = [
+                {"exists": {"field": self._get_indexed_field_path(field, field_type)}}
+                for field_type in self._INDEXED_FIELD_PATHS
+            ]
+            type_filters.append({"term": {"_ignored": keyword_path}})
+            filters.append(
+                {
                     "bool": {
-                        "should": [
-                            field_filter,
-                            {"term": {"_ignored": field_name}},
-                        ],
+                        "should": type_filters,
                         "minimum_should_match": 1,
                     }
                 }
-            filters.append(field_filter)
+            )
         if len(filters) == 1:
             return filters[0]
         return {"bool": {"should": filters, "minimum_should_match": 1}}
@@ -919,19 +1044,25 @@ class DatabaseClient(BaseTimeseriesClient):
         include_tags: bool = True,
     ) -> TimeseriesPoint:
         timestamp = document.get("@timestamp")
-        point = {
-            "time": self._normalize_time(timestamp, precision=precision),
-            "__openwisp_time_key": timestamp,
-        }
+        point = {"time": self._normalize_time(timestamp, precision=precision)}
         if include_tags:
             point.update(document.get("tags") or {})
         values = document.get("fields") or {}
         if not fields or fields == ["*"]:
             point.update(values)
-            return point
-        for field in fields:
-            if field in values:
-                point[field] = values[field]
+        else:
+            for field in fields:
+                if field in values:
+                    point[field] = values[field]
+        point.update(
+            {
+                "__openwisp_time_key": timestamp,
+                "__openwisp_measurement_key": document.get("measurement"),
+                "__openwisp_tags_key": tuple(
+                    sorted((document.get("tags") or {}).items())
+                ),
+            }
+        )
         return point
 
     def _get_hits(self, response) -> list[Mapping[str, Any]]:
@@ -956,7 +1087,13 @@ class DatabaseClient(BaseTimeseriesClient):
                 "query": self._build_base_query(
                     key=key, tags=tags, since=since, where=where
                 ),
-                "aggs": {"count": {"cardinality": {"field": f"fields.{field}"}}},
+                "aggs": {
+                    "count": {
+                        "cardinality": {
+                            "field": self._get_indexed_field_path(field, "keyword")
+                        }
+                    }
+                },
                 "__retention_policy": retention_policy,
             },
             precision=precision,
@@ -1039,26 +1176,46 @@ class DatabaseClient(BaseTimeseriesClient):
         if fields != ["*"]:
             projection_fields = list(dict.fromkeys([*fields, *where_fields]))
             filter_only_fields = set(where_fields) - set(fields)
-        response = self.query(query, precision=precision)
-        points = [
-            self._document_to_point(
-                hit.get("_source", {}),
-                fields=projection_fields,
-                precision=precision,
-                include_tags=False,
-            )
-            for hit in self._get_hits(response)
-        ]
-        points = self._filter_points(self._merge_points_by_time(points), where)
-        if filter_only_fields:
+
+        def get_filtered_points(hits):
             points = [
-                {
-                    field: value
-                    for field, value in point.items()
-                    if field not in filter_only_fields
-                }
-                for point in points
+                self._document_to_point(
+                    hit.get("_source", {}),
+                    fields=projection_fields,
+                    precision=precision,
+                    include_tags=False,
+                )
+                for hit in hits
             ]
+            points = self._merge_points_by_time(points, preserve_time_key=True)
+            return self._filter_points(points, where)
+
+        logical_limit = int(limit) if limit else None
+
+        def has_complete_limit(hits):
+            if not logical_limit or logical_limit < 0:
+                return False
+            points = get_filtered_points(hits)
+            if len(points) < logical_limit:
+                return False
+            boundary_time = points[logical_limit - 1]["__openwisp_time_key"]
+            last_hit_time = hits[-1].get("_source", {}).get("@timestamp")
+            return boundary_time != last_hit_time
+
+        hits = self._get_paginated_hits(
+            query,
+            should_stop=has_complete_limit if logical_limit else None,
+        )
+        points = get_filtered_points(hits)
+        hidden_fields = {*filter_only_fields, "__openwisp_time_key"}
+        points = [
+            {
+                field: value
+                for field, value in point.items()
+                if field not in hidden_fields
+            }
+            for point in points
+        ]
         return points[: int(limit)] if limit else points
 
     def _format_query_mapping(self, value, params):
@@ -1127,6 +1284,14 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _format_chart_metrics(self, query, params, fields=None):
         format_params = {**params}
+        dynamic_metric = query.get("dynamic_metric")
+        if dynamic_metric is not None:
+            if not fields:
+                return []
+            dynamic_metric = self._format_query_mapping(dynamic_metric, format_params)
+            return [
+                {**dynamic_metric, "name": field, "field": field} for field in fields
+            ]
         metrics = self._format_query_mapping(query.get("metrics", []), format_params)
         if fields:
             selected_fields = set(fields)
@@ -1139,8 +1304,9 @@ class DatabaseClient(BaseTimeseriesClient):
         return [metric for metric in metrics if metric.get("field")]
 
     def _build_metric_aggregation(self, metric):
-        field = f"fields.{metric['field']}"
         aggregation = metric.get("agg", "avg")
+        field_type = "keyword" if aggregation == "cardinality" else "numeric"
+        field = self._get_indexed_field_path(metric["field"], field_type)
         if aggregation == "sum":
             metric_aggregation = {"sum": {"field": field}}
         elif aggregation == "cardinality":
@@ -1262,6 +1428,9 @@ class DatabaseClient(BaseTimeseriesClient):
     def _normalize_raw_chart_fields(self, query, params, fields=None):
         if fields:
             return list(fields)
+        configured_fields = query.get("fields")
+        if configured_fields:
+            return list(self._format_query_mapping(configured_fields, params))
         field = self._format_query_mapping(query.get("field"), params)
         if not field or field == "{fields}":
             return ["*"]
@@ -1291,6 +1460,16 @@ class DatabaseClient(BaseTimeseriesClient):
             return False
         if self._is_openwisp_query(query):
             return bool(query.get("aggregate", query.get("__openwisp_aggregate", True)))
+        if query.get("aggs") or query.get("aggregations"):
+            raise ValidationError(
+                {
+                    "configuration": _(
+                        "Native Elasticsearch aggregations are not supported in "
+                        "chart queries. Use an OpenWISP Elasticsearch chart query "
+                        "descriptor instead."
+                    )
+                }
+            )
         validation_query = query.get("query", {"match_all": {}})
         try:
             response = self.db.indices.validate_query(
@@ -1301,30 +1480,11 @@ class DatabaseClient(BaseTimeseriesClient):
         except Exception as exception:
             if not self._is_not_found(exception):
                 raise
-            return self._is_aggregate(query)
+            return False
         response = self._response_body(response)
         if not response.get("valid", False):
             message = response.get("error") or _("Invalid Elasticsearch query")
             raise ValidationError({"configuration": message})
-        return self._is_aggregate(query)
-
-    def _is_aggregate(self, query) -> bool:
-        if not isinstance(query, Mapping):
-            return False
-        if self._is_openwisp_query(query):
-            return bool(query.get("aggregate", query.get("__openwisp_aggregate", True)))
-        aggregations = query.get("aggs") or query.get("aggregations")
-        if not isinstance(aggregations, Mapping):
-            return False
-        return self._contains_aggregate(aggregations)
-
-    def _contains_aggregate(self, value) -> bool:
-        if isinstance(value, Mapping):
-            if any(key in self._AGGREGATE for key in value.keys()):
-                return True
-            return any(self._contains_aggregate(item) for item in value.values())
-        if isinstance(value, list):
-            return any(self._contains_aggregate(item) for item in value)
         return False
 
     def get_query(
@@ -1451,7 +1611,7 @@ class DatabaseClient(BaseTimeseriesClient):
         metric_aggregation = aggregation.get(metric["name"], {})
         if "doc_count" in metric_aggregation:
             if metric_aggregation["doc_count"] == 0:
-                return None
+                return 0 if metric.get("agg") == "cardinality" else None
             metric_aggregation = metric_aggregation.get("value", {})
         if metric.get("agg") == "mode":
             buckets = metric_aggregation.get("buckets", [])
@@ -1512,7 +1672,7 @@ class DatabaseClient(BaseTimeseriesClient):
 
     def _extract_grouped_chart_value(self, bucket, metric):
         return self._extract_chart_metric_value(
-            {"value": bucket.get("value", {})}, metric
+            {metric["name"]: bucket.get("value", {})}, metric
         )
 
     def _warn_if_grouped_chart_truncated(self, aggregations, query):
@@ -1560,22 +1720,46 @@ class DatabaseClient(BaseTimeseriesClient):
                 points.append(point)
         return points
 
-    def _merge_points_by_time(self, points):
+    def _merge_points_by_time(self, points, preserve_time_key=False):
         merged = {}
         order = []
         for point in points:
             time_key = point.get("__openwisp_time_key", point.get("time"))
-            if time_key not in merged:
-                merged[time_key] = {"time": point.get("time")}
-                order.append(time_key)
-            merged[time_key].update(
+            series_key = (
+                time_key,
+                point.get("__openwisp_measurement_key"),
+                point.get("__openwisp_tags_key"),
+            )
+            if series_key not in merged:
+                merged[series_key] = {"time": point.get("time")}
+                if preserve_time_key:
+                    merged[series_key]["__openwisp_time_key"] = time_key
+                order.append(series_key)
+            merged[series_key].update(
                 {
                     key: value
                     for key, value in point.items()
-                    if key not in ("time", "__openwisp_time_key")
+                    if key != "time" and key not in _POINT_IDENTITY_FIELDS
                 }
             )
-        return [merged[time_key] for time_key in order]
+        return [merged[series_key] for series_key in order]
+
+    @staticmethod
+    def _backfill_raw_chart_fields(points, fields):
+        if not fields:
+            return points
+        expected_fields = [field for field in fields if field != "*"]
+        if "*" in fields:
+            expected_fields.extend(
+                field
+                for point in points
+                for field in point
+                if field != "time" and field not in expected_fields
+            )
+        for point in points:
+            for field in expected_fields:
+                point.setdefault(field, None)
+        return points
 
     def get_list_query(
         self, query: Mapping[str, Any], precision: str = "s"
@@ -1599,7 +1783,11 @@ class DatabaseClient(BaseTimeseriesClient):
         if self._is_openwisp_query(query, "grouped_chart"):
             response = self.query(query, precision=precision)
             return self._get_grouped_chart_points(response, query, precision=precision)
-        response = self.query(query, precision=precision)
+        if self._is_openwisp_query(query, "raw_chart"):
+            hits = self._get_paginated_hits(query)
+        else:
+            response = self.query(query, precision=precision)
+            hits = self._get_hits(response)
         fields = query.get("__openwisp_fields") if isinstance(query, Mapping) else None
         points = [
             self._document_to_point(
@@ -1608,9 +1796,12 @@ class DatabaseClient(BaseTimeseriesClient):
                 precision=precision,
                 include_tags=False,
             )
-            for hit in self._get_hits(response)
+            for hit in hits
         ]
-        return self._merge_points_by_time(points)
+        points = self._merge_points_by_time(points)
+        if self._is_openwisp_query(query, "raw_chart"):
+            return self._backfill_raw_chart_fields(points, fields)
+        return points
 
     def get_device_data_query(
         self,

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -1128,9 +1128,12 @@ class DatabaseClient(BaseTimeseriesClient):
         if not fields or fields == ["*"]:
             point.update(values)
         else:
+            tags = document.get("tags") or {}
             for field in fields:
                 if field in values:
                     point[field] = values[field]
+                elif field in tags:
+                    point[field] = tags[field]
         point.update(
             {
                 "__openwisp_time_key": timestamp,
@@ -1317,7 +1320,7 @@ class DatabaseClient(BaseTimeseriesClient):
             return {"terms": {tag_field: values}}
         return {"term": {tag_field: str(value)}}
 
-    def _build_chart_base_query(self, params, timezone_name=None):
+    def _build_chart_base_query(self, params, timezone_name=None, end_date=True):
         filters = []
         measurement_filter = self._build_measurement_filter(params.get("key"))
         if measurement_filter:
@@ -1327,7 +1330,7 @@ class DatabaseClient(BaseTimeseriesClient):
             time_filter["gte"] = self._get_timestamp(
                 params["time"], timezone_name=timezone_name
             )
-        if params.get("end_date"):
+        if end_date and params.get("end_date"):
             time_filter["lte"] = self._get_timestamp(
                 params["end_date"], timezone_name=timezone_name
             )
@@ -1397,7 +1400,11 @@ class DatabaseClient(BaseTimeseriesClient):
         metrics = self._format_chart_metrics(query, params, fields=fields)
         body = {
             "size": 0,
-            "query": self._build_chart_base_query(params, timezone_name=timezone),
+            "query": self._build_chart_base_query(
+                params,
+                timezone_name=timezone,
+                end_date=query.get("end_date", True),
+            ),
             "__index": self._get_stream_name(params.get("retention_policy")),
             "__openwisp_query_type": "chart",
             "__openwisp_metrics": metrics,

--- a/openwisp_monitoring/db/backends/elasticsearch/client.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/client.py
@@ -63,6 +63,13 @@ _POINT_IDENTITY_FIELDS = (
 )
 
 
+def _redact_url_userinfo(url):
+    parsed_url = urlparse(url)
+    if not parsed_url.username and not parsed_url.password:
+        return url
+    return parsed_url._replace(netloc=parsed_url.netloc.rsplit("@", 1)[-1]).geturl()
+
+
 def _normalize_datetime(value: datetime, precision="s"):
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
@@ -207,8 +214,8 @@ class DatabaseClient(BaseTimeseriesClient):
     _DEFAULT_ROLLOVER_SECONDS = 30 * 24 * 60 * 60
     _PIT_KEEP_ALIVE = "1m"
     _DISTINCT_PAGE_SIZE = 1000
-    # highest precision supported by the cardinality aggregation,
-    # counts below this threshold are exact
+    # highest precision supported by the cardinality aggregation;
+    # cardinality counts remain approximate even below this threshold
     _CARDINALITY_PRECISION = 40000
     # Wins over broad external templates that may also match OpenWISP streams.
     _OPENWISP_INDEX_TEMPLATE_PRIORITY = 500
@@ -317,13 +324,19 @@ class DatabaseClient(BaseTimeseriesClient):
                 TIMESERIES_DB["USER"],
                 TIMESERIES_DB["PASSWORD"],
             )
-        credentials = kwargs.keys() & {"api_key", "bearer_auth", "basic_auth"}
-        if credentials and url and urlparse(url).scheme == "http":
+        parsed_url = urlparse(url) if url else None
+        has_url_credentials = parsed_url and (
+            parsed_url.username or parsed_url.password
+        )
+        credentials = (
+            kwargs.keys() & {"api_key", "bearer_auth", "basic_auth"}
+        ) or has_url_credentials
+        if credentials and parsed_url and parsed_url.scheme == "http":
             logger.warning(
                 'Sending Elasticsearch credentials over insecure HTTP at "%s". '
                 'Consider switching TIMESERIES_DATABASE["URL"] to https:// when '
                 "running outside local development.",
-                url,
+                _redact_url_userinfo(url),
             )
         for setting_name, kwarg_name in (
             ("CA_CERTS", "ca_certs"),
@@ -500,7 +513,7 @@ class DatabaseClient(BaseTimeseriesClient):
                         },
                     ],
                     "properties": {
-                        "@timestamp": {"type": "date"},
+                        "@timestamp": {"type": "date_nanos"},
                         "measurement": {"type": "keyword"},
                         "openwisp_write_sequence": {
                             "type": "long",
@@ -700,6 +713,12 @@ class DatabaseClient(BaseTimeseriesClient):
             return ZoneInfo(str(timezone_name))
         except Exception:
             return timezone.utc
+
+    def _resolve_timezone_name(self, timezone_name=None):
+        if not timezone_name:
+            return None
+        timezone_obj = self._get_timezone(timezone_name)
+        return getattr(timezone_obj, "key", "UTC")
 
     def _parse_timestamp(self, timestamp):
         if isinstance(timestamp, datetime):
@@ -1602,6 +1621,7 @@ class DatabaseClient(BaseTimeseriesClient):
             query = self.get_default_chart_query(
                 has_object_scope=bool(params.get("object_id"))
             )
+        timezone = self._resolve_timezone_name(timezone)
         if self._is_openwisp_query(query, "chart"):
             return self._build_chart_query(
                 query,

--- a/openwisp_monitoring/db/backends/elasticsearch/queries.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/queries.py
@@ -1,0 +1,165 @@
+from copy import deepcopy
+
+
+class ElasticsearchQuery(dict):
+    def replace(self, old, new):
+        query = deepcopy(self)
+
+        def replace_value(value):
+            if isinstance(value, str):
+                return value.replace(old, new)
+            if isinstance(value, dict):
+                return {key: replace_value(item) for key, item in value.items()}
+            if isinstance(value, list):
+                return [replace_value(item) for item in value]
+            return value
+
+        return ElasticsearchQuery(replace_value(query))
+
+
+class ElasticsearchDefaultChartQuery:
+    def resolve(self, has_object_scope=False):
+        filters = ["content_type", "object_id"] if has_object_scope else []
+        return ElasticsearchQuery(
+            {
+                "__openwisp_query_type": "raw_chart",
+                "aggregate": False,
+                "field": "{field_name}",
+                "filters": filters,
+            }
+        )
+
+
+def _metric(name, field, agg="avg", scale=None, round_value=False):
+    metric = {"name": name, "field": field, "agg": agg}
+    if scale is not None:
+        metric["scale"] = scale
+    if round_value:
+        metric["round"] = True
+    return metric
+
+
+def _chart(*metrics):
+    return ElasticsearchQuery(
+        {
+            "__openwisp_query_type": "chart",
+            "aggregate": True,
+            "metrics": list(metrics),
+        }
+    )
+
+
+_gb = 1 / 1000000000
+
+chart_query = {
+    "uptime": {
+        "elasticsearch": _chart(
+            _metric("uptime", "{field_name}", scale=100),
+        )
+    },
+    "packet_loss": {
+        "elasticsearch": _chart(
+            _metric("packet_loss", "loss"),
+        )
+    },
+    "rtt": {
+        "elasticsearch": _chart(
+            _metric("RTT_average", "rtt_avg"),
+            _metric("RTT_max", "rtt_max"),
+            _metric("RTT_min", "rtt_min"),
+        )
+    },
+    "wifi_clients": {
+        "elasticsearch": _chart(
+            _metric("wifi_clients", "{field_name}", agg="cardinality"),
+        )
+    },
+    "general_wifi_clients": {
+        "elasticsearch": _chart(
+            _metric("wifi_clients", "{field_name}", agg="cardinality"),
+        )
+    },
+    "traffic": {
+        "elasticsearch": _chart(
+            _metric("upload", "tx_bytes", agg="sum", scale=_gb),
+            _metric("download", "rx_bytes", agg="sum", scale=_gb),
+        )
+    },
+    "general_traffic": {
+        "elasticsearch": _chart(
+            _metric("upload", "tx_bytes", agg="sum", scale=_gb),
+            _metric("download", "rx_bytes", agg="sum", scale=_gb),
+        )
+    },
+    "memory": {
+        "elasticsearch": _chart(
+            _metric("memory_usage", "percent_used"),
+        )
+    },
+    "cpu": {
+        "elasticsearch": _chart(
+            _metric("CPU_load", "cpu_usage"),
+        )
+    },
+    "disk": {
+        "elasticsearch": _chart(
+            _metric("disk_usage", "used_disk"),
+        )
+    },
+    "signal_strength": {
+        "elasticsearch": _chart(
+            _metric("signal_strength", "signal_strength", round_value=True),
+            _metric("signal_power", "signal_power", round_value=True),
+        )
+    },
+    "signal_quality": {
+        "elasticsearch": _chart(
+            _metric("signal_quality", "signal_quality", round_value=True),
+            _metric("signal_to_noise_ratio", "snr", round_value=True),
+        )
+    },
+    "access_tech": {
+        "elasticsearch": _chart(
+            _metric("access_tech", "access_tech", agg="mode"),
+        )
+    },
+    "bandwidth": {
+        "elasticsearch": _chart(
+            _metric("TCP", "sent_bps_tcp", scale=_gb),
+            _metric("UDP", "sent_bps_udp", scale=_gb),
+        )
+    },
+    "transfer": {
+        "elasticsearch": _chart(
+            _metric("TCP", "sent_bytes_tcp", agg="sum", scale=_gb),
+            _metric("UDP", "sent_bytes_udp", agg="sum", scale=_gb),
+        )
+    },
+    "retransmits": {
+        "elasticsearch": _chart(
+            _metric("retransmits", "retransmits"),
+        )
+    },
+    "jitter": {
+        "elasticsearch": _chart(
+            _metric("jitter", "jitter"),
+        )
+    },
+    "datagram": {
+        "elasticsearch": _chart(
+            _metric("lost_datagram", "lost_packets"),
+            _metric("total_datagram", "total_packets"),
+        )
+    },
+    "datagram_loss": {
+        "elasticsearch": _chart(
+            _metric("datagram_loss", "lost_percent"),
+        )
+    },
+}
+
+summary_query = {
+    key: {"elasticsearch": value["elasticsearch"]} for key, value in chart_query.items()
+}
+default_chart_query = ElasticsearchDefaultChartQuery()
+device_data_query = "elasticsearch-device-data-query"

--- a/openwisp_monitoring/db/backends/elasticsearch/queries.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/queries.py
@@ -16,18 +16,8 @@ class ElasticsearchQuery(dict):
 
         return ElasticsearchQuery(replace_value(query))
 
-
-class ElasticsearchDefaultChartQuery:
-    def resolve(self, has_object_scope=False):
-        filters = ["content_type", "object_id"] if has_object_scope else []
-        return ElasticsearchQuery(
-            {
-                "__openwisp_query_type": "raw_chart",
-                "aggregate": False,
-                "field": "{field_name}",
-                "filters": filters,
-            }
-        )
+    def resolve(self):
+        return ElasticsearchQuery(deepcopy(self))
 
 
 def _metric(name, field, agg="avg", scale=None, round_value=False):
@@ -49,7 +39,9 @@ def _chart(*metrics):
     )
 
 
-_gb = 1 / 1000000000
+_gb = (
+    1 / 1000000000
+)  # Scale byte-based traffic and transfer metrics to decimal gigabytes for charts.
 
 chart_query = {
     "uptime": {
@@ -161,5 +153,11 @@ chart_query = {
 summary_query = {
     key: {"elasticsearch": value["elasticsearch"]} for key, value in chart_query.items()
 }
-default_chart_query = ElasticsearchDefaultChartQuery()
+default_chart_query = ElasticsearchQuery(
+    {
+        "__openwisp_query_type": "raw_chart",
+        "aggregate": False,
+        "field": "{field_name}",
+    }
+)
 device_data_query = "elasticsearch-device-data-query"

--- a/openwisp_monitoring/db/backends/elasticsearch/queries.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/queries.py
@@ -29,12 +29,13 @@ def _metric(name, field, agg="avg", scale=None, round_value=False):
     return metric
 
 
-def _chart(*metrics):
+def _chart(*metrics, end_date=True):
     return ElasticsearchQuery(
         {
             "__openwisp_query_type": "chart",
             "aggregate": True,
             "metrics": list(metrics),
+            "end_date": end_date,
         }
     )
 

--- a/openwisp_monitoring/db/backends/elasticsearch/queries.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/queries.py
@@ -16,7 +16,7 @@ class ElasticsearchQuery(dict):
 
         return ElasticsearchQuery(replace_value(query))
 
-    def resolve(self):
+    def resolve(self, has_object_scope=False):
         return ElasticsearchQuery(deepcopy(self))
 
 

--- a/openwisp_monitoring/db/backends/elasticsearch/queries.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/queries.py
@@ -151,7 +151,8 @@ chart_query = {
 }
 
 summary_query = {
-    key: {"elasticsearch": value["elasticsearch"]} for key, value in chart_query.items()
+    key: {"elasticsearch": value["elasticsearch"].resolve()}
+    for key, value in chart_query.items()
 }
 default_chart_query = ElasticsearchQuery(
     {

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -1269,15 +1269,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
                 {
                     "top_metrics": {
                         "metrics": {"field": "indexed_fields.numeric.value"},
-                        "sort": [
-                            {"@timestamp": "desc"},
-                            {
-                                "openwisp_write_sequence": {
-                                    "order": "desc",
-                                    "unmapped_type": "long",
-                                }
-                            },
-                        ],
+                        "sort": {"@timestamp": "desc"},
                     }
                 },
             ),

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -1627,6 +1627,16 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             "tags.method",
         )
 
+    def test_grouped_chart_query_can_opt_out_of_object_scope(self):
+        query = self._build_grouped_query(object_scope=False)
+        filters = query["query"]["bool"]["filter"]
+        self.assertNotIn({"term": {"tags.content_type": "config.device"}}, filters)
+        self.assertNotIn({"term": {"tags.object_id": "device-1"}}, filters)
+        self.assertEqual(
+            query["aggs"]["timeseries"]["aggs"]["groups"]["terms"]["field"],
+            "tags.method",
+        )
+
     def test_grouped_chart_last_aggregation(self):
         query = self._build_grouped_query(
             metric={"name": "count", "field": "count", "agg": "last"}

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -1253,11 +1253,33 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             ("sum", {"sum": {"field": "indexed_fields.numeric.value"}}),
             (
                 "cardinality",
-                {"cardinality": {"field": "indexed_fields.keyword.value"}},
+                {
+                    "cardinality": {
+                        "field": "indexed_fields.keyword.value",
+                        "precision_threshold": 40000,
+                    }
+                },
             ),
             (
                 "mode",
                 {"terms": {"field": "indexed_fields.numeric.value", "size": 1}},
+            ),
+            (
+                "last",
+                {
+                    "top_metrics": {
+                        "metrics": {"field": "indexed_fields.numeric.value"},
+                        "sort": [
+                            {"@timestamp": "desc"},
+                            {
+                                "openwisp_write_sequence": {
+                                    "order": "desc",
+                                    "unmapped_type": "long",
+                                }
+                            },
+                        ],
+                    }
+                },
             ),
             ("unknown", {"avg": {"field": "indexed_fields.numeric.value"}}),
         )
@@ -1572,6 +1594,118 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(self.timeseries_db.get_list_query(query), [])
 
+    _GROUPED_CHART_QUERY = {
+        "__openwisp_query_type": "grouped_chart",
+        "aggregate": True,
+        "group_by": "method",
+        "metric": {"name": "count", "field": "count", "agg": "sum"},
+    }
+
+    def _build_grouped_query(self, **overrides):
+        params = {
+            "key": "radius_acc",
+            "content_type": "config.device",
+            "object_id": "device-1",
+            "method": "mobile_phone",
+        }
+        params.update(overrides.pop("params", {}))
+        return self.timeseries_db.get_query(
+            chart_type="stackedbar+lines",
+            params=params,
+            time="30d",
+            group_map={"30d": "1d"},
+            query={**self._GROUPED_CHART_QUERY, **overrides},
+        )
+
+    def test_grouped_chart_query_keeps_object_scope(self):
+        query = self._build_grouped_query()
+        filters = query["query"]["bool"]["filter"]
+        self.assertIn({"term": {"tags.content_type": "config.device"}}, filters)
+        self.assertIn({"term": {"tags.object_id": "device-1"}}, filters)
+        self.assertEqual(
+            query["aggs"]["timeseries"]["aggs"]["groups"]["terms"]["field"],
+            "tags.method",
+        )
+
+    def test_grouped_chart_last_aggregation(self):
+        query = self._build_grouped_query(
+            metric={"name": "count", "field": "count", "agg": "last"}
+        )
+        aggregation = query["aggs"]["timeseries"]["aggs"]["groups"]["aggs"]["value"]
+        self.assertEqual(
+            aggregation["aggs"]["value"]["top_metrics"]["metrics"],
+            {"field": "indexed_fields.numeric.count"},
+        )
+        response = {
+            "aggregations": {
+                "timeseries": {
+                    "buckets": [
+                        {
+                            "key": 1711368000000,
+                            "groups": {
+                                "buckets": [
+                                    {
+                                        "key": "mobile_phone",
+                                        "value": {
+                                            "doc_count": 2,
+                                            "value": {
+                                                "top": [
+                                                    {
+                                                        "metrics": {
+                                                            "indexed_fields."
+                                                            "numeric.count": 7
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                        },
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+        points = self.timeseries_db._get_grouped_chart_points(response, query)
+        self.assertEqual(points, [{"time": 1711368000, "mobile_phone": 7}])
+
+    def test_grouped_chart_fill_previous(self):
+        query = self._build_grouped_query(
+            metric={"name": "count", "field": "count", "agg": "sum"},
+            fill="previous",
+        )
+        self.assertEqual(query["__openwisp_fill"], "previous")
+
+        def bucket(key, value=None):
+            groups = {"buckets": []}
+            if value is not None:
+                groups["buckets"].append(
+                    {"key": "mobile_phone", "value": {"doc_count": 1, "value": value}}
+                )
+            return {"key": key, "groups": groups}
+
+        response = {
+            "aggregations": {
+                "timeseries": {
+                    "buckets": [
+                        bucket(1711368000000, {"value": 3}),
+                        bucket(1711454400000),
+                        bucket(1711540800000, {"value": 5}),
+                    ]
+                }
+            }
+        }
+        points = self.timeseries_db._get_grouped_chart_points(response, query)
+        self.assertEqual(
+            points,
+            [
+                {"time": 1711368000, "mobile_phone": 3},
+                {"time": 1711454400, "mobile_phone": 3},
+                {"time": 1711540800, "mobile_phone": 5},
+            ],
+        )
+
     def test_grouped_chart_truncation_logs_once(self):
         query = {
             "__openwisp_metric": {"name": "clients", "field": "clients"},
@@ -1841,6 +1975,33 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertIn({"term": {"tags.host": "server1"}}, filters)
         self.assertTrue(first_call.kwargs["refresh"])
         mock_indices.assert_called_once()
+
+    @patch.object(DatabaseClient, "_get_data_stream_names", return_value=["openwisp2"])
+    @patch.object(DatabaseClient, "_get_index_names", return_value=[])
+    def test_delete_metric_data_at_timestamp(self, mock_indices, mock_streams):
+        mock_db = self._mock_db()
+        timestamp = datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc)
+        self.timeseries_db.delete_metric_data(
+            key="radius_acc",
+            tags={"organization_id": "org"},
+            timestamp=timestamp,
+        )
+        filters = mock_db.delete_by_query.call_args.kwargs["body"]["query"]["bool"][
+            "filter"
+        ]
+        serialized_timestamp = self.timeseries_db._get_timestamp(timestamp)
+        self.assertIn(
+            {
+                "range": {
+                    "@timestamp": {
+                        "gte": serialized_timestamp,
+                        "lte": serialized_timestamp,
+                    }
+                }
+            },
+            filters,
+        )
+        self.assertIn({"term": {"tags.organization_id": "org"}}, filters)
 
     @patch("openwisp_monitoring.utils.sleep")
     @patch.object(DatabaseClient, "_get_data_stream_names", return_value=["openwisp2"])
@@ -2643,6 +2804,52 @@ class TestElasticsearchClientIntegration(
             if value is not None
         ]
         self.assertEqual(non_null_points, [local_midnight.strftime("%Y-%m-%d %H:%M")])
+
+    def test_grouped_chart_counts_distinct_values_per_tag(self):
+        timestamp = now()
+        device = {"content_type": "config.device", "object_id": "device-1"}
+        other_device = {"content_type": "config.device", "object_id": "device-2"}
+        sessions = (
+            ({**device, "method": "mobile_phone"}, "user1"),
+            ({**device, "method": "mobile_phone"}, "user2"),
+            ({**device, "method": "mobile_phone"}, "user2"),
+            ({**device, "method": "email"}, "user3"),
+            ({**other_device, "method": "email"}, "user4"),
+        )
+        for tags, username in sessions:
+            timeseries_db.write(
+                "radius_acc",
+                {"username": username},
+                tags=tags,
+                timestamp=timestamp,
+            )
+        query = timeseries_db.get_query(
+            chart_type="stackedbar+lines",
+            params={
+                "key": "radius_acc",
+                "time": timestamp - timedelta(days=1),
+                **device,
+            },
+            time="30d",
+            group_map={"30d": "1d"},
+            query={
+                "__openwisp_query_type": "grouped_chart",
+                "aggregate": True,
+                "group_by": "method",
+                "metric": {
+                    "name": "sessions",
+                    "field": "username",
+                    "agg": "cardinality",
+                },
+            },
+        )
+        values = {}
+        for point in timeseries_db.get_list_query(query):
+            for key, value in point.items():
+                if key != "time" and value:
+                    values[key] = value
+        # user2 is counted once and the session of device-2 is not counted
+        self.assertEqual(values, {"mobile_phone": 2, "email": 1})
 
     def test_delete_metric_data_and_delete_series_round_trip(self):
         general_metric = self._create_general_metric(name="delete-general")

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -5,6 +5,7 @@ Elasticsearch Database Client Tests
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
+from uuid import UUID
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -61,6 +62,35 @@ def _search_response(*documents, aggregations=None):
             "hits": [{"_source": document} for document in documents],
         },
         "aggregations": aggregations or {},
+    }
+
+
+def _search_hit(document, sort):
+    return {"_source": document, "sort": sort}
+
+
+def _paginated_search_response(pit_id, *hits):
+    return {"pit_id": pit_id, "hits": {"hits": list(hits)}}
+
+
+def _field_exists_filter(field):
+    return {
+        "bool": {
+            "should": [
+                {"exists": {"field": f"indexed_fields.keyword.{field}"}},
+                {"exists": {"field": f"indexed_fields.numeric.{field}"}},
+                {"exists": {"field": f"indexed_fields.boolean.{field}"}},
+                {"term": {"_ignored": f"indexed_fields.keyword.{field}"}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def _resource_metadata(database="openwisp2"):
+    return {
+        "description": "OpenWISP Monitoring Elasticsearch data stream data",
+        "openwisp_monitoring": {"database": database},
     }
 
 
@@ -261,6 +291,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     def test_build_index_template_uses_data_stream_settings(self):
         body = self.timeseries_db._build_index_template_body(SHORT_RP)
         self.assertEqual(body["index_patterns"], ["openwisp2-short"])
+        self.assertEqual(body["_meta"], _resource_metadata())
         settings_body = body["template"]["settings"]
         self.assertEqual(settings_body["index.lifecycle.name"], "openwisp2-short-ilm")
         self.assertNotIn("lifecycle", body["template"])
@@ -268,17 +299,53 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertNotIn("index.look_ahead_time", settings_body)
         self.assertNotIn("index.look_back_time", settings_body)
         self.assertNotIn("index.routing_path", settings_body)
+        self.assertEqual(
+            body["template"]["mappings"]["_source"],
+            {"excludes": ["indexed_fields"]},
+        )
+        self.assertEqual(
+            body["template"]["mappings"]["_meta"],
+            _resource_metadata(),
+        )
         mappings = body["template"]["mappings"]["properties"]
         self.assertEqual(mappings["@timestamp"], {"type": "date"})
         self.assertEqual(mappings["measurement"], {"type": "keyword"})
         self.assertNotIn("openwisp_series_id", mappings)
         self.assertNotIn("openwisp_doc_count", mappings)
         self.assertEqual(mappings["openwisp_write_sequence"]["type"], "long")
+        self.assertEqual(
+            mappings["fields"],
+            {"type": "object", "enabled": False},
+        )
+        self.assertEqual(
+            mappings["indexed_fields"],
+            {"type": "object", "dynamic": True},
+        )
+        templates = body["template"]["mappings"]["dynamic_templates"]
+        self.assertIn(
+            {
+                "keyword_fields": {
+                    "path_match": "indexed_fields.keyword.*",
+                    "mapping": {"type": "keyword", "ignore_above": 8192},
+                }
+            },
+            templates,
+        )
+        self.assertIn(
+            {
+                "numeric_fields": {
+                    "path_match": "indexed_fields.numeric.*",
+                    "mapping": {"type": "double"},
+                }
+            },
+            templates,
+        )
 
     def test_build_lifecycle_policy_bounds_rollover_age(self):
         short_policy = self.timeseries_db._build_lifecycle_policy("24h0m0s")
         default_policy = self.timeseries_db._build_lifecycle_policy("26280h0m0s")
         no_retention_policy = self.timeseries_db._build_lifecycle_policy()
+        self.assertEqual(short_policy["_meta"], _resource_metadata())
         self.assertEqual(
             short_policy["phases"]["hot"]["actions"]["rollover"]["max_age"],
             "86400s",
@@ -367,13 +434,22 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         mock_db = self._mock_db()
         mock_db.ilm.get_lifecycle.return_value = {
             "openwisp2-autogen-ilm": {
-                "policy": {"phases": {"delete": {"min_age": "94608000s"}}}
+                "policy": {
+                    "_meta": _resource_metadata(),
+                    "phases": {"delete": {"min_age": "94608000s"}},
+                }
             },
             "openwisp2-short-ilm": {
-                "policy": {"phases": {"delete": {"min_age": "86400s"}}}
+                "policy": {
+                    "_meta": _resource_metadata(),
+                    "phases": {"delete": {"min_age": "86400s"}},
+                }
             },
-            "another-project-autogen-ilm": {
-                "policy": {"phases": {"delete": {"min_age": "60s"}}}
+            "openwisp2-prod-autogen-ilm": {
+                "policy": {
+                    "_meta": _resource_metadata("openwisp2-prod"),
+                    "phases": {"delete": {"min_age": "60s"}},
+                }
             },
         }
         policies = self.timeseries_db.get_list_retention_policies()
@@ -396,14 +472,16 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         mock_db.ilm.get_lifecycle.assert_called_once_with(name="openwisp2-*-ilm")
 
-    def test_get_data_stream_names_filters_namespace(self):
+    def test_get_data_stream_names_filters_exact_owner(self):
         mock_db = self._mock_db()
         mock_db.indices.get_data_stream.return_value = {
             "data_streams": [
-                {"name": "openwisp2"},
-                {"name": "openwisp2-short"},
-                {"name": "openwisp2_test"},
-                {"name": "openwisp20"},
+                {"name": "openwisp2", "_meta": _resource_metadata()},
+                {"name": "openwisp2-short", "_meta": _resource_metadata()},
+                {
+                    "name": "openwisp2-prod",
+                    "_meta": _resource_metadata("openwisp2-prod"),
+                },
             ]
         }
         self.assertEqual(
@@ -411,12 +489,14 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             ["openwisp2", "openwisp2-short"],
         )
 
-    def test_get_index_names_filters_data_stream_backing_indices(self):
+    def test_get_index_names_filters_exact_owner(self):
         mock_db = self._mock_db()
         mock_db.indices.get.return_value = {
-            "openwisp2": {},
-            "openwisp2-short": {},
-            "openwisp2_test": {},
+            "openwisp2": {"mappings": {"_meta": _resource_metadata()}},
+            "openwisp2-short": {"mappings": {"_meta": _resource_metadata()}},
+            "openwisp2-prod": {
+                "mappings": {"_meta": _resource_metadata("openwisp2-prod")}
+            },
             ".ds-openwisp2-2026.07.27-000001": {},
         }
         self.assertEqual(
@@ -431,8 +511,8 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     ):
         mock_db = self._mock_db()
         mock_db.indices.get.return_value = {
-            "openwisp2": {},
-            "openwisp2-short": {},
+            "openwisp2": {"mappings": {"_meta": _resource_metadata()}},
+            "openwisp2-short": {"mappings": {"_meta": _resource_metadata()}},
             ".ds-openwisp2-2026.07.27-000001": {},
         }
         self.timeseries_db.drop_database()
@@ -447,23 +527,46 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         mock_templates.assert_called_once()
         mock_policies.assert_called_once()
 
-    def test_drop_database_deletes_only_namespaced_resources(self):
+    def test_drop_database_deletes_only_resources_with_exact_owner(self):
         mock_db = self._mock_db()
         mock_db.indices.get_data_stream.return_value = {
             "data_streams": [
-                {"name": "openwisp2"},
-                {"name": "openwisp2-short"},
-                {"name": "another-project"},
+                {"name": "openwisp2", "_meta": _resource_metadata()},
+                {"name": "openwisp2-short", "_meta": _resource_metadata()},
+                {
+                    "name": "openwisp2-prod",
+                    "_meta": _resource_metadata("openwisp2-prod"),
+                },
             ]
         }
         mock_db.indices.get.return_value = {
-            "openwisp2-legacy": {},
-            "another-project": {},
+            "openwisp2-legacy": {"mappings": {"_meta": _resource_metadata()}},
+            "openwisp2-prod-legacy": {
+                "mappings": {"_meta": _resource_metadata("openwisp2-prod")}
+            },
+        }
+        mock_db.indices.get_index_template.return_value = {
+            "index_templates": [
+                {
+                    "name": "openwisp2-template",
+                    "index_template": {"_meta": _resource_metadata()},
+                },
+                {
+                    "name": "openwisp2-short-template",
+                    "index_template": {"_meta": _resource_metadata()},
+                },
+                {
+                    "name": "openwisp2-prod-template",
+                    "index_template": {"_meta": _resource_metadata("openwisp2-prod")},
+                },
+            ]
         }
         mock_db.ilm.get_lifecycle.return_value = {
-            "openwisp2-autogen-ilm": {},
-            "openwisp2-short-ilm": {},
-            "another-project-autogen-ilm": {},
+            "openwisp2-autogen-ilm": {"policy": {"_meta": _resource_metadata()}},
+            "openwisp2-short-ilm": {"policy": {"_meta": _resource_metadata()}},
+            "openwisp2-prod-autogen-ilm": {
+                "policy": {"_meta": _resource_metadata("openwisp2-prod")}
+            },
         }
         self.timeseries_db.drop_database()
         self.assertEqual(
@@ -478,10 +581,10 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             mock_db.indices.delete_index_template.call_args_list,
             [
                 call(name="openwisp2-template"),
-                call(name="openwisp2-*-template"),
+                call(name="openwisp2-short-template"),
             ],
         )
-        mock_db.indices.get_index_template.assert_not_called()
+        mock_db.indices.get_index_template.assert_called_once_with(name="openwisp2*")
         self.assertEqual(
             mock_db.ilm.delete_lifecycle.call_args_list,
             [
@@ -563,20 +666,50 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             {"usage": 10},
             tags={"host": "server1"},
             timestamp=timestamp,
+            operation_id="operation-1",
         )
         mock_ensure.assert_not_called()
         mock_db.index.assert_called_once_with(
             index="openwisp2",
+            id="operation-1",
             document={
                 "@timestamp": "2024-03-25T12:00:00Z",
                 "measurement": "cpu",
                 "openwisp_write_sequence": 0,
                 "tags": {"host": "server1"},
                 "fields": {"usage": 10},
+                "indexed_fields": {"numeric": {"usage": 10}},
             },
             op_type="create",
             refresh="wait_for",
         )
+
+    @patch.object(monitoring_tasks.timeseries_write, "delay")
+    def test_write_operation_id_is_created_before_enqueue(self, mock_delay):
+        monitoring_tasks._timeseries_write("cpu", {"usage": 10})
+        operation_id = mock_delay.call_args.kwargs["operation_id"]
+        self.assertEqual(UUID(operation_id).hex, operation_id)
+
+    @patch.object(monitoring_tasks.timeseries_batch_write, "delay")
+    def test_batch_operation_ids_are_created_before_enqueue(self, mock_delay):
+        data = [
+            {
+                "name": "cpu",
+                "values": {"usage": 10},
+                "metric": MagicMock(pk="metric-1"),
+            },
+            {
+                "name": "cpu",
+                "values": {"usage": 10},
+                "metric": MagicMock(pk="metric-2"),
+            },
+        ]
+        monitoring_tasks._timeseries_batch_write(data)
+        queued_data = mock_delay.call_args.kwargs["data"]
+        operation_ids = [item["operation_id"] for item in queued_data]
+        self.assertEqual(len(set(operation_ids)), 2)
+        for operation_id in operation_ids:
+            self.assertEqual(UUID(operation_id).hex, operation_id)
 
     @patch.object(DatabaseClient, "_ensure_data_stream_resources")
     def test_write_preserves_zero_timestamp(self, mock_ensure):
@@ -599,6 +732,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
                     "values": {"usage": 10},
                     "tags": {"host": "server1"},
                     "timestamp": timestamp,
+                    "operation_id": "operation-1",
                 },
                 {
                     "name": "memory",
@@ -606,6 +740,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
                     "tags": {"host": "server1"},
                     "timestamp": timestamp,
                     "retention_policy": SHORT_RP,
+                    "operation_id": "operation-2",
                 },
                 {
                     "name": "disk",
@@ -613,6 +748,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
                     "tags": {"host": "server1"},
                     "timestamp": timestamp,
                     "retention_policy": SHORT_RP,
+                    "operation_id": "operation-3",
                 },
             ]
         )
@@ -620,9 +756,19 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         actions = mock_bulk.call_args.args[1]
         self.assertEqual(actions[0]["_op_type"], "create")
         self.assertEqual(actions[0]["_index"], "openwisp2")
+        self.assertEqual(actions[0]["_id"], "operation-1")
         self.assertEqual(actions[1]["_index"], "openwisp2-short")
         self.assertEqual(actions[2]["_source"]["fields"], {"used": 30})
-        mock_bulk.assert_called_once_with(mock_db, actions, refresh="wait_for")
+        self.assertEqual(
+            actions[2]["_source"]["indexed_fields"],
+            {"numeric": {"used": 30}},
+        )
+        mock_bulk.assert_called_once_with(
+            mock_db,
+            actions,
+            refresh="wait_for",
+            ignore_status=(409,),
+        )
 
     @patch.object(DatabaseClient, "_ensure_data_stream_resources")
     @patch("openwisp_monitoring.db.backends.elasticsearch.client.logger.warning")
@@ -639,6 +785,16 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         mocked_warning.assert_called_once()
         mock_ensure.assert_not_called()
+
+    @patch(
+        "openwisp_monitoring.db.backends.elasticsearch.client.bulk",
+        side_effect=RuntimeError("bulk write failed"),
+    )
+    def test_batch_write_failure_raises_timeseries_exception(self, mock_bulk):
+        self._mock_db()
+        with self.assertRaises(TimeseriesWriteException):
+            self.timeseries_db.batch_write([{"name": "cpu", "values": {"usage": 10}}])
+        mock_bulk.assert_called_once()
 
     @patch.object(DatabaseClient, "_ensure_data_stream_resources")
     def test_write_failure_raises_timeseries_exception(self, mock_ensure):
@@ -713,10 +869,8 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             body={"query": {"match_all": {}}},
         )
 
-    @patch.object(
-        DatabaseClient, "query", return_value=QueryResultSet(_search_response())
-    )
-    def test_read_builds_search_body(self, mock_query):
+    @patch.object(DatabaseClient, "_get_paginated_hits", return_value=[])
+    def test_read_builds_search_body(self, mock_get_hits):
         since = datetime(2024, 3, 25, 10, 0, tzinfo=timezone.utc)
         self.timeseries_db.read(
             key="cpu,memory",
@@ -728,7 +882,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             limit=5,
             retention_policy=SHORT_RP,
         )
-        query = mock_query.call_args.args[0]
+        query = mock_get_hits.call_args.args[0]
         self.assertEqual(query["size"], 10000)
         self.assertEqual(
             query["sort"],
@@ -741,38 +895,34 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         filters = query["query"]["bool"]["filter"]
         self.assertIn({"terms": {"measurement": ["cpu", "memory"]}}, filters)
         self.assertIn({"term": {"tags.host": "server1"}}, filters)
-        self.assertIn({"exists": {"field": "fields.usage"}}, filters)
+        self.assertIn(_field_exists_filter("usage"), filters)
         self.assertIn(
             {"range": {"@timestamp": {"gte": "2024-03-25T10:00:00Z"}}},
             filters,
         )
 
-    @patch.object(DatabaseClient, "query")
-    def test_read_returns_selected_fields(self, mock_query):
-        mock_query.return_value = QueryResultSet(
-            _search_response(
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "cpu",
-                    "tags": {"host": "server1"},
-                    "fields": {"usage": 10, "load": 2},
-                }
-            )
-        )
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_read_returns_selected_fields(self, mock_get_hits):
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "cpu",
+                "tags": {"host": "server1"},
+                "fields": {"usage": 10, "load": 2},
+            }
+        )["hits"]["hits"]
         points = self.timeseries_db.read("cpu", "usage", {"host": "server1"})
         self.assertEqual(points, [{"time": 1711368000, "usage": 10}])
 
-    @patch.object(DatabaseClient, "query")
-    def test_read_filters_by_unselected_field(self, mock_query):
-        mock_query.return_value = QueryResultSet(
-            _search_response(
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "load",
-                    "fields": {"value": 10, "related": 100},
-                }
-            )
-        )
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_read_filters_by_unselected_field(self, mock_get_hits):
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "load",
+                "fields": {"value": 10, "related": 100},
+            }
+        )["hits"]["hits"]
         points = self.timeseries_db.read(
             "load",
             "value",
@@ -781,24 +931,24 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(points, [{"time": 1711368000, "value": 10}])
 
-    @patch.object(DatabaseClient, "query")
-    def test_read_deduplicates_same_timestamp_before_where_filtering(self, mock_query):
-        mock_query.return_value = QueryResultSet(
-            _search_response(
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "ping",
-                    "tags": {"object_id": "1"},
-                    "fields": {"reachable": 0},
-                },
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "ping",
-                    "tags": {"object_id": "1"},
-                    "fields": {"reachable": 1},
-                },
-            )
-        )
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_read_deduplicates_same_timestamp_before_where_filtering(
+        self, mock_get_hits
+    ):
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "ping",
+                "tags": {"object_id": "1"},
+                "fields": {"reachable": 0},
+            },
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "ping",
+                "tags": {"object_id": "1"},
+                "fields": {"reachable": 1},
+            },
+        )["hits"]["hits"]
         points = self.timeseries_db.read(
             "ping",
             "reachable",
@@ -807,19 +957,134 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(points, [])
 
-    @patch.object(DatabaseClient, "query")
-    def test_read_supports_wildcard_extra_fields(self, mock_query):
-        mock_query.return_value = QueryResultSet(
-            _search_response(
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "cpu",
-                    "fields": {"usage": 10, "load": 2},
-                }
-            )
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_read_keeps_measurements_and_tag_series_separate(self, mock_get_hits):
+        timestamp = "2024-03-25T12:00:00Z"
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": timestamp,
+                "measurement": "cpu",
+                "tags": {"host": "router1", "ifname": "eth0"},
+                "fields": {"usage": 72},
+            },
+            {
+                "@timestamp": timestamp,
+                "measurement": "cpu",
+                "tags": {"ifname": "eth0", "host": "router1"},
+                "fields": {"load": 1},
+            },
+            {
+                "@timestamp": timestamp,
+                "measurement": "memory",
+                "tags": {"host": "router1", "ifname": "eth0"},
+                "fields": {"usage": 91},
+            },
+            {
+                "@timestamp": timestamp,
+                "measurement": "cpu",
+                "tags": {"host": "router2", "ifname": "eth0"},
+                "fields": {"usage": 55},
+            },
+        )["hits"]["hits"]
+
+        self.assertEqual(
+            self.timeseries_db.read(
+                "cpu,memory",
+                ["usage", "load"],
+                {},
+            ),
+            [
+                {"time": 1711368000, "usage": 72, "load": 1},
+                {"time": 1711368000, "usage": 91},
+                {"time": 1711368000, "usage": 55},
+            ],
         )
+
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_read_supports_wildcard_extra_fields(self, mock_get_hits):
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "cpu",
+                "fields": {"usage": 10, "load": 2},
+            }
+        )["hits"]["hits"]
         points = self.timeseries_db.read("cpu", "usage", {}, extra_fields="*")
         self.assertEqual(points, [{"time": 1711368000, "usage": 10, "load": 2}])
+
+    @patch.dict(
+        "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
+        {"OPTIONS": {"read_size": 2}},
+    )
+    def test_read_paginates_until_where_limit_after_timestamp_merge(self):
+        mock_db = self._mock_db()
+        mock_db.open_point_in_time.return_value = {"id": "pit-1"}
+        first_timestamp = "2024-03-25T10:00:00Z"
+        matching_timestamp = "2024-03-25T11:00:00Z"
+        last_timestamp = "2024-03-25T12:00:00Z"
+        mock_db.search.side_effect = [
+            _paginated_search_response(
+                "pit-2",
+                _search_hit(
+                    {
+                        "@timestamp": first_timestamp,
+                        "measurement": "load",
+                        "fields": {"value": 10, "related": 0},
+                    },
+                    [first_timestamp, 0, 0],
+                ),
+                _search_hit(
+                    {
+                        "@timestamp": matching_timestamp,
+                        "measurement": "load",
+                        "fields": {"value": 20},
+                    },
+                    [matching_timestamp, 1, 1],
+                ),
+            ),
+            _paginated_search_response(
+                "pit-3",
+                _search_hit(
+                    {
+                        "@timestamp": matching_timestamp,
+                        "measurement": "load",
+                        "fields": {"related": 100},
+                    },
+                    [matching_timestamp, 2, 2],
+                ),
+                _search_hit(
+                    {
+                        "@timestamp": last_timestamp,
+                        "measurement": "load",
+                        "fields": {"value": 30, "related": 0},
+                    },
+                    [last_timestamp, 3, 3],
+                ),
+            ),
+        ]
+
+        points = self.timeseries_db.read(
+            "load",
+            "value",
+            {},
+            where=[("related", ">", 50)],
+            limit=1,
+        )
+
+        self.assertEqual(points, [{"time": 1711364400, "value": 20}])
+        mock_db.open_point_in_time.assert_called_once_with(
+            index="openwisp2",
+            keep_alive="1m",
+        )
+        self.assertEqual(mock_db.search.call_count, 2)
+        first_body = mock_db.search.call_args_list[0].kwargs["body"]
+        second_body = mock_db.search.call_args_list[1].kwargs["body"]
+        self.assertEqual(first_body["pit"]["id"], "pit-1")
+        self.assertEqual(first_body["sort"][-1], {"_shard_doc": "asc"})
+        self.assertNotIn("search_after", first_body)
+        self.assertEqual(second_body["pit"]["id"], "pit-2")
+        self.assertEqual(second_body["search_after"], [matching_timestamp, 1, 1])
+        mock_db.close_point_in_time.assert_called_once_with(id="pit-3")
 
     @patch.object(DatabaseClient, "query")
     def test_read_count_distinct_single_field(self, mock_query):
@@ -837,7 +1102,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         query = mock_query.call_args.args[0]
         self.assertEqual(
             query["aggs"],
-            {"count": {"cardinality": {"field": "fields.clients"}}},
+            {"count": {"cardinality": {"field": "indexed_fields.keyword.clients"}}},
         )
 
     def test_read_count_distinct_unsupported_shape(self):
@@ -896,22 +1161,27 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(
             query["aggs"]["timeseries"]["aggs"]["uptime"],
             {
-                "filter": {"exists": {"field": "fields.reachable"}},
-                "aggs": {"value": {"avg": {"field": "fields.reachable"}}},
+                "filter": {"exists": {"field": "indexed_fields.numeric.reachable"}},
+                "aggs": {
+                    "value": {"avg": {"field": "indexed_fields.numeric.reachable"}}
+                },
             },
         )
         self.assertEqual(query["__openwisp_metrics"][0]["scale"], 100)
 
     def test_build_metric_aggregation(self):
         cases = (
-            ("avg", {"avg": {"field": "fields.value"}}),
-            ("sum", {"sum": {"field": "fields.value"}}),
+            ("avg", {"avg": {"field": "indexed_fields.numeric.value"}}),
+            ("sum", {"sum": {"field": "indexed_fields.numeric.value"}}),
             (
                 "cardinality",
-                {"cardinality": {"field": "fields.value"}},
+                {"cardinality": {"field": "indexed_fields.keyword.value"}},
             ),
-            ("mode", {"terms": {"field": "fields.value", "size": 1}}),
-            ("unknown", {"avg": {"field": "fields.value"}}),
+            (
+                "mode",
+                {"terms": {"field": "indexed_fields.numeric.value", "size": 1}},
+            ),
+            ("unknown", {"avg": {"field": "indexed_fields.numeric.value"}}),
         )
         for aggregation, expected in cases:
             with self.subTest(aggregation=aggregation):
@@ -934,15 +1204,19 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(
             query["aggs"]["upload"],
             {
-                "filter": {"exists": {"field": "fields.tx_bytes"}},
-                "aggs": {"value": {"sum": {"field": "fields.tx_bytes"}}},
+                "filter": {"exists": {"field": "indexed_fields.numeric.tx_bytes"}},
+                "aggs": {
+                    "value": {"sum": {"field": "indexed_fields.numeric.tx_bytes"}}
+                },
             },
         )
         self.assertEqual(
             query["aggs"]["download"],
             {
-                "filter": {"exists": {"field": "fields.rx_bytes"}},
-                "aggs": {"value": {"sum": {"field": "fields.rx_bytes"}}},
+                "filter": {"exists": {"field": "indexed_fields.numeric.rx_bytes"}},
+                "aggs": {
+                    "value": {"sum": {"field": "indexed_fields.numeric.rx_bytes"}}
+                },
             },
         )
 
@@ -962,12 +1236,47 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             {
                 "bool": {
                     "should": [
-                        {"exists": {"field": "fields.usage"}},
-                        {"exists": {"field": "fields.load"}},
+                        _field_exists_filter("usage"),
+                        _field_exists_filter("load"),
                     ],
                     "minimum_should_match": 1,
                 }
             },
+        )
+
+    def test_get_query_builds_custom_raw_and_dynamic_chart_queries(self):
+        raw_query = self.timeseries_db.get_query(
+            chart_type="line",
+            params={"key": "cpu", "field_name": "usage"},
+            time="1h",
+            group_map={"1h": "5m"},
+            query={
+                "__openwisp_query_type": "raw_chart",
+                "aggregate": False,
+                "fields": ["{field_name}", "load"],
+            },
+        )
+        self.assertEqual(raw_query["__openwisp_fields"], ["usage", "load"])
+
+        aggregate_query = self.timeseries_db.get_query(
+            chart_type="histogram",
+            params={"key": "cpu", "field_name": "usage"},
+            time="1h",
+            group_map={"1h": "5m"},
+            fields=["usage", "load"],
+            query={
+                "__openwisp_query_type": "chart",
+                "aggregate": True,
+                "metrics": [],
+                "dynamic_metric": {"agg": "sum"},
+            },
+        )
+        self.assertEqual(
+            aggregate_query["__openwisp_metrics"],
+            [
+                {"name": "usage", "field": "usage", "agg": "sum"},
+                {"name": "load", "field": "load", "agg": "sum"},
+            ],
         )
 
     def test_query_bundle_matches_backend_contract(self):
@@ -1084,6 +1393,39 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(self.timeseries_db.get_list_query(query), [])
 
     @patch.object(DatabaseClient, "query")
+    def test_get_list_query_keeps_zero_for_empty_cardinality_bucket(self, mock_query):
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params={"key": "wifi_clients", "field_name": "clients"},
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["wifi_clients"]["elasticsearch"],
+        )
+        mock_query.return_value = QueryResultSet(
+            {
+                "hits": {"hits": []},
+                "aggregations": {
+                    "timeseries": {
+                        "buckets": [
+                            {
+                                "key": 1711368000000,
+                                "doc_count": 0,
+                                "wifi_clients": {
+                                    "doc_count": 0,
+                                    "value": {"value": 0},
+                                },
+                            }
+                        ]
+                    }
+                },
+            }
+        )
+        self.assertEqual(
+            self.timeseries_db.get_list_query(query),
+            [{"time": 1711368000, "wifi_clients": 0}],
+        )
+
+    @patch.object(DatabaseClient, "query")
     def test_get_list_query_omits_empty_chart_summary(self, mock_query):
         query = self.timeseries_db.get_query(
             chart_type="bar",
@@ -1103,7 +1445,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
 
     def test_grouped_chart_truncation_logs_once(self):
         query = {
-            "__openwisp_metric": {"name": "value", "field": "clients"},
+            "__openwisp_metric": {"name": "clients", "field": "clients"},
             "__openwisp_group_by": "organization_id",
             "__openwisp_summary": False,
         }
@@ -1155,31 +1497,29 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertIn('tag "organization_id"', captured.output[0])
         self.assertIn("6 document(s)", captured.output[0])
 
-    @patch.object(DatabaseClient, "query")
-    def test_get_list_query_converts_raw_hits(self, mock_query):
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_get_list_query_converts_raw_hits(self, mock_get_hits):
         query = self.timeseries_db.get_query(
             chart_type="line",
             params={"key": "cpu", "field_name": "usage"},
             time="1h",
             group_map={"1h": "5m"},
         )
-        mock_query.return_value = QueryResultSet(
-            _search_response(
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "cpu",
-                    "tags": {"host": "server1"},
-                    "fields": {"usage": 10, "load": 2},
-                }
-            )
-        )
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "cpu",
+                "tags": {"host": "server1"},
+                "fields": {"usage": 10, "load": 2},
+            }
+        )["hits"]["hits"]
         self.assertEqual(
             self.timeseries_db.get_list_query(query),
             [{"time": 1711368000, "usage": 10}],
         )
 
-    @patch.object(DatabaseClient, "query")
-    def test_get_list_query_merges_raw_hits_by_time(self, mock_query):
+    @patch.object(DatabaseClient, "_get_paginated_hits")
+    def test_get_list_query_merges_raw_hits_by_time(self, mock_get_hits):
         query = self.timeseries_db.get_query(
             chart_type="line",
             params={"key": "traffic", "field_name": "download"},
@@ -1187,24 +1527,100 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             group_map={"1h": "5m"},
             fields=["download", "upload"],
         )
-        mock_query.return_value = QueryResultSet(
-            _search_response(
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "traffic",
-                    "fields": {"download": 10},
-                },
-                {
-                    "@timestamp": "2024-03-25T12:00:00Z",
-                    "measurement": "traffic",
-                    "fields": {"upload": 20},
-                },
-            )
-        )
+        mock_get_hits.return_value = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "traffic",
+                "fields": {"download": 10},
+            },
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "traffic",
+                "fields": {"upload": 20},
+            },
+        )["hits"]["hits"]
         self.assertEqual(
             self.timeseries_db.get_list_query(query),
             [{"time": 1711368000, "download": 10, "upload": 20}],
         )
+
+    @patch.dict(
+        "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
+        {"OPTIONS": {"read_size": 2}},
+    )
+    def test_get_list_query_paginates_raw_chart_hits(self):
+        mock_db = self._mock_db()
+        mock_db.open_point_in_time.return_value = {"id": "pit-1"}
+        first_timestamp = "2024-03-25T12:00:00Z"
+        second_timestamp = "2024-03-25T13:00:00Z"
+        third_timestamp = "2024-03-25T14:00:00Z"
+        mock_db.search.side_effect = [
+            _paginated_search_response(
+                "pit-2",
+                _search_hit(
+                    {
+                        "@timestamp": first_timestamp,
+                        "measurement": "traffic",
+                        "fields": {"download": 10},
+                    },
+                    [first_timestamp, 0],
+                ),
+                _search_hit(
+                    {
+                        "@timestamp": second_timestamp,
+                        "measurement": "traffic",
+                        "fields": {"download": 20},
+                    },
+                    [second_timestamp, 1],
+                ),
+            ),
+            _paginated_search_response(
+                "pit-3",
+                _search_hit(
+                    {
+                        "@timestamp": second_timestamp,
+                        "measurement": "traffic",
+                        "fields": {"upload": 30},
+                    },
+                    [second_timestamp, 2],
+                ),
+                _search_hit(
+                    {
+                        "@timestamp": third_timestamp,
+                        "measurement": "traffic",
+                        "fields": {"download": 40},
+                    },
+                    [third_timestamp, 3],
+                ),
+            ),
+            _paginated_search_response("pit-4"),
+        ]
+        query = self.timeseries_db.get_query(
+            chart_type="line",
+            params={"key": "traffic", "field_name": "download"},
+            time="1h",
+            group_map={"1h": "5m"},
+            fields=["download", "upload"],
+        )
+
+        self.assertEqual(
+            self.timeseries_db.get_list_query(query),
+            [
+                {"time": 1711368000, "download": 10, "upload": None},
+                {"time": 1711371600, "download": 20, "upload": 30},
+                {"time": 1711375200, "download": 40, "upload": None},
+            ],
+        )
+        self.assertEqual(mock_db.search.call_count, 3)
+        self.assertEqual(
+            mock_db.search.call_args_list[1].kwargs["body"]["search_after"],
+            [second_timestamp, 1],
+        )
+        self.assertEqual(
+            mock_db.search.call_args_list[2].kwargs["body"]["search_after"],
+            [third_timestamp, 3],
+        )
+        mock_db.close_point_in_time.assert_called_once_with(id="pit-4")
 
     @patch.object(DatabaseClient, "read", return_value=[{"time": 1, "data": {}}])
     def test_get_device_data_query_is_consumed_by_get_list_query(self, mock_read):
@@ -1239,18 +1655,30 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     def test_validate_query_uses_elasticsearch_validate_api(self):
         mock_db = self._mock_db()
         mock_db.indices.validate_query.return_value = {"valid": True}
-        aggregate = self.timeseries_db.validate_query(
-            {
-                "query": {"match_all": {}},
-                "aggs": {"usage": {"avg": {"field": "fields.usage"}}},
-            }
-        )
-        self.assertTrue(aggregate)
+        aggregate = self.timeseries_db.validate_query({"query": {"match_all": {}}})
+        self.assertFalse(aggregate)
         mock_db.indices.validate_query.assert_called_once_with(
             index="openwisp2",
             body={"query": {"match_all": {}}},
             explain=True,
         )
+
+    def test_validate_query_rejects_native_aggregations(self):
+        for aggregation_key in ("aggs", "aggregations"):
+            with self.subTest(
+                aggregation_key=aggregation_key
+            ), self.assertRaisesMessage(
+                ValidationError,
+                "Native Elasticsearch aggregations are not supported in chart queries",
+            ):
+                self.timeseries_db.validate_query(
+                    {
+                        "query": {"match_all": {}},
+                        aggregation_key: {
+                            "usage": {"avg": {"field": "indexed_fields.numeric.usage"}}
+                        },
+                    }
+                )
 
     def test_validate_query_raises_validation_error_for_invalid_query(self):
         mock_db = self._mock_db()
@@ -1362,6 +1790,246 @@ class TestElasticsearchClientIntegration(
         points = self._read_metric(metric)
         self.assertEqual(len(points), 1)
         self.assertEqual(points[0][metric.field_name], 50)
+
+    @patch.dict(
+        "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
+        {"OPTIONS": {"read_size": 2}},
+    )
+    def test_paginated_read_and_raw_chart_round_trip(self):
+        measurement = "paginated_round_trip"
+        tags = {"object_id": "paginated-round-trip"}
+        first_timestamp = now().replace(microsecond=0) - timedelta(minutes=3)
+        second_timestamp = first_timestamp + timedelta(minutes=1)
+        third_timestamp = second_timestamp + timedelta(minutes=1)
+        timeseries_db.write(
+            measurement,
+            {"value": 10, "related": 0},
+            tags=tags,
+            timestamp=first_timestamp,
+        )
+        timeseries_db.write(
+            measurement,
+            {"value": 20},
+            tags=tags,
+            timestamp=second_timestamp,
+        )
+        timeseries_db.write(
+            measurement,
+            {"related": 100},
+            tags=tags,
+            timestamp=second_timestamp,
+        )
+        timeseries_db.write(
+            measurement,
+            {"value": 30, "related": 0},
+            tags=tags,
+            timestamp=third_timestamp,
+        )
+
+        self.assertEqual(
+            timeseries_db.read(
+                measurement,
+                "value",
+                tags,
+                where=[("related", ">", 50)],
+                limit=1,
+            ),
+            [{"time": int(second_timestamp.timestamp()), "value": 20}],
+        )
+        query = {
+            "size": 2,
+            "query": timeseries_db._build_base_query(
+                key=measurement,
+                tags=tags,
+            ),
+            "sort": [{"@timestamp": {"order": "asc"}}],
+            "__index": timeseries_db.db_name,
+            "__openwisp_query_type": "raw_chart",
+            "__openwisp_fields": ["value", "related"],
+        }
+        self.assertEqual(
+            timeseries_db.get_list_query(query),
+            [
+                {
+                    "time": int(first_timestamp.timestamp()),
+                    "value": 10,
+                    "related": 0,
+                },
+                {
+                    "time": int(second_timestamp.timestamp()),
+                    "value": 20,
+                    "related": 100,
+                },
+                {
+                    "time": int(third_timestamp.timestamp()),
+                    "value": 30,
+                    "related": 0,
+                },
+            ],
+        )
+
+    def test_sparse_raw_chart_keeps_traces_aligned(self):
+        chart = self._create_chart(test_data=False, configuration="multiple_test")
+        first_metric = chart.metric
+        second_metric = self._create_object_metric(
+            name="test metric 2",
+            key=first_metric.key,
+            field_name="value2",
+            content_object=first_metric.content_object,
+        )
+        timestamp = now().replace(microsecond=0)
+        first_metric.write(1, time=timestamp - timedelta(minutes=2), check=False)
+        second_metric.write(2, time=timestamp - timedelta(minutes=1), check=False)
+
+        data = self._read_chart(chart)
+        traces = dict(data["traces"])
+        self.assertEqual(traces[first_metric.field_name], [1, None])
+        self.assertEqual(traces[second_metric.field_name], [None, 2])
+        for trace in traces.values():
+            self.assertEqual(len(trace), len(data["x"]))
+
+    def test_read_keeps_same_timestamp_series_separate(self):
+        timestamp = now().replace(microsecond=0)
+        timeseries_db.batch_write(
+            [
+                {
+                    "name": "series_cpu",
+                    "values": {"usage": 72},
+                    "tags": {"host": "router1", "ifname": "eth0"},
+                    "timestamp": timestamp,
+                },
+                {
+                    "name": "series_cpu",
+                    "values": {"load": 1},
+                    "tags": {"ifname": "eth0", "host": "router1"},
+                    "timestamp": timestamp,
+                },
+                {
+                    "name": "series_memory",
+                    "values": {"usage": 91},
+                    "tags": {"host": "router1", "ifname": "eth0"},
+                    "timestamp": timestamp,
+                },
+                {
+                    "name": "series_cpu",
+                    "values": {"usage": 55},
+                    "tags": {"host": "router2", "ifname": "eth0"},
+                    "timestamp": timestamp,
+                },
+            ]
+        )
+
+        self.assertEqual(
+            timeseries_db.read(
+                "series_cpu,series_memory",
+                ["usage", "load"],
+                {},
+            ),
+            [
+                {"time": int(timestamp.timestamp()), "usage": 72, "load": 1},
+                {"time": int(timestamp.timestamp()), "usage": 91},
+                {"time": int(timestamp.timestamp()), "usage": 55},
+            ],
+        )
+
+    def test_retried_writes_are_idempotent(self):
+        timestamp = now()
+        tags = {"object_id": "idempotent-write-test"}
+        write_kwargs = {
+            "tags": tags,
+            "timestamp": timestamp,
+            "operation_id": "single-operation",
+        }
+        timeseries_db.write("single_retry", {"value": 1}, **write_kwargs)
+        timeseries_db.write("single_retry", {"value": 1}, **write_kwargs)
+        single_count = timeseries_db.db.count(
+            index=timeseries_db.db_name,
+            query={"term": {"measurement": "single_retry"}},
+        )["count"]
+        self.assertEqual(single_count, 1)
+
+        batch_item = {
+            "name": "batch_retry",
+            "values": {"value": 1},
+            "tags": tags,
+            "timestamp": timestamp,
+            "operation_id": "batch-operation-1",
+        }
+        retry_batch = [
+            batch_item,
+            {**batch_item, "operation_id": "batch-operation-2"},
+        ]
+        timeseries_db.batch_write([batch_item])
+        timeseries_db.batch_write(retry_batch)
+        timeseries_db.batch_write(retry_batch)
+        batch_count = timeseries_db.db.count(
+            index=timeseries_db.db_name,
+            query={"term": {"measurement": "batch_retry"}},
+        )["count"]
+        self.assertEqual(batch_count, 2)
+
+    def test_field_types_are_stable_across_measurements(self):
+        timestamp = now()
+        tags = {"object_id": "field-type-test"}
+        samples = (
+            ("wifi_clients", "00:11:22:33:44:55"),
+            ("wifi_clients_max", 3),
+        )
+        for order in ("keyword-first", "numeric-first"):
+            with self.subTest(order=order):
+                client = DatabaseClient(
+                    db_name=f"{timeseries_db.db_name}-field-types-{order}"
+                )
+                client.create_database()
+                try:
+                    write_order = samples if order == "keyword-first" else samples[::-1]
+                    for measurement, value in write_order:
+                        client.write(
+                            measurement,
+                            {"clients": value},
+                            tags=tags,
+                            timestamp=timestamp,
+                        )
+                    response = client.db.search(
+                        index=client.db_name,
+                        query={"match_all": {}},
+                    )
+                    for hit in response["hits"]["hits"]:
+                        self.assertIn("fields", hit["_source"])
+                        self.assertNotIn("indexed_fields", hit["_source"])
+                    wifi_clients = client.read(
+                        "wifi_clients",
+                        ["clients"],
+                        tags,
+                        limit=None,
+                    )
+                    self.assertEqual(
+                        wifi_clients[0]["clients"],
+                        "00:11:22:33:44:55",
+                    )
+                    healthy_points = client.read(
+                        "wifi_clients_max",
+                        ["clients"],
+                        tags,
+                        where=[("clients", "<", 10)],
+                        limit=None,
+                    )
+                    self.assertEqual(
+                        healthy_points[0]["clients"],
+                        3,
+                    )
+                    self.assertEqual(
+                        client.read(
+                            "wifi_clients_max",
+                            ["clients"],
+                            tags,
+                            where=[("clients", ">", 10)],
+                            limit=None,
+                        ),
+                        [],
+                    )
+                finally:
+                    client.drop_database()
 
     def test_large_device_data_snapshot_round_trip(self):
         device_id = "large-device-data"

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -2,6 +2,7 @@
 Elasticsearch Database Client Tests
 """
 
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
 
@@ -972,8 +973,14 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     def test_query_bundle_matches_backend_contract(self):
         self.timeseries_db.queries.validate(self.timeseries_db.backend_name)
         self.assertEqual(set(chart_query.keys()), set(summary_query.keys()))
-        for config in self.timeseries_db.queries.chart_query.values():
+        for key, config in self.timeseries_db.queries.chart_query.items():
             self.assertIn("elasticsearch", config)
+            self.assertEqual(
+                summary_query[key]["elasticsearch"], config["elasticsearch"]
+            )
+            self.assertIsNot(
+                summary_query[key]["elasticsearch"], config["elasticsearch"]
+            )
 
     @patch.object(
         ElasticsearchQuery,
@@ -992,10 +999,19 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     @patch.object(DatabaseClient, "query")
     def test_get_top_fields(self, mock_query):
         mock_query.return_value = QueryResultSet(
-            _search_response(
-                {"fields": {"http2": 100, "ssh": 90, "ignored": "string"}},
-                {"fields": {"http2": 1, "udp": 80, "is_bool": True}},
-            )
+            {
+                "aggregations": {
+                    "top_fields": {
+                        "value": {
+                            "http2": 101,
+                            "ssh": 90,
+                            "udp": 80,
+                            "is_bool": True,
+                            "ignored": "string",
+                        }
+                    }
+                }
+            }
         )
         fields = self.timeseries_db._get_top_fields(
             query=self.timeseries_db.get_default_chart_query(has_object_scope=False),
@@ -1006,6 +1022,10 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             time="30d",
         )
         self.assertEqual(fields, ["http2", "ssh"])
+        search = mock_query.call_args.args[0]
+        self.assertEqual(search["size"], 0)
+        self.assertNotIn("_source", search)
+        self.assertIn("scripted_metric", search["aggs"]["top_fields"])
 
     @patch.object(DatabaseClient, "query")
     def test_get_list_query_converts_chart_aggregations(self, mock_query):
@@ -1081,6 +1101,60 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(self.timeseries_db.get_list_query(query), [])
 
+    def test_grouped_chart_truncation_logs_once(self):
+        query = {
+            "__openwisp_metric": {"name": "value", "field": "clients"},
+            "__openwisp_group_by": "organization_id",
+            "__openwisp_summary": False,
+        }
+        response = {
+            "aggregations": {
+                "timeseries": {
+                    "buckets": [
+                        {
+                            "key": 1711368000000,
+                            "groups": {
+                                "sum_other_doc_count": 2,
+                                "buckets": [
+                                    {
+                                        "key": "org-1",
+                                        "value": {"value": 3},
+                                    }
+                                ],
+                            },
+                        },
+                        {
+                            "key": 1711368600000,
+                            "groups": {
+                                "sum_other_doc_count": 4,
+                                "buckets": [
+                                    {
+                                        "key": "org-1",
+                                        "value": {"value": 5},
+                                    }
+                                ],
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+        with self.assertLogs(
+            "openwisp_monitoring.db.backends.elasticsearch.client",
+            level="WARNING",
+        ) as captured:
+            points = self.timeseries_db._get_grouped_chart_points(response, query)
+        self.assertEqual(
+            points,
+            [
+                {"time": 1711368000, "org-1": 3},
+                {"time": 1711368600, "org-1": 5},
+            ],
+        )
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn('tag "organization_id"', captured.output[0])
+        self.assertIn("6 document(s)", captured.output[0])
+
     @patch.object(DatabaseClient, "query")
     def test_get_list_query_converts_raw_hits(self, mock_query):
         query = self.timeseries_db.get_query(
@@ -1138,7 +1212,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(
             query,
             {
-                "_openwisp_query_type": "device_data",
+                "__openwisp_query_type": "device_data",
                 "retention_policy": SHORT_RP,
                 "measurement": "device_data",
                 "pk": "1",
@@ -1288,6 +1362,24 @@ class TestElasticsearchClientIntegration(
         points = self._read_metric(metric)
         self.assertEqual(len(points), 1)
         self.assertEqual(points[0][metric.field_name], 50)
+
+    def test_large_device_data_snapshot_round_trip(self):
+        device_id = "large-device-data"
+        snapshot = json.dumps({"payload": "x" * 9000})
+        timeseries_db.write(
+            "device_data",
+            {"data": snapshot},
+            tags={"pk": device_id},
+            retention_policy=SHORT_RP,
+        )
+        query = timeseries_db.get_device_data_query(
+            SHORT_RP,
+            "device_data",
+            device_id,
+        )
+        points = timeseries_db.get_list_query(query, precision=None)
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0]["data"], snapshot)
 
     def test_metric_read_omit_since(self):
         metric = self._create_general_metric(name="historical-load")
@@ -1445,6 +1537,16 @@ class TestElasticsearchClientIntegration(
             },
         )
         self.assertEqual(chart.get_top_fields(number=3), ["http2", "ssh", "udp"])
+
+    def test_chart_top_fields_aggregates_all_documents(self):
+        metric = self._create_object_metric(
+            name="top-fields-all-documents",
+            configuration="get_top_fields",
+        )
+        chart = Chart(metric=metric, configuration="histogram")
+        metric.write(None, extra_values={"http2": 100, "ssh": 0})
+        metric.write(None, extra_values={"http2": 0, "ssh": 200})
+        self.assertEqual(chart.get_top_fields(number=1), ["ssh"])
 
     def test_ping_uptime_chart_summary_round_trip(self):
         metric = self._create_object_metric(name="ping", configuration="ping")
@@ -1777,16 +1879,10 @@ class TestElasticsearchClientIntegration(
     def test_write_failure_raises_timeseries_exception(self):
         mock_db = MagicMock()
         mock_db.index.side_effect = RuntimeError("write failed")
-        original_db = timeseries_db.__dict__.get("db")
-        timeseries_db.__dict__["db"] = mock_db
-        try:
-            with self.assertRaises(TimeseriesWriteException):
-                timeseries_db.write("test_write", {"value": 1})
-        finally:
-            if original_db is None:
-                timeseries_db.__dict__.pop("db", None)
-            else:
-                timeseries_db.__dict__["db"] = original_db
+        with patch.dict(timeseries_db.__dict__, {"db": mock_db}), self.assertRaises(
+            TimeseriesWriteException
+        ):
+            timeseries_db.write("test_write", {"value": 1})
 
 
 @tag("timeseries_client", "elasticsearch")
@@ -1798,8 +1894,16 @@ class TestElasticsearchCheckIntegration(
     TestDeviceMonitoringMixin,
     TransactionTestCase,
 ):
-    _WIFI_CLIENTS = check_settings.CHECK_CLASSES[3][0]
-    _DATA_COLLECTED = check_settings.CHECK_CLASSES[4][0]
+    _WIFI_CLIENTS = next(
+        path
+        for path, _name, _setting in check_settings.CHECK_CLASSES
+        if path.endswith(".WifiClients")
+    )
+    _DATA_COLLECTED = next(
+        path
+        for path, _name, _setting in check_settings.CHECK_CLASSES
+        if path.endswith(".DataCollected")
+    )
     expected_backend = "elasticsearch"
 
     def _create_device(self, monitoring_status="ok", *args, **kwargs):

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -270,18 +270,43 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     @patch("openwisp_monitoring.db.backends.elasticsearch.client.Elasticsearch")
     def test_insecure_http_warning_only_with_credentials(self, mock_client):
         cases = (
-            ({"API_KEY": "api-key"}, True),
-            ({"BEARER_AUTH": "bearer"}, True),
-            ({"USER": "openwisp", "PASSWORD": "secret"}, True),
+            ({"API_KEY": "api-key"}, True, "http://localhost:9200"),
+            ({"BEARER_AUTH": "bearer"}, True, "http://localhost:9200"),
+            ({"USER": "openwisp", "PASSWORD": "secret"}, True, "http://localhost:9200"),
             # loopback is not exempted: credentials over HTTP always warn
-            ({"URL": "http://127.0.0.1:9200", "API_KEY": "api-key"}, True),
+            (
+                {"URL": "http://127.0.0.1:9200", "API_KEY": "api-key"},
+                True,
+                "http://127.0.0.1:9200",
+            ),
+            (
+                {"URL": "http://openwisp:secret@es.example.org:9200"},
+                True,
+                "http://es.example.org:9200",
+            ),
+            (
+                {
+                    "URL": "http://openwisp:secret@es.example.org:9200",
+                    "API_KEY": "api-key",
+                },
+                True,
+                "http://es.example.org:9200",
+            ),
             # unauthenticated HTTP is supported for local development
-            ({}, False),
+            ({}, False, None),
             # HTTPS and cloud IDs are secure transports
-            ({"URL": "https://es.example.org:9200", "API_KEY": "api-key"}, False),
-            ({"URL": "", "CLOUD_ID": "cluster:cloud-id", "API_KEY": "key"}, False),
+            (
+                {"URL": "https://es.example.org:9200", "API_KEY": "api-key"},
+                False,
+                None,
+            ),
+            (
+                {"URL": "", "CLOUD_ID": "cluster:cloud-id", "API_KEY": "key"},
+                False,
+                None,
+            ),
         )
-        for config, expected in cases:
+        for config, expected, endpoint in cases:
             with self.subTest(config=config):
                 with patch.dict(
                     "openwisp_monitoring.db.backends.elasticsearch.client."
@@ -294,6 +319,8 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
                     self.assertEqual(mocked_warning.called, expected)
                     if expected:
                         self.assertIn("insecure HTTP", mocked_warning.call_args.args[0])
+                        self.assertEqual(mocked_warning.call_args.args[1], endpoint)
+                        self.assertNotIn("secret", mocked_warning.call_args.args[1])
 
     def test_reset_clears_cached_state(self):
         client = DatabaseClient(db_name="initial-db")
@@ -336,7 +363,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             _resource_metadata(),
         )
         mappings = body["template"]["mappings"]["properties"]
-        self.assertEqual(mappings["@timestamp"], {"type": "date"})
+        self.assertEqual(mappings["@timestamp"], {"type": "date_nanos"})
         self.assertEqual(mappings["measurement"], {"type": "keyword"})
         self.assertNotIn("openwisp_series_id", mappings)
         self.assertNotIn("openwisp_doc_count", mappings)
@@ -1247,6 +1274,71 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(query["__openwisp_metrics"][0]["scale"], 100)
 
+    def test_get_query_resolves_invalid_timezone_to_utc(self):
+        params = {
+            "key": "ping",
+            "field_name": "reachable",
+            "time": "2024-03-25 10:00:00",
+            "end_date": "2024-03-25 11:00:00",
+            "content_type": "config.device",
+            "object_id": "device-id",
+        }
+        expected_range_filter = {
+            "range": {
+                "@timestamp": {
+                    "gte": "2024-03-25T10:00:00Z",
+                    "lte": "2024-03-25T11:00:00Z",
+                }
+            }
+        }
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params=params,
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["uptime"]["elasticsearch"],
+            timezone="Invalid/Timezone",
+        )
+        histogram = query["aggs"]["timeseries"]["date_histogram"]
+        self.assertEqual(histogram["time_zone"], "UTC")
+        self.assertEqual(
+            histogram["extended_bounds"],
+            {
+                "min": "2024-03-25T10:00:00Z",
+                "max": "2024-03-25T11:00:00Z",
+            },
+        )
+        self.assertIn(expected_range_filter, query["query"]["bool"]["filter"])
+
+        query = self._build_grouped_query(
+            params={
+                **params,
+                "key": "radius_acc",
+                "method": "mobile_phone",
+            },
+            timezone="Invalid/Timezone",
+        )
+        histogram = query["aggs"]["timeseries"]["date_histogram"]
+        self.assertEqual(histogram["time_zone"], "UTC")
+        self.assertIn(expected_range_filter, query["query"]["bool"]["filter"])
+
+        query = self.timeseries_db.get_query(
+            chart_type="line",
+            params=params,
+            time="1h",
+            group_map={"1h": "5m"},
+            fields=["reachable"],
+            query={
+                "__openwisp_query_type": "raw_chart",
+                "aggregate": False,
+                "fields": ["{field_name}"],
+            },
+            timezone="Invalid/Timezone",
+        )
+        self.assertEqual(query["__openwisp_query_type"], "raw_chart")
+        self.assertNotIn("aggs", query)
+        self.assertIn(expected_range_filter, query["query"]["bool"]["filter"])
+
     def test_build_metric_aggregation(self):
         cases = (
             ("avg", {"avg": {"field": "indexed_fields.numeric.value"}}),
@@ -1393,7 +1485,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         default_query = self.timeseries_db.queries.default_chart_query
         self.assertIsInstance(default_query, ElasticsearchQuery)
         query = self.timeseries_db.get_default_chart_query(has_object_scope=True)
-        mock_resolve.assert_called_once_with(default_query)
+        mock_resolve.assert_called_once_with(default_query, has_object_scope=True)
         self.assertNotIn("filters", query)
         self.assertIsNot(query, default_query)
 
@@ -1593,7 +1685,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         "metric": {"name": "count", "field": "count", "agg": "sum"},
     }
 
-    def _build_grouped_query(self, **overrides):
+    def _build_grouped_query(self, timezone=settings.TIME_ZONE, **overrides):
         params = {
             "key": "radius_acc",
             "content_type": "config.device",
@@ -1607,6 +1699,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             time="30d",
             group_map={"30d": "1d"},
             query={**self._GROUPED_CHART_QUERY, **overrides},
+            timezone=timezone,
         )
 
     def test_grouped_chart_query_keeps_object_scope(self):
@@ -2877,6 +2970,49 @@ class TestElasticsearchClientIntegration(
         self.assertEqual(self._read_metric(general_metric), [])
         timeseries_db.delete_metric_data(key=short_metric.key)
         self.assertEqual(self._read_metric(short_metric, retention_policy=SHORT_RP), [])
+
+    def test_delete_metric_data_at_same_millisecond_preserves_other_points(self):
+        def to_microseconds(timestamp):
+            return int(timestamp.timestamp()) * 1000000 + timestamp.microsecond
+
+        client = DatabaseClient(db_name="delete-same-millisecond-db").attach_queries(
+            timeseries_db.queries
+        )
+        client.drop_database()
+        client.create_database()
+        self.addCleanup(client.drop_database)
+        measurement = "delete-same-millisecond"
+        tags = {"object_id": "same-millisecond"}
+        first_timestamp = datetime(2026, 8, 19, 10, 30, 0, 100, tzinfo=timezone.utc)
+        second_timestamp = datetime(2026, 8, 19, 10, 30, 0, 900, tzinfo=timezone.utc)
+        client.write(
+            measurement,
+            {"value": 10},
+            tags=tags,
+            timestamp=first_timestamp,
+        )
+        client.write(
+            measurement,
+            {"value": 20},
+            tags=tags,
+            timestamp=second_timestamp,
+        )
+        self.assertEqual(
+            client.read(measurement, "value", tags, precision="u"),
+            [
+                {"time": to_microseconds(first_timestamp), "value": 10},
+                {"time": to_microseconds(second_timestamp), "value": 20},
+            ],
+        )
+        client.delete_metric_data(
+            key=measurement,
+            tags=tags,
+            timestamp=first_timestamp,
+        )
+        self.assertEqual(
+            client.read(measurement, "value", tags, precision="u"),
+            [{"time": to_microseconds(second_timestamp), "value": 20}],
+        )
 
     def test_delete_metric_data_without_filters_clears_default_and_short_streams(self):
         general_metric = self._create_general_metric(name="delete-all-general")

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -22,6 +22,7 @@ from openwisp_monitoring.db.backends.elasticsearch.client import (
     QueryResultSet,
 )
 from openwisp_monitoring.db.backends.elasticsearch.queries import (
+    ElasticsearchQuery,
     chart_query,
     summary_query,
 )
@@ -124,17 +125,16 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             "a" * 256,
         )
         for name in invalid_names:
-            with self.subTest(name=name):
-                with self.assertRaisesMessage(
-                    ImproperlyConfigured,
-                    '"NAME" must be a valid Elasticsearch data stream name.',
-                ):
-                    DatabaseClient.validate_settings(
-                        {
-                            **self.base_config,
-                            "NAME": name,
-                        }
-                    )
+            with self.subTest(name=name), self.assertRaisesMessage(
+                ImproperlyConfigured,
+                '"NAME" must be a valid Elasticsearch data stream name.',
+            ):
+                DatabaseClient.validate_settings(
+                    {
+                        **self.base_config,
+                        "NAME": name,
+                    }
+                )
 
     def test_validate_settings_rejects_invalid_advanced_options(self):
         invalid_settings = (
@@ -150,14 +150,15 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             ),
         )
         for invalid_setting, message in invalid_settings:
-            with self.subTest(setting=invalid_setting):
-                with self.assertRaisesMessage(ImproperlyConfigured, message):
-                    DatabaseClient.validate_settings(
-                        {
-                            **self.base_config,
-                            **invalid_setting,
-                        }
-                    )
+            with self.subTest(setting=invalid_setting), self.assertRaisesMessage(
+                ImproperlyConfigured, message
+            ):
+                DatabaseClient.validate_settings(
+                    {
+                        **self.base_config,
+                        **invalid_setting,
+                    }
+                )
 
     @patch.dict(
         "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
@@ -473,6 +474,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             ],
         )
 
+    @patch.object(DatabaseClient, "_is_not_found")
     @patch.object(DatabaseClient, "_delete_lifecycle_policies")
     @patch.object(DatabaseClient, "_delete_index_templates")
     @patch.object(DatabaseClient, "_delete_indices")
@@ -482,7 +484,12 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         return_value=["openwisp2", "openwisp2-short"],
     )
     def test_drop_database_retries_safely_after_partial_deletion(
-        self, mock_streams, mock_indices, mock_templates, mock_policies
+        self,
+        mock_streams,
+        mock_indices,
+        mock_templates,
+        mock_policies,
+        mock_is_not_found,
     ):
         mock_db = self._mock_db()
         transient_error = RuntimeError("temporary failure")
@@ -493,16 +500,8 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             missing_error,
             None,
         ]
-
-        def is_not_found(exception):
-            return exception is missing_error
-
-        with patch.object(
-            DatabaseClient,
-            "_is_not_found",
-            side_effect=is_not_found,
-        ):
-            self.timeseries_db.drop_database()
+        mock_is_not_found.side_effect = lambda exception: exception is missing_error
+        self.timeseries_db.drop_database()
         self.assertEqual(mock_streams.call_count, 2)
         self.assertEqual(
             mock_db.indices.delete_data_stream.call_args_list,
@@ -745,7 +744,7 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             )
         )
         points = self.timeseries_db.read("cpu", "usage", {"host": "server1"})
-        self.assertEqual(points, [{"time": 1711368000, "host": "server1", "usage": 10}])
+        self.assertEqual(points, [{"time": 1711368000, "usage": 10}])
 
     @patch.object(DatabaseClient, "query")
     def test_read_deduplicates_same_timestamp_before_where_filtering(self, mock_query):
@@ -868,6 +867,24 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(query["__openwisp_metrics"][0]["scale"], 100)
 
+    def test_build_metric_aggregation(self):
+        cases = (
+            ("avg", {"avg": {"field": "fields.value"}}),
+            ("sum", {"sum": {"field": "fields.value"}}),
+            (
+                "cardinality",
+                {"cardinality": {"field": "fields.value"}},
+            ),
+            ("mode", {"terms": {"field": "fields.value", "size": 1}}),
+            ("unknown", {"avg": {"field": "fields.value"}}),
+        )
+        for aggregation, expected in cases:
+            with self.subTest(aggregation=aggregation):
+                result = self.timeseries_db._build_metric_aggregation(
+                    {"field": "value", "agg": aggregation}
+                )
+                self.assertEqual(result["aggs"]["value"], expected)
+
     def test_get_query_builds_summary_query(self):
         query = self.timeseries_db.get_query(
             chart_type="traffic",
@@ -924,6 +941,20 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         for config in self.timeseries_db.queries.chart_query.values():
             self.assertIn("elasticsearch", config)
 
+    @patch.object(
+        ElasticsearchQuery,
+        "resolve",
+        autospec=True,
+        wraps=ElasticsearchQuery.resolve,
+    )
+    def test_default_chart_query_omits_unused_filter_metadata(self, mock_resolve):
+        default_query = self.timeseries_db.queries.default_chart_query
+        self.assertIsInstance(default_query, ElasticsearchQuery)
+        query = self.timeseries_db.get_default_chart_query(has_object_scope=True)
+        mock_resolve.assert_called_once_with(default_query)
+        self.assertNotIn("filters", query)
+        self.assertIsNot(query, default_query)
+
     @patch.object(DatabaseClient, "query")
     def test_get_top_fields(self, mock_query):
         mock_query.return_value = QueryResultSet(
@@ -970,6 +1001,51 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             self.timeseries_db.get_list_query(query),
             [{"time": 1711368000, "uptime": 50.0}],
         )
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_list_query_omits_empty_chart_aggregations(self, mock_query):
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params={"key": "ping", "field_name": "reachable"},
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["uptime"]["elasticsearch"],
+        )
+        mock_query.return_value = QueryResultSet(
+            {
+                "hits": {"hits": []},
+                "aggregations": {
+                    "timeseries": {
+                        "buckets": [
+                            {
+                                "key": 1711368000000,
+                                "doc_count": 0,
+                                "uptime": {"value": None},
+                            }
+                        ]
+                    }
+                },
+            }
+        )
+        self.assertEqual(self.timeseries_db.get_list_query(query), [])
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_list_query_omits_empty_chart_summary(self, mock_query):
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params={"key": "ping", "field_name": "reachable"},
+            time="1d",
+            group_map={"1d": "10m"},
+            summary=True,
+            query=chart_query["uptime"]["elasticsearch"],
+        )
+        mock_query.return_value = QueryResultSet(
+            {
+                "hits": {"hits": []},
+                "aggregations": {"uptime": {"value": None}},
+            }
+        )
+        self.assertEqual(self.timeseries_db.get_list_query(query), [])
 
     @patch.object(DatabaseClient, "query")
     def test_get_list_query_converts_raw_hits(self, mock_query):

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -1,0 +1,1801 @@
+"""
+Elasticsearch Database Client Tests
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, call, patch
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.test import TestCase, TransactionTestCase, tag
+from django.urls import reverse
+from django.utils.timezone import now
+from freezegun import freeze_time
+from swapper import load_model
+
+from openwisp_monitoring.check import settings as check_settings
+from openwisp_monitoring.check.tests import AutoDataCollectedCheck, AutoWifiClientCheck
+from openwisp_monitoring.db.backends.elasticsearch.client import (
+    DatabaseClient,
+    QueryResultSet,
+)
+from openwisp_monitoring.db.backends.elasticsearch.queries import (
+    chart_query,
+    summary_query,
+)
+from openwisp_monitoring.device import tasks as device_tasks
+from openwisp_monitoring.device.tests import TestDeviceMonitoringMixin
+from openwisp_monitoring.device.utils import (
+    DEFAULT_RP,
+    SHORT_RP,
+    manage_default_retention_policy,
+    manage_short_retention_policy,
+)
+from openwisp_monitoring.monitoring import settings as monitoring_settings
+from openwisp_monitoring.monitoring import tasks as monitoring_tasks
+from openwisp_monitoring.monitoring.tests import (
+    RequireTimeseriesBackendMixin,
+    TestMonitoringMixin,
+)
+from openwisp_utils.tests import capture_stderr
+
+from ... import timeseries_db
+from ...exceptions import TimeseriesWriteException
+
+Chart = load_model("monitoring", "Chart")
+Check = load_model("check", "Check")
+Device = load_model("config", "Device")
+DeviceData = load_model("device_monitoring", "DeviceData")
+Metric = load_model("monitoring", "Metric")
+Notification = load_model("openwisp_notifications", "Notification")
+
+
+def _search_response(*documents, aggregations=None):
+    return {
+        "hits": {
+            "total": {"value": len(documents)},
+            "hits": [{"_source": document} for document in documents],
+        },
+        "aggregations": aggregations or {},
+    }
+
+
+@tag("timeseries_client", "elasticsearch")
+class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
+    expected_backend = "elasticsearch"
+    base_config = {
+        "BACKEND": "openwisp_monitoring.db.backends.elasticsearch",
+        "NAME": "openwisp2",
+        "URL": "http://localhost:9200",
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        assert settings.TIMESERIES_DATABASE["BACKEND"].endswith("elasticsearch")
+
+    def setUp(self):
+        super().setUp()
+        self.timeseries_db = DatabaseClient().attach_queries(timeseries_db.queries)
+
+    def _mock_db(self):
+        mock_db = MagicMock()
+        self.timeseries_db.__dict__["db"] = mock_db
+        return mock_db
+
+    def test_backend_name(self):
+        self.assertEqual(self.timeseries_db.backend_name, "elasticsearch")
+        self.assertFalse(self.timeseries_db.use_udp)
+
+    def test_validate_settings_accepts_supported_connection_options(self):
+        for config in (
+            self.base_config,
+            {
+                **self.base_config,
+                "URL": "",
+                "HOST": "localhost",
+                "PORT": "9200",
+            },
+            {**self.base_config, "URL": "", "CLOUD_ID": "cluster:cloud-id"},
+        ):
+            with self.subTest(config=config):
+                self.assertEqual(DatabaseClient.validate_settings(config), config)
+
+    def test_validate_settings_rejects_missing_connection_options(self):
+        config = {
+            "BACKEND": "openwisp_monitoring.db.backends.elasticsearch",
+            "NAME": "openwisp2",
+        }
+        with self.assertRaisesMessage(
+            ImproperlyConfigured,
+            'Elasticsearch TIMESERIES_DATABASE must define "CLOUD_ID", "URL", or both "HOST" and "PORT".',
+        ):
+            DatabaseClient.validate_settings(config)
+
+    def test_validate_settings_rejects_unsafe_data_stream_names(self):
+        invalid_names = (
+            "",
+            "OpenWISP",
+            "openwisp*",
+            "-openwisp",
+            ".",
+            "a" * 256,
+        )
+        for name in invalid_names:
+            with self.subTest(name=name):
+                with self.assertRaisesMessage(
+                    ImproperlyConfigured,
+                    '"NAME" must be a valid Elasticsearch data stream name.',
+                ):
+                    DatabaseClient.validate_settings(
+                        {
+                            **self.base_config,
+                            "NAME": name,
+                        }
+                    )
+
+    def test_validate_settings_rejects_invalid_advanced_options(self):
+        invalid_settings = (
+            ({"OPTIONS": []}, '"OPTIONS" must be a mapping.'),
+            ({"VERIFY_CERTS": "false"}, '"VERIFY_CERTS" must be a boolean.'),
+            (
+                {"USER": "openwisp"},
+                '"USER" and "PASSWORD" must be configured together.',
+            ),
+            (
+                {"PASSWORD": "secret"},
+                '"USER" and "PASSWORD" must be configured together.',
+            ),
+        )
+        for invalid_setting, message in invalid_settings:
+            with self.subTest(setting=invalid_setting):
+                with self.assertRaisesMessage(ImproperlyConfigured, message):
+                    DatabaseClient.validate_settings(
+                        {
+                            **self.base_config,
+                            **invalid_setting,
+                        }
+                    )
+
+    @patch.dict(
+        "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
+        {
+            **base_config,
+            "API_KEY": "api-key",
+            "BEARER_AUTH": "bearer",
+            "USER": "openwisp",
+            "PASSWORD": "secret",
+            "CA_CERTS": "/tmp/ca.pem",
+            "SSL_ASSERT_FINGERPRINT": "fingerprint",
+            "VERIFY_CERTS": False,
+            "OPTIONS": {
+                "http_compress": True,
+                "request_timeout": 30,
+                "max_retries": 2,
+                "retry_on_timeout": True,
+            },
+        },
+        clear=True,
+    )
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.Elasticsearch")
+    def test_client_kwargs_use_api_key_first(self, mock_client):
+        client = DatabaseClient()
+        client.db
+        mock_client.assert_called_once_with(
+            hosts=["http://localhost:9200"],
+            api_key="api-key",
+            ca_certs="/tmp/ca.pem",
+            ssl_assert_fingerprint="fingerprint",
+            verify_certs=False,
+            http_compress=True,
+            request_timeout=30,
+            max_retries=2,
+            retry_on_timeout=True,
+        )
+
+    @patch.dict(
+        "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
+        {
+            **base_config,
+            "BEARER_AUTH": "bearer",
+            "USER": "openwisp",
+            "PASSWORD": "secret",
+        },
+        clear=True,
+    )
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.Elasticsearch")
+    def test_client_kwargs_use_bearer_before_basic_auth(self, mock_client):
+        client = DatabaseClient()
+        client.db
+        mock_client.assert_called_once_with(
+            hosts=["http://localhost:9200"],
+            bearer_auth="bearer",
+        )
+
+    @patch.dict(
+        "openwisp_monitoring.db.backends.elasticsearch.client.TIMESERIES_DB",
+        {
+            **base_config,
+            "URL": "",
+            "CLOUD_ID": "cluster:cloud-id",
+            "USER": "openwisp",
+            "PASSWORD": "secret",
+        },
+        clear=True,
+    )
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.Elasticsearch")
+    def test_client_kwargs_support_cloud_id_and_basic_auth(self, mock_client):
+        client = DatabaseClient()
+        client.db
+        mock_client.assert_called_once_with(
+            cloud_id="cluster:cloud-id",
+            basic_auth=("openwisp", "secret"),
+        )
+
+    def test_reset_clears_cached_state(self):
+        client = DatabaseClient(db_name="initial-db")
+        client.__dict__["db"] = object()
+        client.reset(db_name="reset-db")
+        self.assertEqual(client.db_name, "reset-db")
+        self.assertNotIn("db", client.__dict__)
+
+    def test_build_index_template_uses_data_stream_settings(self):
+        body = self.timeseries_db._build_index_template_body(SHORT_RP)
+        self.assertEqual(body["index_patterns"], ["openwisp2-short"])
+        settings_body = body["template"]["settings"]
+        self.assertEqual(settings_body["index.lifecycle.name"], "openwisp2-short-ilm")
+        self.assertNotIn("lifecycle", body["template"])
+        self.assertNotIn("index.mode", settings_body)
+        self.assertNotIn("index.look_ahead_time", settings_body)
+        self.assertNotIn("index.look_back_time", settings_body)
+        self.assertNotIn("index.routing_path", settings_body)
+        mappings = body["template"]["mappings"]["properties"]
+        self.assertEqual(mappings["@timestamp"], {"type": "date"})
+        self.assertEqual(mappings["measurement"], {"type": "keyword"})
+        self.assertNotIn("openwisp_series_id", mappings)
+        self.assertNotIn("openwisp_doc_count", mappings)
+        self.assertEqual(mappings["openwisp_write_sequence"]["type"], "long")
+
+    def test_build_lifecycle_policy_bounds_rollover_age(self):
+        short_policy = self.timeseries_db._build_lifecycle_policy("24h0m0s")
+        default_policy = self.timeseries_db._build_lifecycle_policy("26280h0m0s")
+        no_retention_policy = self.timeseries_db._build_lifecycle_policy()
+        self.assertEqual(
+            short_policy["phases"]["hot"]["actions"]["rollover"]["max_age"],
+            "86400s",
+        )
+        self.assertEqual(
+            default_policy["phases"]["hot"]["actions"]["rollover"]["max_age"],
+            "2592000s",
+        )
+        self.assertEqual(
+            no_retention_policy["phases"]["hot"]["actions"]["rollover"]["max_age"],
+            "2592000s",
+        )
+        self.assertNotIn("delete", no_retention_policy["phases"])
+
+    def test_elasticsearch_9_api_type_errors_are_not_masked(self):
+        mock_db = self._mock_db()
+        mock_db.ilm.put_lifecycle.side_effect = TypeError("invalid policy")
+        with self.assertRaisesMessage(TypeError, "invalid policy"):
+            self.timeseries_db._put_lifecycle_policy("policy", {"phases": {}})
+        mock_db.ilm.put_lifecycle.assert_called_once_with(
+            name="policy",
+            policy={"phases": {}},
+        )
+
+        mock_db.indices.put_index_template.side_effect = TypeError(
+            "invalid index template"
+        )
+        with self.assertRaisesMessage(TypeError, "invalid index template"):
+            self.timeseries_db._put_index_template()
+        self.assertEqual(mock_db.indices.put_index_template.call_count, 1)
+
+    @patch.object(DatabaseClient, "_data_stream_exists", side_effect=[False, True])
+    def test_ensure_data_stream_resources_creates_policy_template_and_stream(
+        self, mock_exists
+    ):
+        mock_db = self._mock_db()
+        self.timeseries_db._ensure_data_stream_resources(SHORT_RP, "24h0m0s")
+        mock_db.ilm.put_lifecycle.assert_called_once()
+        policy = mock_db.ilm.put_lifecycle.call_args.kwargs["policy"]
+        self.assertEqual(policy["phases"]["delete"]["min_age"], "86400s")
+        mock_db.indices.put_index_template.assert_called_once()
+        mock_db.indices.create_data_stream.assert_called_once_with(
+            name="openwisp2-short"
+        )
+        self.assertEqual(mock_exists.call_count, 1)
+
+        self.timeseries_db._ensure_data_stream_resources(SHORT_RP, "24h0m0s")
+        self.assertEqual(mock_db.ilm.put_lifecycle.call_count, 2)
+        self.assertEqual(mock_db.indices.put_index_template.call_count, 2)
+        self.assertEqual(mock_db.indices.create_data_stream.call_count, 1)
+        self.assertEqual(mock_exists.call_count, 2)
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    def test_create_database_ensures_default_stream(self, mock_ensure):
+        self.timeseries_db.create_database()
+        mock_ensure.assert_called_once_with()
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    def test_create_or_alter_retention_policy_ensures_retention_stream(
+        self, mock_ensure
+    ):
+        self.timeseries_db.create_or_alter_retention_policy(SHORT_RP, "24h0m0s")
+        mock_ensure.assert_called_once_with(
+            retention_policy=SHORT_RP,
+            duration="24h0m0s",
+        )
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    def test_create_or_alter_retention_policy_validates_before_network_call(
+        self, mock_ensure
+    ):
+        with self.assertRaisesMessage(ValueError, 'Invalid duration "one day"'):
+            self.timeseries_db.create_or_alter_retention_policy(SHORT_RP, "one day")
+        mock_ensure.assert_not_called()
+
+    @patch.object(
+        DatabaseClient,
+        "_ensure_data_stream_resources",
+        side_effect=[ConnectionError("temporary failure"), None],
+    )
+    def test_create_or_alter_retention_policy_retries_network_errors(self, mock_ensure):
+        self.timeseries_db.create_or_alter_retention_policy(SHORT_RP, "24h0m0s")
+        self.assertEqual(mock_ensure.call_count, 2)
+
+    def test_get_list_retention_policies(self):
+        mock_db = self._mock_db()
+        mock_db.ilm.get_lifecycle.return_value = {
+            "openwisp2-autogen-ilm": {
+                "policy": {"phases": {"delete": {"min_age": "94608000s"}}}
+            },
+            "openwisp2-short-ilm": {
+                "policy": {"phases": {"delete": {"min_age": "86400s"}}}
+            },
+            "another-project-autogen-ilm": {
+                "policy": {"phases": {"delete": {"min_age": "60s"}}}
+            },
+        }
+        policies = self.timeseries_db.get_list_retention_policies()
+        self.assertEqual(
+            policies,
+            [
+                {
+                    "name": DEFAULT_RP,
+                    "default": True,
+                    "duration": "94608000s",
+                    "replication": 1,
+                },
+                {
+                    "name": SHORT_RP,
+                    "default": False,
+                    "duration": "86400s",
+                    "replication": 1,
+                },
+            ],
+        )
+        mock_db.ilm.get_lifecycle.assert_called_once_with(name="openwisp2-*-ilm")
+
+    def test_get_data_stream_names_filters_namespace(self):
+        mock_db = self._mock_db()
+        mock_db.indices.get_data_stream.return_value = {
+            "data_streams": [
+                {"name": "openwisp2"},
+                {"name": "openwisp2-short"},
+                {"name": "openwisp2_test"},
+                {"name": "openwisp20"},
+            ]
+        }
+        self.assertEqual(
+            self.timeseries_db._get_data_stream_names(),
+            ["openwisp2", "openwisp2-short"],
+        )
+
+    def test_get_index_names_filters_data_stream_backing_indices(self):
+        mock_db = self._mock_db()
+        mock_db.indices.get.return_value = {
+            "openwisp2": {},
+            "openwisp2-short": {},
+            "openwisp2_test": {},
+            ".ds-openwisp2-2026.07.27-000001": {},
+        }
+        self.assertEqual(
+            self.timeseries_db._get_index_names(), ["openwisp2", "openwisp2-short"]
+        )
+
+    @patch.object(DatabaseClient, "_delete_lifecycle_policies")
+    @patch.object(DatabaseClient, "_delete_index_templates")
+    @patch.object(DatabaseClient, "_get_data_stream_names", return_value=[])
+    def test_drop_database_deletes_regular_namespace_indices(
+        self, mock_streams, mock_templates, mock_policies
+    ):
+        mock_db = self._mock_db()
+        mock_db.indices.get.return_value = {
+            "openwisp2": {},
+            "openwisp2-short": {},
+            ".ds-openwisp2-2026.07.27-000001": {},
+        }
+        self.timeseries_db.drop_database()
+        self.assertEqual(
+            mock_db.indices.delete.call_args_list,
+            [
+                call(index="openwisp2"),
+                call(index="openwisp2-short"),
+            ],
+        )
+        mock_streams.assert_called_once()
+        mock_templates.assert_called_once()
+        mock_policies.assert_called_once()
+
+    def test_drop_database_deletes_only_namespaced_resources(self):
+        mock_db = self._mock_db()
+        mock_db.indices.get_data_stream.return_value = {
+            "data_streams": [
+                {"name": "openwisp2"},
+                {"name": "openwisp2-short"},
+                {"name": "another-project"},
+            ]
+        }
+        mock_db.indices.get.return_value = {
+            "openwisp2-legacy": {},
+            "another-project": {},
+        }
+        mock_db.ilm.get_lifecycle.return_value = {
+            "openwisp2-autogen-ilm": {},
+            "openwisp2-short-ilm": {},
+            "another-project-autogen-ilm": {},
+        }
+        self.timeseries_db.drop_database()
+        self.assertEqual(
+            mock_db.indices.delete_data_stream.call_args_list,
+            [
+                call(name="openwisp2"),
+                call(name="openwisp2-short"),
+            ],
+        )
+        mock_db.indices.delete.assert_called_once_with(index="openwisp2-legacy")
+        self.assertEqual(
+            mock_db.indices.delete_index_template.call_args_list,
+            [
+                call(name="openwisp2-template"),
+                call(name="openwisp2-*-template"),
+            ],
+        )
+        mock_db.indices.get_index_template.assert_not_called()
+        self.assertEqual(
+            mock_db.ilm.delete_lifecycle.call_args_list,
+            [
+                call(name="openwisp2-autogen-ilm"),
+                call(name="openwisp2-short-ilm"),
+            ],
+        )
+
+    @patch.object(DatabaseClient, "_delete_lifecycle_policies")
+    @patch.object(DatabaseClient, "_delete_index_templates")
+    @patch.object(DatabaseClient, "_delete_indices")
+    @patch.object(
+        DatabaseClient,
+        "_get_data_stream_names",
+        return_value=["openwisp2", "openwisp2-short"],
+    )
+    def test_drop_database_retries_safely_after_partial_deletion(
+        self, mock_streams, mock_indices, mock_templates, mock_policies
+    ):
+        mock_db = self._mock_db()
+        transient_error = RuntimeError("temporary failure")
+        missing_error = RuntimeError("already deleted")
+        mock_db.indices.delete_data_stream.side_effect = [
+            None,
+            transient_error,
+            missing_error,
+            None,
+        ]
+
+        def is_not_found(exception):
+            return exception is missing_error
+
+        with patch.object(
+            DatabaseClient,
+            "_is_not_found",
+            side_effect=is_not_found,
+        ):
+            self.timeseries_db.drop_database()
+        self.assertEqual(mock_streams.call_count, 2)
+        self.assertEqual(
+            mock_db.indices.delete_data_stream.call_args_list,
+            [
+                call(name="openwisp2"),
+                call(name="openwisp2-short"),
+                call(name="openwisp2"),
+                call(name="openwisp2-short"),
+            ],
+        )
+        mock_indices.assert_called_once()
+        mock_templates.assert_called_once()
+        mock_policies.assert_called_once()
+
+    def test_retention_policy_rejects_unsafe_stream_name(self):
+        with self.assertRaisesMessage(
+            ValueError,
+            'Invalid Elasticsearch data stream name "openwisp2-other*"',
+        ):
+            self.timeseries_db.create_or_alter_retention_policy(
+                "other*",
+                "24h0m0s",
+            )
+
+    @patch.object(DatabaseClient, "_is_resource_exists", return_value=True)
+    @patch.object(DatabaseClient, "_data_stream_exists", side_effect=[False, False])
+    def test_ensure_data_stream_resources_raises_for_regular_index_collision(
+        self, mock_exists, mock_resource_exists
+    ):
+        mock_db = self._mock_db()
+        mock_db.indices.create_data_stream.side_effect = RuntimeError("name collision")
+        with self.assertRaisesMessage(RuntimeError, "name collision"):
+            self.timeseries_db._ensure_data_stream_resources()
+        self.assertEqual(mock_exists.call_count, 2)
+        mock_resource_exists.assert_called_once()
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    def test_write_single_point(self, mock_ensure):
+        mock_db = self._mock_db()
+        timestamp = datetime(2024, 3, 25, 12, 0, tzinfo=timezone.utc)
+        self.timeseries_db.write(
+            "cpu",
+            {"usage": 10},
+            tags={"host": "server1"},
+            timestamp=timestamp,
+        )
+        mock_ensure.assert_not_called()
+        mock_db.index.assert_called_once_with(
+            index="openwisp2",
+            document={
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "cpu",
+                "openwisp_write_sequence": 0,
+                "tags": {"host": "server1"},
+                "fields": {"usage": 10},
+            },
+            op_type="create",
+            refresh="wait_for",
+        )
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    def test_write_preserves_zero_timestamp(self, mock_ensure):
+        mock_db = self._mock_db()
+        self.timeseries_db.write("cpu", {"usage": 10}, timestamp=0)
+        mock_ensure.assert_not_called()
+        self.assertEqual(mock_db.index.call_args.kwargs["document"]["@timestamp"], 0)
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.bulk")
+    def test_batch_write_builds_bulk_actions_without_stream_setup(
+        self, mock_bulk, mock_ensure
+    ):
+        mock_db = self._mock_db()
+        timestamp = datetime(2024, 3, 25, 12, 0, tzinfo=timezone.utc)
+        self.timeseries_db.batch_write(
+            [
+                {
+                    "name": "cpu",
+                    "values": {"usage": 10},
+                    "tags": {"host": "server1"},
+                    "timestamp": timestamp,
+                },
+                {
+                    "name": "memory",
+                    "values": {"used": 20},
+                    "tags": {"host": "server1"},
+                    "timestamp": timestamp,
+                    "retention_policy": SHORT_RP,
+                },
+                {
+                    "name": "disk",
+                    "values": {"used": 30},
+                    "tags": {"host": "server1"},
+                    "timestamp": timestamp,
+                    "retention_policy": SHORT_RP,
+                },
+            ]
+        )
+        mock_ensure.assert_not_called()
+        actions = mock_bulk.call_args.args[1]
+        self.assertEqual(actions[0]["_op_type"], "create")
+        self.assertEqual(actions[0]["_index"], "openwisp2")
+        self.assertEqual(actions[1]["_index"], "openwisp2-short")
+        self.assertEqual(actions[2]["_source"]["fields"], {"used": 30})
+        mock_bulk.assert_called_once_with(mock_db, actions, refresh="wait_for")
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.logger.warning")
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.bulk")
+    def test_batch_write_warns_once_per_distinct_database(
+        self, mock_bulk, mocked_warning, mock_ensure
+    ):
+        self._mock_db()
+        self.timeseries_db.batch_write(
+            [
+                {"name": "cpu", "values": {"usage": 10}, "database": "other"},
+                {"name": "memory", "values": {"used": 20}, "database": "other"},
+            ]
+        )
+        mocked_warning.assert_called_once()
+        mock_ensure.assert_not_called()
+
+    @patch.object(DatabaseClient, "_ensure_data_stream_resources")
+    def test_write_failure_raises_timeseries_exception(self, mock_ensure):
+        mock_db = self._mock_db()
+        mock_db.index.side_effect = RuntimeError("write failed")
+        with self.assertRaises(TimeseriesWriteException):
+            self.timeseries_db.write("cpu", {"usage": 10})
+        mock_ensure.assert_not_called()
+
+    def test_query_result_set_get_points_keys_and_items(self):
+        resultset = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "cpu",
+                    "tags": {"host": "server1"},
+                    "fields": {"usage": 10, "load": 2},
+                },
+                {
+                    "@timestamp": "2024-03-25T12:05:00Z",
+                    "measurement": "memory",
+                    "tags": {"host": "server2"},
+                    "fields": {"used": 20},
+                },
+            )
+        )
+        self.assertEqual(len(resultset), 2)
+        self.assertEqual(
+            resultset.keys(),
+            [
+                ("cpu", {"host": "server1"}),
+                ("memory", {"host": "server2"}),
+            ],
+        )
+        cpu_points = list(resultset.get_points(measurement="cpu"))
+        self.assertEqual(len(cpu_points), 2)
+        self.assertEqual({point["_field"] for point in cpu_points}, {"usage", "load"})
+        items = resultset.items()
+        self.assertEqual(items[0][0], ("cpu", {"host": "server1"}))
+        self.assertEqual(list(items[0][1]), cpu_points)
+
+    def test_query_result_set_precision(self):
+        response = _search_response(
+            {
+                "@timestamp": "2024-03-25T12:00:00Z",
+                "measurement": "cpu",
+                "fields": {"usage": 10},
+            }
+        )
+        self.assertEqual(
+            list(QueryResultSet(response, precision="ms").get_points())[0]["time"],
+            1711368000000,
+        )
+        self.assertEqual(
+            list(QueryResultSet(response, precision=None).get_points())[0]["time"],
+            "2024-03-25T12:00:00Z",
+        )
+
+    def test_query_strips_internal_metadata(self):
+        mock_db = self._mock_db()
+        mock_db.search.return_value = _search_response()
+        result = self.timeseries_db.query(
+            {
+                "__index": "openwisp2-short",
+                "__openwisp_query_type": "chart",
+                "query": {"match_all": {}},
+            }
+        )
+        self.assertIsInstance(result, QueryResultSet)
+        mock_db.search.assert_called_once_with(
+            index="openwisp2-short",
+            body={"query": {"match_all": {}}},
+        )
+
+    @patch.object(
+        DatabaseClient, "query", return_value=QueryResultSet(_search_response())
+    )
+    def test_read_builds_search_body(self, mock_query):
+        since = datetime(2024, 3, 25, 10, 0, tzinfo=timezone.utc)
+        self.timeseries_db.read(
+            key="cpu,memory",
+            fields=["usage"],
+            tags={"host": "server1"},
+            since=since,
+            where=[("usage", ">=", 80)],
+            order_by="-time",
+            limit=5,
+            retention_policy=SHORT_RP,
+        )
+        query = mock_query.call_args.args[0]
+        self.assertEqual(query["size"], 10000)
+        self.assertEqual(
+            query["sort"],
+            [
+                {"@timestamp": {"order": "desc"}},
+                {"openwisp_write_sequence": {"order": "asc", "unmapped_type": "long"}},
+            ],
+        )
+        self.assertEqual(query["__retention_policy"], SHORT_RP)
+        filters = query["query"]["bool"]["filter"]
+        self.assertIn({"terms": {"measurement": ["cpu", "memory"]}}, filters)
+        self.assertIn({"term": {"tags.host": "server1"}}, filters)
+        self.assertIn({"exists": {"field": "fields.usage"}}, filters)
+        self.assertIn(
+            {"range": {"@timestamp": {"gte": "2024-03-25T10:00:00Z"}}},
+            filters,
+        )
+
+    @patch.object(DatabaseClient, "query")
+    def test_read_returns_selected_fields(self, mock_query):
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "cpu",
+                    "tags": {"host": "server1"},
+                    "fields": {"usage": 10, "load": 2},
+                }
+            )
+        )
+        points = self.timeseries_db.read("cpu", "usage", {"host": "server1"})
+        self.assertEqual(points, [{"time": 1711368000, "host": "server1", "usage": 10}])
+
+    @patch.object(DatabaseClient, "query")
+    def test_read_deduplicates_same_timestamp_before_where_filtering(self, mock_query):
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "ping",
+                    "tags": {"object_id": "1"},
+                    "fields": {"reachable": 0},
+                },
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "ping",
+                    "tags": {"object_id": "1"},
+                    "fields": {"reachable": 1},
+                },
+            )
+        )
+        points = self.timeseries_db.read(
+            "ping",
+            "reachable",
+            {"object_id": "1"},
+            where=[("reachable", "<", 1)],
+        )
+        self.assertEqual(points, [])
+
+    @patch.object(DatabaseClient, "query")
+    def test_read_supports_wildcard_extra_fields(self, mock_query):
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "cpu",
+                    "fields": {"usage": 10, "load": 2},
+                }
+            )
+        )
+        points = self.timeseries_db.read("cpu", "usage", {}, extra_fields="*")
+        self.assertEqual(points, [{"time": 1711368000, "usage": 10, "load": 2}])
+
+    @patch.object(DatabaseClient, "query")
+    def test_read_count_distinct_single_field(self, mock_query):
+        mock_query.return_value = QueryResultSet(
+            {"hits": {"hits": []}, "aggregations": {"count": {"value": 3}}}
+        )
+        points = self.timeseries_db.read(
+            "wifi_clients",
+            ["clients"],
+            {"content_type": "config.device"},
+            distinct_fields=["clients"],
+            count_fields=["clients"],
+        )
+        self.assertEqual(points, [{"count": 3, "time": None}])
+        query = mock_query.call_args.args[0]
+        self.assertEqual(
+            query["aggs"],
+            {"count": {"cardinality": {"field": "fields.clients"}}},
+        )
+
+    def test_read_count_distinct_unsupported_shape(self):
+        with self.assertRaises(NotImplementedError):
+            self.timeseries_db.read(
+                "wifi_clients",
+                ["clients"],
+                {},
+                distinct_fields=["clients"],
+                count_fields=[],
+            )
+
+    def test_get_query_builds_aggregate_chart_query(self):
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params={
+                "key": "ping",
+                "field_name": "reachable",
+                "time": "2024-03-25 10:00:00",
+                "end_date": "2024-03-25 11:00:00",
+                "content_type": "config.device",
+                "object_id": "device-id",
+            },
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["uptime"]["elasticsearch"],
+            timezone="Asia/Kolkata",
+        )
+        self.assertEqual(query["__index"], "openwisp2")
+        self.assertEqual(query["__openwisp_query_type"], "chart")
+        self.assertEqual(
+            query["aggs"]["timeseries"]["date_histogram"],
+            {
+                "field": "@timestamp",
+                "fixed_interval": "10m",
+                "min_doc_count": 0,
+                "extended_bounds": {
+                    "min": "2024-03-25T04:30:00Z",
+                    "max": "2024-03-25T05:30:00Z",
+                },
+                "time_zone": "Asia/Kolkata",
+            },
+        )
+        filters = query["query"]["bool"]["filter"]
+        self.assertIn(
+            {
+                "range": {
+                    "@timestamp": {
+                        "gte": "2024-03-25T04:30:00Z",
+                        "lte": "2024-03-25T05:30:00Z",
+                    }
+                }
+            },
+            filters,
+        )
+        self.assertEqual(
+            query["aggs"]["timeseries"]["aggs"]["uptime"],
+            {
+                "filter": {"exists": {"field": "fields.reachable"}},
+                "aggs": {"value": {"avg": {"field": "fields.reachable"}}},
+            },
+        )
+        self.assertEqual(query["__openwisp_metrics"][0]["scale"], 100)
+
+    def test_get_query_builds_summary_query(self):
+        query = self.timeseries_db.get_query(
+            chart_type="traffic",
+            params={"key": "traffic", "retention_policy": SHORT_RP},
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["traffic"]["elasticsearch"],
+            summary=True,
+        )
+        self.assertEqual(query["__index"], "openwisp2-short")
+        self.assertNotIn("timeseries", query["aggs"])
+        self.assertEqual(
+            query["aggs"]["upload"],
+            {
+                "filter": {"exists": {"field": "fields.tx_bytes"}},
+                "aggs": {"value": {"sum": {"field": "fields.tx_bytes"}}},
+            },
+        )
+        self.assertEqual(
+            query["aggs"]["download"],
+            {
+                "filter": {"exists": {"field": "fields.rx_bytes"}},
+                "aggs": {"value": {"sum": {"field": "fields.rx_bytes"}}},
+            },
+        )
+
+    def test_get_query_builds_raw_chart_query(self):
+        query = self.timeseries_db.get_query(
+            chart_type="line",
+            params={"key": "cpu", "field_name": "usage"},
+            time="1h",
+            group_map={"1h": "5m"},
+            fields=["usage", "load"],
+        )
+        self.assertEqual(query["__openwisp_query_type"], "raw_chart")
+        self.assertEqual(query["__openwisp_fields"], ["usage", "load"])
+        self.assertEqual(query["sort"], [{"@timestamp": {"order": "asc"}}])
+        self.assertEqual(
+            query["query"]["bool"]["filter"][-1],
+            {
+                "bool": {
+                    "should": [
+                        {"exists": {"field": "fields.usage"}},
+                        {"exists": {"field": "fields.load"}},
+                    ],
+                    "minimum_should_match": 1,
+                }
+            },
+        )
+
+    def test_query_bundle_matches_backend_contract(self):
+        self.timeseries_db.queries.validate(self.timeseries_db.backend_name)
+        self.assertEqual(set(chart_query.keys()), set(summary_query.keys()))
+        for config in self.timeseries_db.queries.chart_query.values():
+            self.assertIn("elasticsearch", config)
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_top_fields(self, mock_query):
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {"fields": {"http2": 100, "ssh": 90, "ignored": "string"}},
+                {"fields": {"http2": 1, "udp": 80, "is_bool": True}},
+            )
+        )
+        fields = self.timeseries_db._get_top_fields(
+            query=self.timeseries_db.get_default_chart_query(has_object_scope=False),
+            params={"key": "applications", "field_name": "app"},
+            chart_type="histogram",
+            group_map={"30d": "30d"},
+            number=2,
+            time="30d",
+        )
+        self.assertEqual(fields, ["http2", "ssh"])
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_list_query_converts_chart_aggregations(self, mock_query):
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params={"key": "ping", "field_name": "reachable"},
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["uptime"]["elasticsearch"],
+        )
+        mock_query.return_value = QueryResultSet(
+            {
+                "hits": {"hits": []},
+                "aggregations": {
+                    "timeseries": {
+                        "buckets": [
+                            {
+                                "key": 1711368000000,
+                                "uptime": {"value": 0.5},
+                            }
+                        ]
+                    }
+                },
+            }
+        )
+        self.assertEqual(
+            self.timeseries_db.get_list_query(query),
+            [{"time": 1711368000, "uptime": 50.0}],
+        )
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_list_query_converts_raw_hits(self, mock_query):
+        query = self.timeseries_db.get_query(
+            chart_type="line",
+            params={"key": "cpu", "field_name": "usage"},
+            time="1h",
+            group_map={"1h": "5m"},
+        )
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "cpu",
+                    "tags": {"host": "server1"},
+                    "fields": {"usage": 10, "load": 2},
+                }
+            )
+        )
+        self.assertEqual(
+            self.timeseries_db.get_list_query(query),
+            [{"time": 1711368000, "usage": 10}],
+        )
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_list_query_merges_raw_hits_by_time(self, mock_query):
+        query = self.timeseries_db.get_query(
+            chart_type="line",
+            params={"key": "traffic", "field_name": "download"},
+            time="1h",
+            group_map={"1h": "5m"},
+            fields=["download", "upload"],
+        )
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "traffic",
+                    "fields": {"download": 10},
+                },
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "traffic",
+                    "fields": {"upload": 20},
+                },
+            )
+        )
+        self.assertEqual(
+            self.timeseries_db.get_list_query(query),
+            [{"time": 1711368000, "download": 10, "upload": 20}],
+        )
+
+    @patch.object(DatabaseClient, "read", return_value=[{"time": 1, "data": {}}])
+    def test_get_device_data_query_is_consumed_by_get_list_query(self, mock_read):
+        query = self.timeseries_db.get_device_data_query(SHORT_RP, "device_data", "1")
+        self.assertEqual(
+            query,
+            {
+                "_openwisp_query_type": "device_data",
+                "retention_policy": SHORT_RP,
+                "measurement": "device_data",
+                "pk": "1",
+            },
+        )
+        self.assertEqual(
+            self.timeseries_db.get_list_query(query), [{"time": 1, "data": {}}]
+        )
+        mock_read.assert_called_once_with(
+            key="device_data",
+            fields="data",
+            tags={"pk": "1"},
+            retention_policy=SHORT_RP,
+            limit=1,
+            order="-time",
+            precision="s",
+        )
+
+    def test_validate_query_rejects_non_mapping(self):
+        with self.assertRaises(ValidationError) as context:
+            self.timeseries_db.validate_query("BAD")
+        self.assertIn("configuration", context.exception.message_dict)
+
+    def test_validate_query_uses_elasticsearch_validate_api(self):
+        mock_db = self._mock_db()
+        mock_db.indices.validate_query.return_value = {"valid": True}
+        aggregate = self.timeseries_db.validate_query(
+            {
+                "query": {"match_all": {}},
+                "aggs": {"usage": {"avg": {"field": "fields.usage"}}},
+            }
+        )
+        self.assertTrue(aggregate)
+        mock_db.indices.validate_query.assert_called_once_with(
+            index="openwisp2",
+            body={"query": {"match_all": {}}},
+            explain=True,
+        )
+
+    def test_validate_query_raises_validation_error_for_invalid_query(self):
+        mock_db = self._mock_db()
+        mock_db.indices.validate_query.return_value = {
+            "valid": False,
+            "error": "bad query",
+        }
+        with self.assertRaises(ValidationError) as context:
+            self.timeseries_db.validate_query({"query": {"bad": {}}})
+        self.assertIn("bad query", context.exception.message_dict["configuration"])
+
+    @patch.object(
+        DatabaseClient,
+        "_get_data_stream_names",
+        return_value=["openwisp2", "openwisp2-short"],
+    )
+    @patch.object(DatabaseClient, "_get_index_names", return_value=[])
+    def test_delete_metric_data_calls_delete_by_query_for_streams(
+        self, mock_indices, mock_streams
+    ):
+        mock_db = self._mock_db()
+        self.timeseries_db.delete_metric_data(
+            key="cpu",
+            tags={"host": "server1"},
+        )
+        self.assertEqual(mock_db.delete_by_query.call_count, 2)
+        first_call = mock_db.delete_by_query.call_args_list[0]
+        self.assertEqual(first_call.kwargs["index"], "openwisp2")
+        filters = first_call.kwargs["body"]["query"]["bool"]["filter"]
+        self.assertIn({"term": {"measurement": "cpu"}}, filters)
+        self.assertIn({"term": {"tags.host": "server1"}}, filters)
+        self.assertTrue(first_call.kwargs["refresh"])
+        mock_indices.assert_called_once()
+
+    @patch.object(DatabaseClient, "_get_data_stream_names")
+    @patch.object(DatabaseClient, "_get_index_names")
+    def test_delete_series_requires_filter(self, mock_indices, mock_streams):
+        with self.assertRaises(ValueError):
+            self.timeseries_db.delete_series()
+        mock_streams.assert_not_called()
+        mock_indices.assert_not_called()
+
+
+class ElasticsearchIntegrationMixin:
+    @classmethod
+    def _get_class_patchers(cls):
+        return (
+            patch.object(
+                monitoring_tasks.timeseries_write,
+                "delay",
+                side_effect=monitoring_tasks.timeseries_write.run,
+            ),
+            patch.object(
+                monitoring_tasks.timeseries_batch_write,
+                "delay",
+                side_effect=monitoring_tasks.timeseries_batch_write.run,
+            ),
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        cls._class_patchers = cls._get_class_patchers()
+        started_patchers = []
+        super_setup_completed = False
+        try:
+            for patcher in cls._class_patchers:
+                patcher.start()
+                started_patchers.append(patcher)
+            super().setUpClass()
+            super_setup_completed = True
+            manage_short_retention_policy()
+        except Exception:
+            for patcher in reversed(started_patchers):
+                patcher.stop()
+            if super_setup_completed:
+                super().tearDownClass()
+            raise
+        assert settings.TIMESERIES_DATABASE["BACKEND"].endswith("elasticsearch")
+
+    @classmethod
+    def tearDownClass(cls):
+        for patcher in reversed(cls._class_patchers):
+            patcher.stop()
+        super().tearDownClass()
+
+
+@tag("timeseries_client", "elasticsearch")
+class TestElasticsearchClientIntegration(
+    ElasticsearchIntegrationMixin,
+    RequireTimeseriesBackendMixin,
+    TestMonitoringMixin,
+    TestCase,
+):
+    expected_backend = "elasticsearch"
+
+    @classmethod
+    def _get_class_patchers(cls):
+        return super()._get_class_patchers() + (
+            patch.object(
+                device_tasks.write_device_metrics,
+                "delay",
+                side_effect=device_tasks.write_device_metrics.run,
+            ),
+        )
+
+    def test_metric_write_and_read_round_trip(self):
+        metric = self._create_general_metric(name="load")
+        self._write_metric(metric, 50, check=False)
+        points = self._read_metric(metric)
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0][metric.field_name], 50)
+
+    def test_metric_read_omit_since(self):
+        metric = self._create_general_metric(name="historical-load")
+        metric.write(50, time=now() - timedelta(days=2), current=False)
+        points = self._read_metric(metric, limit=None)
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0][metric.field_name], 50)
+
+    def test_metric_read_order_and_same_key_different_fields(self):
+        metric = self._create_general_metric(name="load")
+        self._write_metric(metric, 30, check=False)
+        self._write_metric(metric, 40, check=False, time=now() - timedelta(hours=2))
+        ascending = self._read_metric(metric, limit=2, order="time")
+        descending = self._read_metric(metric, limit=2, order="-time")
+        self.assertEqual([point["value"] for point in ascending], [40, 30])
+        self.assertEqual([point["value"] for point in descending], [30, 40])
+        download = self._create_general_metric(
+            name="traffic (download)",
+            key="traffic",
+            field_name="download",
+        )
+        upload = self._create_general_metric(
+            name="traffic (upload)",
+            key="traffic",
+            field_name="upload",
+        )
+        timestamp = now() - timedelta(hours=1)
+        self._write_metric(download, 200, check=False, time=timestamp)
+        self._write_metric(upload, 100, check=False, time=timestamp)
+        self.assertEqual(self._read_metric(download, order="-time")[0]["download"], 200)
+        self.assertEqual(self._read_metric(upload, order="-time")[0]["upload"], 100)
+
+    def test_metric_read_limit_applies_to_latest_point_only(self):
+        metric = self._create_general_metric(
+            name="optional-field-metric",
+            configuration="test_alert_field",
+        )
+        old_time = now() - timedelta(hours=2)
+        new_time = now() - timedelta(hours=1)
+        metric.write(
+            10,
+            extra_values={"test_related_1": 100},
+            time=old_time,
+            check=False,
+        )
+        metric.write(20, time=new_time, check=False)
+        points = self._read_metric(
+            metric,
+            limit=1,
+            order="-time",
+            extra_fields="*",
+        )
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0][metric.field_name], 20)
+        self.assertNotIn("test_related_1", points[0])
+
+    def test_metric_batch_write_round_trip(self):
+        metric = self._create_general_metric(name="batch-load")
+        Metric.batch_write(
+            [
+                (
+                    metric,
+                    {
+                        "value": 11,
+                        "time": now() - timedelta(minutes=5),
+                        "current": False,
+                    },
+                ),
+                (
+                    metric,
+                    {
+                        "value": 22,
+                        "time": now(),
+                        "current": False,
+                    },
+                ),
+            ]
+        )
+        values = self._read_metric(metric, limit=2, order="time")
+        self.assertEqual([point["value"] for point in values], [11, 22])
+
+    @patch.object(monitoring_settings, "TOLERANCE_INTERVAL", 300)
+    def test_alert_tolerance_uses_read_contract(self):
+        self._create_admin()
+        metric = self._create_general_metric(name="load")
+        self._create_alert_settings(
+            metric=metric,
+            custom_operator=">",
+            custom_threshold=90,
+            custom_tolerance=5,
+        )
+        base_time = now().replace(second=0, microsecond=0)
+        with freeze_time(base_time):
+            metric.write(99)
+        with freeze_time(base_time + timedelta(minutes=2)):
+            metric.write(99)
+        metric.refresh_from_db(fields=["is_healthy", "is_healthy_tolerant"])
+        self.assertEqual(metric.is_healthy, False)
+        self.assertEqual(metric.is_healthy_tolerant, True)
+        self.assertEqual(Notification.objects.count(), 0)
+        with freeze_time(base_time + timedelta(minutes=6)):
+            metric.write(99)
+        metric.refresh_from_db(fields=["is_healthy", "is_healthy_tolerant"])
+        self.assertEqual(metric.is_healthy, False)
+        self.assertEqual(metric.is_healthy_tolerant, False)
+        self.assertEqual(Notification.objects.count(), 1)
+
+    def test_chart_read_default_query_round_trip(self):
+        chart = self._create_chart(configuration="dummy")
+        data = self._read_chart(chart)
+        self.assertIn("x", data)
+        self.assertIn("traces", data)
+        self.assertEqual(len(data["x"]), 3)
+        self.assertEqual(data["traces"], [("value", [3, 6, 9])])
+        self.assertEqual(data["summary"], {"value": None})
+
+    def test_ping_uptime_chart_summary_round_trip(self):
+        metric = self._create_object_metric(name="ping", configuration="ping")
+        timestamp = now()
+        metric.write(
+            1,
+            extra_values={"loss": 0, "rtt_min": 1.2, "rtt_avg": 2.4, "rtt_max": 3.6},
+            time=timestamp - timedelta(days=2),
+        )
+        metric.write(
+            1,
+            extra_values={"loss": 0, "rtt_min": 1.1, "rtt_avg": 2.1, "rtt_max": 3.1},
+            time=timestamp - timedelta(days=1),
+        )
+        metric.write(
+            1,
+            extra_values={"loss": 0, "rtt_min": 1.0, "rtt_avg": 2.0, "rtt_max": 3.0},
+            time=timestamp,
+        )
+        chart = Chart(metric=metric, configuration="uptime")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(chart, time="7d")
+        self.assertEqual(data["summary"], {"uptime": 100.0})
+
+    def test_chart_summary_does_not_sum_split_tag_series(self):
+        metric = self._create_object_metric(name="disk", configuration="disk")
+        timestamp = now()
+        timeseries_db.write(
+            metric.key,
+            {metric.field_name: 75},
+            tags=metric.tags,
+            timestamp=timestamp - timedelta(days=2),
+        )
+        tags = {**metric.tags, "host": "openwisp-staging"}
+        timeseries_db.write(
+            metric.key,
+            {metric.field_name: 76},
+            tags=tags,
+            timestamp=timestamp,
+        )
+        chart = Chart(metric=metric, configuration="disk")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(chart, time="7d")
+        self.assertEqual(data["summary"], {"disk_usage": 75.5})
+
+    def test_chart_read_does_not_hide_split_tag_series(self):
+        metric = self._create_object_metric(name="disk", configuration="disk")
+        timestamp = now()
+        timeseries_db.write(
+            metric.key,
+            {metric.field_name: 75},
+            tags=metric.tags,
+            timestamp=timestamp - timedelta(days=2),
+        )
+        tags = {**metric.tags, "host": "openwisp-staging"}
+        timeseries_db.write(
+            metric.key,
+            {metric.field_name: 76},
+            tags=tags,
+            timestamp=timestamp,
+        )
+        chart = Chart(metric=metric, configuration="disk")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(chart, time="7d")
+        values = [value for value in data["traces"][0][1] if value is not None]
+        self.assertEqual(values, [75.0, 76.0])
+
+    def test_ping_uptime_chart_uses_uniform_10_minute_buckets_for_1d(self):
+        metric = self._create_object_metric(name="ping", configuration="ping")
+        base_time = (
+            (now() - timedelta(days=1))
+            .astimezone(timezone.utc)
+            .replace(hour=10, minute=5, second=0, microsecond=0)
+        )
+        range_start = base_time - timedelta(days=1) + timedelta(minutes=2)
+        range_end = base_time + timedelta(minutes=2)
+        timestamps = [
+            base_time - timedelta(minutes=30),
+            base_time - timedelta(minutes=20),
+            base_time - timedelta(minutes=10),
+            base_time,
+        ]
+        for timestamp in timestamps:
+            metric.write(
+                1,
+                extra_values={
+                    "loss": 0,
+                    "rtt_min": 1.0,
+                    "rtt_avg": 2.0,
+                    "rtt_max": 3.0,
+                },
+                time=timestamp,
+            )
+        chart = Chart(metric=metric, configuration="uptime")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(
+            chart,
+            time="1d",
+            start_date=range_start.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date=range_end.strftime("%Y-%m-%d %H:%M:%S"),
+            timezone="UTC",
+        )
+        non_null_points = [
+            datetime.strptime(timestamp, "%Y-%m-%d %H:%M")
+            for timestamp, value in zip(data["x"], data["traces"][0][1])
+            if value is not None
+        ]
+        self.assertGreaterEqual(len(non_null_points), 1)
+        self.assertTrue(all(point.minute % 10 == 0 for point in non_null_points))
+        if len(non_null_points) > 1:
+            self.assertEqual(
+                {
+                    int((current - previous).total_seconds())
+                    for previous, current in zip(non_null_points, non_null_points[1:])
+                },
+                {600},
+            )
+        self.assertEqual(
+            non_null_points[-1].strftime("%Y-%m-%d %H:%M"),
+            base_time.replace(minute=0).strftime("%Y-%m-%d %H:%M"),
+        )
+        self.assertEqual(data["summary"], {"uptime": 100.0})
+
+    def test_wifi_clients_chart_uses_uniform_10_minute_buckets_for_1d(self):
+        metric = self._create_object_metric(
+            name="wifi associations",
+            key="hostapd",
+            field_name="mac",
+            extra_tags={"ifname": "wlan0"},
+        )
+        range_start = (
+            (now() - timedelta(days=1))
+            .astimezone(timezone.utc)
+            .replace(hour=10, minute=7, second=0, microsecond=0)
+        )
+        for minutes, mac in (
+            (1, "00:14:5c:00:00:01"),
+            (11, "00:14:5c:00:00:02"),
+            (21, "00:14:5c:00:00:03"),
+        ):
+            metric.write(mac, time=range_start + timedelta(minutes=minutes))
+        chart = Chart(metric=metric, configuration="wifi_clients")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(
+            chart,
+            time="1d",
+            start_date=range_start.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date=(range_start + timedelta(minutes=30)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            timezone="UTC",
+        )
+        non_null_points = [
+            datetime.strptime(timestamp, "%Y-%m-%d %H:%M")
+            for timestamp, value in zip(data["x"], data["traces"][0][1])
+            if value is not None
+        ]
+        self.assertGreaterEqual(len(non_null_points), 1)
+        self.assertTrue(all(point.minute % 10 == 0 for point in non_null_points), data)
+        self.assertEqual(data["summary"], {"wifi_clients": 3})
+
+    def test_access_tech_chart_keeps_sparse_range_buckets(self):
+        metric = self._create_object_metric(
+            name="access technology",
+            key="signal",
+            field_name="access_tech",
+            configuration="access_tech",
+            extra_tags={"ifname": "wwan0"},
+        )
+        range_start = (
+            (now() - timedelta(days=1))
+            .astimezone(timezone.utc)
+            .replace(hour=10, minute=7, second=0, microsecond=0)
+        )
+        metric.write(4, time=range_start + timedelta(minutes=1))
+        metric.write(4, time=range_start + timedelta(minutes=11))
+        chart = Chart(metric=metric, configuration="access_tech")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(
+            chart,
+            time="1d",
+            start_date=range_start.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date=(range_start + timedelta(minutes=60)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            timezone="UTC",
+        )
+        non_null_values = [value for value in data["traces"][0][1] if value is not None]
+        self.assertEqual(non_null_values, [4, 4])
+        self.assertGreaterEqual(len(data["x"]), 6, data)
+
+    def test_ping_uptime_chart_zoom_range_uses_request_timezone(self):
+        metric = self._create_object_metric(name="ping", configuration="ping")
+        request_day = (now() - timedelta(days=1)).astimezone(timezone.utc).date()
+        metric.write(
+            1,
+            extra_values={"loss": 0, "rtt_min": 1.0, "rtt_avg": 2.0, "rtt_max": 3.0},
+            time=datetime(
+                request_day.year,
+                request_day.month,
+                request_day.day,
+                4,
+                40,
+                tzinfo=timezone.utc,
+            ),
+        )
+        chart = Chart(metric=metric, configuration="uptime")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(
+            chart,
+            time="1d",
+            start_date=f"{request_day:%Y-%m-%d} 10:00:00",
+            end_date=f"{request_day:%Y-%m-%d} 11:00:00",
+            timezone="Asia/Kolkata",
+        )
+        self.assertIn("x", data)
+        self.assertTrue(data["traces"], data)
+        self.assertEqual(data["traces"][0][0], "uptime")
+        self.assertIn(100.0, data["traces"][0][1])
+        self.assertEqual(data["summary"], {"uptime": 100.0})
+
+    def test_ping_uptime_chart_daily_window_uses_request_timezone(self):
+        metric = self._create_object_metric(name="ping", configuration="ping")
+        india_timezone = timezone(timedelta(hours=5, minutes=30))
+        write_day = (now() - timedelta(days=2)).astimezone(timezone.utc).date()
+        write_time = datetime(
+            write_day.year,
+            write_day.month,
+            write_day.day,
+            20,
+            0,
+            tzinfo=timezone.utc,
+        )
+        local_midnight = write_time.astimezone(india_timezone).replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
+        window_start = local_midnight - timedelta(days=1)
+        window_end = local_midnight + timedelta(
+            days=1,
+            hours=23,
+            minutes=59,
+            seconds=59,
+        )
+        metric.write(
+            1,
+            extra_values={"loss": 0, "rtt_min": 1.0, "rtt_avg": 2.0, "rtt_max": 3.0},
+            time=write_time,
+        )
+        chart = Chart(metric=metric, configuration="uptime")
+        chart.full_clean()
+        chart.save()
+        data = self._read_chart(
+            chart,
+            time="30d",
+            start_date=window_start.strftime("%Y-%m-%d %H:%M:%S"),
+            end_date=window_end.strftime("%Y-%m-%d %H:%M:%S"),
+            timezone="Asia/Kolkata",
+        )
+        non_null_points = [
+            timestamp
+            for timestamp, value in zip(data["x"], data["traces"][0][1])
+            if value is not None
+        ]
+        self.assertEqual(non_null_points, [local_midnight.strftime("%Y-%m-%d %H:%M")])
+
+    def test_delete_metric_data_and_delete_series_round_trip(self):
+        general_metric = self._create_general_metric(name="delete-general")
+        object_metric = self._create_object_metric(name="delete-object")
+        short_metric = self._create_general_metric(name="delete-short")
+        self._write_metric(general_metric, 100, check=False)
+        self._write_metric(object_metric, 50, check=False)
+        self._write_metric(short_metric, 75, check=False, retention_policy=SHORT_RP)
+        self.assertEqual(self._read_metric(general_metric)[0]["value"], 100)
+        self.assertEqual(self._read_metric(object_metric)[0]["value"], 50)
+        self.assertEqual(
+            self._read_metric(short_metric, retention_policy=SHORT_RP)[0]["value"],
+            75,
+        )
+        timeseries_db.delete_series(key=object_metric.key, tags=object_metric.tags)
+        self.assertEqual(self._read_metric(object_metric), [])
+        self.assertEqual(self._read_metric(general_metric)[0]["value"], 100)
+        self.assertEqual(
+            self._read_metric(short_metric, retention_policy=SHORT_RP)[0]["value"],
+            75,
+        )
+        timeseries_db.delete_metric_data(key=general_metric.key)
+        self.assertEqual(self._read_metric(general_metric), [])
+        timeseries_db.delete_metric_data(key=short_metric.key)
+        self.assertEqual(self._read_metric(short_metric, retention_policy=SHORT_RP), [])
+
+    def test_delete_metric_data_without_filters_clears_default_and_short_streams(self):
+        general_metric = self._create_general_metric(name="delete-all-general")
+        short_metric = self._create_general_metric(name="delete-all-short")
+        self._write_metric(general_metric, 100, check=False)
+        self._write_metric(short_metric, 75, check=False, retention_policy=SHORT_RP)
+        self.assertEqual(self._read_metric(general_metric)[0]["value"], 100)
+        self.assertEqual(
+            self._read_metric(short_metric, retention_policy=SHORT_RP)[0]["value"],
+            75,
+        )
+        timeseries_db.delete_metric_data()
+        self.assertEqual(self._read_metric(general_metric), [])
+        self.assertEqual(self._read_metric(short_metric, retention_policy=SHORT_RP), [])
+
+    def test_retention_policy_utilities_match_current_backend_behavior(self):
+        manage_default_retention_policy()
+        manage_short_retention_policy()
+        policies = timeseries_db.get_list_retention_policies()
+        self.assertEqual(len(policies), 2)
+        self.assertEqual(policies[0]["name"], DEFAULT_RP)
+        self.assertEqual(policies[0]["default"], True)
+        self.assertEqual(policies[0]["duration"], "94608000s")
+        self.assertEqual(policies[0]["replication"], 1)
+        self.assertEqual(policies[1]["name"], SHORT_RP)
+        self.assertEqual(policies[1]["default"], False)
+        self.assertEqual(policies[1]["duration"], "86400s")
+        self.assertEqual(policies[1]["replication"], 1)
+
+    @capture_stderr()
+    def test_write_failure_raises_timeseries_exception(self):
+        mock_db = MagicMock()
+        mock_db.index.side_effect = RuntimeError("write failed")
+        original_db = timeseries_db.__dict__.get("db")
+        timeseries_db.__dict__["db"] = mock_db
+        try:
+            with self.assertRaises(TimeseriesWriteException):
+                timeseries_db.write("test_write", {"value": 1})
+        finally:
+            if original_db is None:
+                timeseries_db.__dict__.pop("db", None)
+            else:
+                timeseries_db.__dict__["db"] = original_db
+
+
+@tag("timeseries_client", "elasticsearch")
+class TestElasticsearchCheckIntegration(
+    ElasticsearchIntegrationMixin,
+    RequireTimeseriesBackendMixin,
+    AutoWifiClientCheck,
+    AutoDataCollectedCheck,
+    TestDeviceMonitoringMixin,
+    TransactionTestCase,
+):
+    _WIFI_CLIENTS = check_settings.CHECK_CLASSES[3][0]
+    _DATA_COLLECTED = check_settings.CHECK_CLASSES[4][0]
+    expected_backend = "elasticsearch"
+
+    def _create_device(self, monitoring_status="ok", *args, **kwargs):
+        device = super()._create_device(*args, **kwargs)
+        device.monitoring.status = monitoring_status
+        device.monitoring.save()
+        return device
+
+    def test_wifi_clients_check_round_trip(self):
+        device = self._create_device()
+        device_data = DeviceData(pk=device.pk)
+        device_data.data = {"interfaces": []}
+        sample_data = self._data()
+        sample_data.pop("resources")
+        device_data.writer.write(sample_data, current=False)
+        raw_metric = Metric.objects.filter(
+            key="wifi_clients",
+            object_id=device.pk,
+        ).first()
+        self.assertIsNotNone(
+            raw_metric,
+            list(
+                Metric.objects.filter(object_id=device.pk).values_list(
+                    "key",
+                    flat=True,
+                )
+            ),
+        )
+        self.assertGreaterEqual(len(self._read_metric(raw_metric, limit=None)), 1)
+        check = Check.objects.get(
+            name="WiFi Clients",
+            check_type=self._WIFI_CLIENTS,
+            content_type=ContentType.objects.get_for_model(Device),
+            object_id=device.pk,
+        )
+        result = check.perform_check()
+        self.assertEqual(result, {"wifi_clients_min": 3, "wifi_clients_max": 3})
+        for key in ("wifi_clients_min", "wifi_clients_max"):
+            metric = Metric.objects.get(key=key, object_id=device_data.id)
+            points = self._read_metric(metric, limit=None)
+            self.assertEqual(len(points), 1)
+            self.assertEqual(points[0]["clients"], 3)
+
+    def test_data_collected_check_round_trip(self):
+        device = self._create_device()
+        device_data = DeviceData(pk=device.pk)
+        device_data.data = {"interfaces": []}
+        sample_data = self._data()
+        sample_data.pop("resources")
+        device_data.writer.write(sample_data, current=False)
+        cache.clear()
+        self.assertGreater(len(DeviceData(pk=device.pk).data["interfaces"]), 0)
+        passive_metric = device.monitoring.related_metrics.exclude(
+            configuration__in=device.monitoring.get_active_metrics()
+        ).first()
+        self.assertIsNotNone(
+            passive_metric,
+            list(
+                device.monitoring.related_metrics.values_list(
+                    "configuration",
+                    "key",
+                )
+            ),
+        )
+        self.assertGreaterEqual(len(self._read_metric(passive_metric, limit=None)), 1)
+        check = Check.objects.create(
+            name="Data Collected",
+            check_type=self._DATA_COLLECTED,
+            content_type=ContentType.objects.get_for_model(Device),
+            object_id=device.pk,
+        )
+        result = check.perform_check()
+        self.assertEqual(result, {"data_collected": 1})
+        metric = Metric.objects.get(key="data_collected", object_id=device_data.id)
+        points = self._read_metric(metric, retention_policy=SHORT_RP)
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0]["data_collected"], 1)
+
+
+@tag("timeseries_client", "elasticsearch")
+class TestElasticsearchDeviceApiIntegration(
+    ElasticsearchIntegrationMixin,
+    RequireTimeseriesBackendMixin,
+    TestDeviceMonitoringMixin,
+    TestCase,
+):
+    expected_backend = "elasticsearch"
+
+    @classmethod
+    def _get_class_patchers(cls):
+        return super()._get_class_patchers() + (
+            patch.object(
+                device_tasks.write_device_metrics,
+                "delay",
+                side_effect=device_tasks.write_device_metrics.run,
+            ),
+        )
+
+    def test_device_metric_post_and_get_round_trip(self):
+        device_data = self.create_test_data()
+        device = self.device_model.objects.get(pk=device_data.pk)
+        response = self.client.get(
+            f"{self._url(device.pk, device.key)}&time=1d&status=1&timezone=Asia/Kolkata"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("data", response.data)
+        self.assertEqual(response.data["data"], device_data.data)
+        self.assertIn("charts", response.data)
+        self.assertGreater(len(response.data["charts"]), 0)
+        for chart in response.data["charts"]:
+            self.assertIn("traces", chart)
+            self.assertIn("summary", chart)
+            self.assertIn("summary_labels", chart)
+            self.assertIn("colors", chart)
+
+    def test_device_metric_csv_export_round_trip(self):
+        device_data = self.create_test_data(no_resources=True)
+        device = self.device_model.objects.get(pk=device_data.pk)
+        response = self.client.get(f"{self._url(device.pk, device.key)}&csv=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get("Content-Disposition"), "attachment; filename=data.csv"
+        )
+        self.assertEqual(response.get("Content-Type"), "text/csv")
+        rows = response.content.decode("utf8").strip().split("\n")
+        header = rows[0].strip().split(",")
+        self.assertEqual(header[0], "time")
+        self.assertIn("wifi_clients - WiFi clients: wlan0", header)
+        self.assertIn("download - Traffic: wlan0", header)
+        self.assertTrue(any(row.strip() for row in rows[1:]))
+
+    def test_dashboard_timeseries_endpoint_round_trip(self):
+        path = reverse("monitoring_general:api_dashboard_timeseries")
+        org = self._create_org(name="org1", slug="org1")
+        metric = self._create_general_metric(
+            name="wifi_clients",
+            configuration="general_clients",
+            field_name="clients",
+            main_tags={"ifname": "wlan0"},
+            extra_tags={"organization_id": str(org.id)},
+        )
+        metric.write("00:23:4a:00:00:00")
+        self.client.force_login(self._create_admin())
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("x", response.data)
+        self.assertIn("charts", response.data)
+        chart = response.data["charts"][0]
+        self.assertEqual(chart["traces"][0][0], "wifi_clients")
+        self.assertEqual(chart["traces"][0][1][-1], 1)
+        self.assertEqual(chart["summary"]["wifi_clients"], 1)

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -90,6 +90,21 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(self.timeseries_db.backend_name, "elasticsearch")
         self.assertFalse(self.timeseries_db.use_udp)
 
+    def test_normalize_chart_window(self):
+        cases = (
+            ("1d", {"1d": "10m"}, "10m"),
+            (5, None, "5m"),
+            (0, None, "1m"),
+            ("5", None, "5m"),
+            ("10m", None, "10m"),
+        )
+        for time_value, group_map, expected in cases:
+            with self.subTest(time_value=time_value, group_map=group_map):
+                self.assertEqual(
+                    self.timeseries_db._normalize_chart_window(time_value, group_map),
+                    expected,
+                )
+
     def test_validate_settings_accepts_supported_connection_options(self):
         for config in (
             self.base_config,
@@ -747,6 +762,25 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(points, [{"time": 1711368000, "usage": 10}])
 
     @patch.object(DatabaseClient, "query")
+    def test_read_filters_by_unselected_field(self, mock_query):
+        mock_query.return_value = QueryResultSet(
+            _search_response(
+                {
+                    "@timestamp": "2024-03-25T12:00:00Z",
+                    "measurement": "load",
+                    "fields": {"value": 10, "related": 100},
+                }
+            )
+        )
+        points = self.timeseries_db.read(
+            "load",
+            "value",
+            {},
+            where=[("related", ">", 50)],
+        )
+        self.assertEqual(points, [{"time": 1711368000, "value": 10}])
+
+    @patch.object(DatabaseClient, "query")
     def test_read_deduplicates_same_timestamp_before_where_filtering(self, mock_query):
         mock_query.return_value = QueryResultSet(
             _search_response(
@@ -1361,6 +1395,30 @@ class TestElasticsearchClientIntegration(
         self.assertEqual(metric.is_healthy_tolerant, False)
         self.assertEqual(Notification.objects.count(), 1)
 
+    @patch.object(monitoring_settings, "TOLERANCE_INTERVAL", 60)
+    def test_alert_tolerance_uses_unselected_related_field(self):
+        self._create_admin()
+        metric = self._create_general_metric(configuration="test_alert_field")
+        self._create_alert_settings(
+            metric=metric,
+            custom_operator=">",
+            custom_threshold=30,
+            custom_tolerance=1,
+        )
+        base_time = now().replace(second=0, microsecond=0)
+        with freeze_time(base_time):
+            metric.write(10, extra_values={"test_related_2": 35})
+        metric.refresh_from_db(fields=["is_healthy", "is_healthy_tolerant"])
+        self.assertEqual(metric.is_healthy, False)
+        self.assertEqual(metric.is_healthy_tolerant, True)
+        self.assertEqual(Notification.objects.count(), 0)
+        with freeze_time(base_time + timedelta(seconds=61)):
+            metric.write(10, extra_values={"test_related_2": 35})
+        metric.refresh_from_db(fields=["is_healthy", "is_healthy_tolerant"])
+        self.assertEqual(metric.is_healthy, False)
+        self.assertEqual(metric.is_healthy_tolerant, False)
+        self.assertEqual(Notification.objects.count(), 1)
+
     def test_chart_read_default_query_round_trip(self):
         chart = self._create_chart(configuration="dummy")
         data = self._read_chart(chart)
@@ -1369,6 +1427,24 @@ class TestElasticsearchClientIntegration(
         self.assertEqual(len(data["x"]), 3)
         self.assertEqual(data["traces"], [("value", [3, 6, 9])])
         self.assertEqual(data["summary"], {"value": None})
+
+    def test_chart_top_fields_round_trip(self):
+        metric = self._create_object_metric(
+            name="applications",
+            configuration="get_top_fields",
+        )
+        chart = Chart(metric=metric, configuration="histogram")
+        self.assertEqual(chart.get_top_fields(number=3), [])
+        metric.write(
+            None,
+            extra_values={
+                "http2": 100,
+                "ssh": 90,
+                "udp": 80,
+                "spdy": 70,
+            },
+        )
+        self.assertEqual(chart.get_top_fields(number=3), ["http2", "ssh", "udp"])
 
     def test_ping_uptime_chart_summary_round_trip(self):
         metric = self._create_object_metric(name="ping", configuration="ping")

--- a/openwisp_monitoring/db/backends/elasticsearch/tests.py
+++ b/openwisp_monitoring/db/backends/elasticsearch/tests.py
@@ -42,6 +42,7 @@ from openwisp_monitoring.monitoring.tests import (
     RequireTimeseriesBackendMixin,
     TestMonitoringMixin,
 )
+from openwisp_monitoring.settings import MONITORING_TIMESERIES_RETRY_OPTIONS
 from openwisp_utils.tests import capture_stderr
 
 from ... import timeseries_db
@@ -120,21 +121,6 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
     def test_backend_name(self):
         self.assertEqual(self.timeseries_db.backend_name, "elasticsearch")
         self.assertFalse(self.timeseries_db.use_udp)
-
-    def test_normalize_chart_window(self):
-        cases = (
-            ("1d", {"1d": "10m"}, "10m"),
-            (5, None, "5m"),
-            (0, None, "1m"),
-            ("5", None, "5m"),
-            ("10m", None, "10m"),
-        )
-        for time_value, group_map, expected in cases:
-            with self.subTest(time_value=time_value, group_map=group_map):
-                self.assertEqual(
-                    self.timeseries_db._normalize_chart_window(time_value, group_map),
-                    expected,
-                )
 
     def test_validate_settings_accepts_supported_connection_options(self):
         for config in (
@@ -281,11 +267,53 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             basic_auth=("openwisp", "secret"),
         )
 
+    @patch("openwisp_monitoring.db.backends.elasticsearch.client.Elasticsearch")
+    def test_insecure_http_warning_only_with_credentials(self, mock_client):
+        cases = (
+            ({"API_KEY": "api-key"}, True),
+            ({"BEARER_AUTH": "bearer"}, True),
+            ({"USER": "openwisp", "PASSWORD": "secret"}, True),
+            # loopback is not exempted: credentials over HTTP always warn
+            ({"URL": "http://127.0.0.1:9200", "API_KEY": "api-key"}, True),
+            # unauthenticated HTTP is supported for local development
+            ({}, False),
+            # HTTPS and cloud IDs are secure transports
+            ({"URL": "https://es.example.org:9200", "API_KEY": "api-key"}, False),
+            ({"URL": "", "CLOUD_ID": "cluster:cloud-id", "API_KEY": "key"}, False),
+        )
+        for config, expected in cases:
+            with self.subTest(config=config):
+                with patch.dict(
+                    "openwisp_monitoring.db.backends.elasticsearch.client."
+                    "TIMESERIES_DB",
+                    {**self.base_config, **config},
+                    clear=True,
+                ):
+                    with patch("logging.Logger.warning") as mocked_warning:
+                        DatabaseClient().db
+                    self.assertEqual(mocked_warning.called, expected)
+                    if expected:
+                        self.assertIn("insecure HTTP", mocked_warning.call_args.args[0])
+
     def test_reset_clears_cached_state(self):
         client = DatabaseClient(db_name="initial-db")
         client.__dict__["db"] = object()
         client.reset(db_name="reset-db")
         self.assertEqual(client.db_name, "reset-db")
+        self.assertNotIn("db", client.__dict__)
+
+    def test_reset_and_close_close_cached_client(self):
+        for method in ("reset", "close"):
+            with self.subTest(method=method):
+                client = DatabaseClient(db_name="initial-db")
+                mock_client = MagicMock()
+                client.__dict__["db"] = mock_client
+                getattr(client, method)()
+                mock_client.close.assert_called_once_with()
+                self.assertNotIn("db", client.__dict__)
+        # closing is not attempted when the client was never instantiated
+        client = DatabaseClient(db_name="initial-db")
+        client.close()
         self.assertNotIn("db", client.__dict__)
 
     def test_build_index_template_uses_data_stream_settings(self):
@@ -1086,11 +1114,12 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertEqual(second_body["search_after"], [matching_timestamp, 1, 1])
         mock_db.close_point_in_time.assert_called_once_with(id="pit-3")
 
-    @patch.object(DatabaseClient, "query")
-    def test_read_count_distinct_single_field(self, mock_query):
-        mock_query.return_value = QueryResultSet(
-            {"hits": {"hits": []}, "aggregations": {"count": {"value": 3}}}
-        )
+    def test_read_count_distinct_single_field(self):
+        mock_db = self._mock_db()
+        mock_db.open_point_in_time.return_value = {"id": "pit-1"}
+        mock_db.search.return_value = {
+            "aggregations": {"distinct": {"buckets": [{"key": {"value": "a"}}] * 3}}
+        }
         points = self.timeseries_db.read(
             "wifi_clients",
             ["clients"],
@@ -1099,11 +1128,60 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
             count_fields=["clients"],
         )
         self.assertEqual(points, [{"count": 3, "time": None}])
-        query = mock_query.call_args.args[0]
+        body = mock_db.search.call_args.kwargs["body"]
+        self.assertEqual(body["size"], 0)
         self.assertEqual(
-            query["aggs"],
-            {"count": {"cardinality": {"field": "indexed_fields.keyword.clients"}}},
+            body["aggs"],
+            {
+                "distinct": {
+                    "composite": {
+                        "size": DatabaseClient._DISTINCT_PAGE_SIZE,
+                        "sources": [
+                            {
+                                "value": {
+                                    "terms": {"field": "indexed_fields.keyword.clients"}
+                                }
+                            }
+                        ],
+                    }
+                }
+            },
         )
+        mock_db.close_point_in_time.assert_called_once_with(id="pit-1")
+
+    def test_read_count_distinct_pages_until_exhausted(self):
+        page_size = DatabaseClient._DISTINCT_PAGE_SIZE
+        mock_db = self._mock_db()
+        mock_db.open_point_in_time.return_value = {"id": "pit-1"}
+        mock_db.search.side_effect = [
+            {
+                "aggregations": {
+                    "distinct": {
+                        "buckets": [{"key": {"value": "a"}}] * page_size,
+                        "after_key": {"value": "a"},
+                    }
+                }
+            },
+            {"aggregations": {"distinct": {"buckets": [{"key": {"value": "b"}}] * 5}}},
+        ]
+        points = self.timeseries_db.read(
+            "wifi_clients",
+            ["clients"],
+            {"content_type": "config.device"},
+            distinct_fields=["clients"],
+            count_fields=["clients"],
+        )
+        self.assertEqual(points, [{"count": page_size + 5, "time": None}])
+        self.assertEqual(mock_db.search.call_count, 2)
+        first_composite = mock_db.search.call_args_list[0].kwargs["body"]["aggs"][
+            "distinct"
+        ]["composite"]
+        second_composite = mock_db.search.call_args_list[1].kwargs["body"]["aggs"][
+            "distinct"
+        ]["composite"]
+        self.assertNotIn("after", first_composite)
+        self.assertEqual(second_composite["after"], {"value": "a"})
+        mock_db.close_point_in_time.assert_called_once_with(id="pit-1")
 
     def test_read_count_distinct_unsupported_shape(self):
         with self.assertRaises(NotImplementedError):
@@ -1414,7 +1492,15 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
                                     "doc_count": 0,
                                     "value": {"value": 0},
                                 },
-                            }
+                            },
+                            {
+                                "key": 1711368600000,
+                                "doc_count": 2,
+                                "wifi_clients": {
+                                    "doc_count": 2,
+                                    "value": {"value": 2},
+                                },
+                            },
                         ]
                     }
                 },
@@ -1422,8 +1508,51 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertEqual(
             self.timeseries_db.get_list_query(query),
-            [{"time": 1711368000, "wifi_clients": 0}],
+            [
+                {"time": 1711368000, "wifi_clients": 0},
+                {"time": 1711368600, "wifi_clients": 2},
+            ],
         )
+
+    @patch.object(DatabaseClient, "query")
+    def test_get_list_query_omits_chart_without_any_cardinality_document(
+        self, mock_query
+    ):
+        query = self.timeseries_db.get_query(
+            chart_type="bar",
+            params={"key": "wifi_clients", "field_name": "clients"},
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["wifi_clients"]["elasticsearch"],
+        )
+        mock_query.return_value = QueryResultSet(
+            {
+                "hits": {"hits": []},
+                "aggregations": {
+                    "timeseries": {
+                        "buckets": [
+                            {
+                                "key": 1711368000000,
+                                "doc_count": 0,
+                                "wifi_clients": {
+                                    "doc_count": 0,
+                                    "value": {"value": 0},
+                                },
+                            },
+                            {
+                                "key": 1711368600000,
+                                "doc_count": 0,
+                                "wifi_clients": {
+                                    "doc_count": 0,
+                                    "value": {"value": 0},
+                                },
+                            },
+                        ]
+                    }
+                },
+            }
+        )
+        self.assertEqual(self.timeseries_db.get_list_query(query), [])
 
     @patch.object(DatabaseClient, "query")
     def test_get_list_query_omits_empty_chart_summary(self, mock_query):
@@ -1712,6 +1841,31 @@ class TestElasticsearchClient(RequireTimeseriesBackendMixin, TestCase):
         self.assertIn({"term": {"tags.host": "server1"}}, filters)
         self.assertTrue(first_call.kwargs["refresh"])
         mock_indices.assert_called_once()
+
+    @patch("openwisp_monitoring.utils.sleep")
+    @patch.object(DatabaseClient, "_get_data_stream_names", return_value=["openwisp2"])
+    @patch.object(DatabaseClient, "_get_index_names", return_value=[])
+    def test_delete_metric_data_raises_on_incomplete_deletion(
+        self, mock_indices, mock_streams, mock_sleep
+    ):
+        for response in (
+            {"timed_out": True},
+            {"failures": [{"cause": {"type": "version_conflict_engine_exception"}}]},
+            {"version_conflicts": 2},
+        ):
+            with self.subTest(response=response):
+                mock_db = self._mock_db()
+                mock_db.delete_by_query.return_value = response
+                with self.assertRaises(TimeseriesWriteException):
+                    self.timeseries_db.delete_metric_data(key="cpu")
+                self.assertEqual(
+                    mock_db.delete_by_query.call_count,
+                    MONITORING_TIMESERIES_RETRY_OPTIONS.get("max_retries"),
+                )
+        mock_db = self._mock_db()
+        mock_db.delete_by_query.return_value = {"timed_out": False, "deleted": 1}
+        self.timeseries_db.delete_metric_data(key="cpu")
+        self.assertEqual(mock_db.delete_by_query.call_count, 1)
 
     @patch.object(DatabaseClient, "_get_data_stream_names")
     @patch.object(DatabaseClient, "_get_index_names")
@@ -2614,6 +2768,40 @@ class TestElasticsearchCheckIntegration(
             points = self._read_metric(metric, limit=None)
             self.assertEqual(len(points), 1)
             self.assertEqual(points[0]["clients"], 3)
+
+    def test_wifi_clients_check_counts_distinct_clients_exactly(self):
+        # more than the default precision_threshold of the cardinality
+        # aggregation, which would return an approximate result
+        clients_count = 4000
+        device = self._create_device()
+        timestamp = now()
+        timeseries_db.batch_write(
+            [
+                {
+                    "name": "wifi_clients",
+                    "values": {
+                        "clients": (f"00:00:00:00:{index // 256:02x}:{index % 256:02x}")
+                    },
+                    "tags": {
+                        "content_type": Device._meta.label_lower,
+                        "object_id": str(device.pk),
+                    },
+                    "timestamp": timestamp,
+                }
+                for index in range(clients_count)
+            ]
+        )
+        check = Check.objects.get(
+            name="WiFi Clients",
+            check_type=self._WIFI_CLIENTS,
+            content_type=ContentType.objects.get_for_model(Device),
+            object_id=device.pk,
+        )
+        result = check.perform_check()
+        self.assertEqual(
+            result,
+            {"wifi_clients_min": clients_count, "wifi_clients_max": clients_count},
+        )
 
     def test_data_collected_check_round_trip(self):
         device = self._create_device()

--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -420,13 +420,9 @@ class DatabaseClient(BaseTimeseriesClient):
     def _delete_point(self, key=None, tags=None, timestamp=None):
         conditions = [f"time = '{self._get_timestamp(timestamp)}'"]
         for tag_key, tag_value in (tags or {}).items():
-            conditions.append(f"\"{tag_key}\" = '{self._escape_tag_value(tag_value)}'")
+            conditions.append(f'"{tag_key}" = {self._format_string_value(tag_value)}')
         measurement = f'FROM "{key}" ' if key else ""
         self.query(f'DELETE {measurement}WHERE {" AND ".join(conditions)}')
-
-    @staticmethod
-    def _escape_tag_value(value):
-        return str(value).replace("'", r"\'")
 
     @retry
     def delete_series(self, key=None, tags=None):

--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -402,16 +402,31 @@ class DatabaseClient(BaseTimeseriesClient):
             pk=self._format_string_value(pk),
         )
 
-    def delete_metric_data(self, key=None, tags=None):
+    def delete_metric_data(self, key=None, tags=None, timestamp=None):
         """Deletes a specific metric.
 
         Deletes a metric based on the key and tags provided, you may also
-        choose to delete all metrics.
+        choose to delete all metrics. If ``timestamp`` is passed, only the
+        data written at that specific time is deleted.
         """
-        if not key and not tags:
+        if timestamp is not None:
+            self._delete_point(key=key, tags=tags, timestamp=timestamp)
+        elif not key and not tags:
             self.query("DROP SERIES FROM /.*/")
         else:
             self.delete_series(key, tags)
+
+    @retry
+    def _delete_point(self, key=None, tags=None, timestamp=None):
+        conditions = [f"time = '{self._get_timestamp(timestamp)}'"]
+        for tag_key, tag_value in (tags or {}).items():
+            conditions.append(f"\"{tag_key}\" = '{self._escape_tag_value(tag_value)}'")
+        measurement = f'FROM "{key}" ' if key else ""
+        self.query(f'DELETE {measurement}WHERE {" AND ".join(conditions)}')
+
+    @staticmethod
+    def _escape_tag_value(value):
+        return str(value).replace("'", r"\'")
 
     @retry
     def delete_series(self, key=None, tags=None):

--- a/openwisp_monitoring/db/backends/influxdb/client.py
+++ b/openwisp_monitoring/db/backends/influxdb/client.py
@@ -417,8 +417,6 @@ class DatabaseClient(BaseTimeseriesClient):
     def delete_series(self, key=None, tags=None):
         self.db.delete_series(measurement=key, tags=tags)
 
-    # Chart related functions below
-
     def validate_query(self, query):
         for word in self._FORBIDDEN:
             if word in query.lower():

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -232,6 +232,42 @@ class TestDatabaseClient(RequireTimeseriesBackendMixin, TestMonitoringMixin, Tes
         self.assertEqual(m.read(), [])
         self.assertEqual(om.read(), [])
 
+    def test_delete_metric_data_at_timestamp(self):
+        m = self._create_general_metric(name="test_metric")
+        first = now() - timedelta(days=2)
+        second = now() - timedelta(days=1)
+        m.write(100, time=first)
+        m.write(200, time=second)
+        self.assertEqual(
+            sorted(point["value"] for point in m.read()),
+            [100, 200],
+        )
+        timeseries_db.delete_metric_data(key=m.key, timestamp=second)
+        self.assertEqual([point["value"] for point in m.read()], [100])
+
+    def test_delete_metric_data_at_timestamp_with_tags(self):
+        m = self._create_object_metric(name="dummy")
+        timestamp = now() - timedelta(days=1)
+        m.write(100, time=timestamp)
+        self.assertEqual([point["value"] for point in m.read()], [100])
+        timeseries_db.delete_metric_data(key=m.key, tags=m.tags, timestamp=timestamp)
+        self.assertEqual(m.read(), [])
+
+    def test_delete_metric_data_at_timestamp_escapes_tags(self):
+        timestamp = make_aware(datetime(2026, 8, 19, 10, 30))
+        with patch.object(timeseries_db, "query") as mocked_query:
+            timeseries_db.delete_metric_data(
+                key="radius_acc",
+                tags={"calling_station_id": "aa'bb"},
+                timestamp=timestamp,
+            )
+        self.assertEqual(
+            mocked_query.call_args[0][0],
+            'DELETE FROM "radius_acc" WHERE '
+            f"time = '{timestamp.isoformat(sep='T', timespec='microseconds')}' "
+            "AND \"calling_station_id\" = 'aa\\'bb'",
+        )
+
     def test_get_query_1d(self):
         c = self._create_chart(test_data=None, configuration="uptime")
         q = c.get_query(time="1d")

--- a/openwisp_monitoring/db/backends/influxdb/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb/tests.py
@@ -255,17 +255,22 @@ class TestDatabaseClient(RequireTimeseriesBackendMixin, TestMonitoringMixin, Tes
 
     def test_delete_metric_data_at_timestamp_escapes_tags(self):
         timestamp = make_aware(datetime(2026, 8, 19, 10, 30))
+        tag_value = r"aa\'bb"
+        expected_tag = "'{}'".format(
+            tag_value.replace("\\", "\\\\").replace("'", "\\'")
+        )
+        self.assertEqual(expected_tag, r"'aa\\\'bb'")
         with patch.object(timeseries_db, "query") as mocked_query:
             timeseries_db.delete_metric_data(
                 key="radius_acc",
-                tags={"calling_station_id": "aa'bb"},
+                tags={"calling_station_id": tag_value},
                 timestamp=timestamp,
             )
         self.assertEqual(
             mocked_query.call_args[0][0],
             'DELETE FROM "radius_acc" WHERE '
             f"time = '{timestamp.isoformat(sep='T', timespec='microseconds')}' "
-            "AND \"calling_station_id\" = 'aa\\'bb'",
+            f'AND "calling_station_id" = {expected_tag}',
         )
 
     def test_get_query_1d(self):

--- a/openwisp_monitoring/db/backends/influxdb2/client.py
+++ b/openwisp_monitoring/db/backends/influxdb2/client.py
@@ -493,6 +493,10 @@ class DatabaseClient(BaseTimeseriesClient):
     def _serialize_flux_time(self, value):
         return value.isoformat().replace("+00:00", "Z")
 
+    def _serialize_delete_stop(self, value):
+        value = value.astimezone(timezone.utc)
+        return f'{value.strftime("%Y-%m-%dT%H:%M:%S")}.{value.microsecond:06d}001Z'
+
     # smallest representable interval added to the stop of a range
     _RANGE_STOP_EPSILON = timedelta(microseconds=1)
 
@@ -1094,7 +1098,7 @@ class DatabaseClient(BaseTimeseriesClient):
                 raise ValueError(f'Invalid timestamp: "{_value}"')
         if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
-        return timestamp, timestamp + timedelta(milliseconds=1)
+        return timestamp, self._serialize_delete_stop(timestamp)
 
     @retry
     def _delete_range(

--- a/openwisp_monitoring/db/backends/influxdb2/client.py
+++ b/openwisp_monitoring/db/backends/influxdb2/client.py
@@ -508,15 +508,6 @@ class DatabaseClient(BaseTimeseriesClient):
             return f'time(v: "{self._serialize_flux_time(value)}")'
         return value
 
-    def _normalize_chart_window(self, time_value, group_map=None):
-        if group_map and time_value in group_map:
-            return group_map[time_value]
-        if isinstance(time_value, (int, float)):
-            return f"{max(int(time_value), 1)}m"
-        if isinstance(time_value, str) and re.fullmatch(r"\d+", time_value):
-            return f"{max(int(time_value), 1)}m"
-        return time_value
-
     def _normalize_chart_start_range(self, time_value, timezone_name=None):
         if isinstance(time_value, (int, float)):
             return f"-{self._normalize_chart_window(time_value)}"

--- a/openwisp_monitoring/db/backends/influxdb2/client.py
+++ b/openwisp_monitoring/db/backends/influxdb2/client.py
@@ -2,7 +2,7 @@ import logging
 import re
 import socket
 from collections.abc import Iterator, Mapping, Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlparse
 from zoneinfo import ZoneInfo
@@ -184,7 +184,18 @@ class QueryResultSet:
 class DatabaseClient(BaseTimeseriesClient):
     """InfluxDB 2.0 client for timeseries database operations."""
 
-    _AGGREGATE = ["mean", "sum", "count", "max", "min", "mode", "stddev"]
+    _AGGREGATE = [
+        "mean",
+        "sum",
+        "count",
+        "max",
+        "min",
+        "mode",
+        "stddev",
+        "last",
+        "first",
+        "distinct",
+    ]
     backend_name = "influxdb2"
     client_error = InfluxDBError
     required_settings = ("BACKEND", "USER", "PASSWORD", "NAME")
@@ -1052,11 +1063,33 @@ class DatabaseClient(BaseTimeseriesClient):
                 predicates.append(f"{tag_key}={self._format_flux_string(tag_value)}")
         return " AND ".join(predicates)
 
+    def _get_delete_range(self, timestamp=None):
+        """Returns the time range used by the delete API.
+
+        The stop of the range is exclusive, hence a minimal range is used to
+        delete the data of a single point.
+        """
+        if timestamp is None:
+            return OPEN_RANGE_START, OPEN_RANGE_STOP
+        if not isinstance(timestamp, datetime):
+            timestamp, _value = self._parse_flux_time(str(timestamp))
+            if timestamp is None:
+                raise ValueError(f'Invalid timestamp: "{_value}"')
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return timestamp, timestamp + timedelta(milliseconds=1)
+
     @retry
-    def _delete_range(self, predicate: str = "", bucket: str | None = None) -> None:
+    def _delete_range(
+        self,
+        predicate: str = "",
+        bucket: str | None = None,
+        start: datetime = OPEN_RANGE_START,
+        stop: datetime = OPEN_RANGE_STOP,
+    ) -> None:
         self._delete_api.delete(
-            OPEN_RANGE_START,
-            OPEN_RANGE_STOP,
+            start,
+            stop,
             predicate,
             bucket=bucket or self.db_name,
             org=self.user,
@@ -1078,13 +1111,23 @@ class DatabaseClient(BaseTimeseriesClient):
             self._delete_range(predicate, bucket=bucket)
 
     def delete_metric_data(
-        self, key: str | None = None, tags: TimeseriesTags | None = None
+        self,
+        key: str | None = None,
+        tags: TimeseriesTags | None = None,
+        timestamp: Any = None,
     ) -> None:
-        """Deletes metric data based on measurement and tags."""
+        """Deletes metric data based on measurement and tags.
+
+        If ``timestamp`` is passed, only the data written at that specific
+        time is deleted.
+        """
         predicate = self._build_delete_predicate(key=key, tags=tags)
+        start, stop = self._get_delete_range(timestamp)
         for bucket in self._get_known_bucket_names():
-            self._delete_range(predicate, bucket=bucket)
-        logger.debug(f"Deleted metric data: key={key}, tags={tags}")
+            self._delete_range(predicate, bucket=bucket, start=start, stop=stop)
+        logger.debug(
+            f"Deleted metric data: key={key}, tags={tags}, timestamp={timestamp}"
+        )
 
     def get_list_query(self, query: str, precision: str = "s") -> list[TimeseriesPoint]:
         """Execute a query and flatten GROUP BY TAG results for chart rendering.
@@ -1230,13 +1273,15 @@ class DatabaseClient(BaseTimeseriesClient):
         return flux_query
 
     def _format_filter(self, field, value):
-        if value in (None, "", "__all__"):
+        # "__all__" is not a wildcard: charts which declare "__all__" are read
+        # from a series tagged with that value, consistently with the InfluxDB 1
+        # backend, see its _get_where_query().
+        if value in (None, ""):
             return ""
         if isinstance(value, (list, tuple)):
-            items = [item for item in value if item != "__all__"]
-            if not items:
+            if not value:
                 return ""
-            values = ", ".join([self._format_flux_string(item) for item in items])
+            values = ", ".join([self._format_flux_string(item) for item in value])
             return f" |> filter(fn: (r) => contains(value: r.{field}, set: [{values}]))"
         return (
             " |> filter(fn: (r) => " f"r.{field} == {self._format_flux_string(value)})"

--- a/openwisp_monitoring/db/backends/influxdb2/client.py
+++ b/openwisp_monitoring/db/backends/influxdb2/client.py
@@ -508,6 +508,15 @@ class DatabaseClient(BaseTimeseriesClient):
             return f'time(v: "{self._serialize_flux_time(value)}")'
         return value
 
+    def _normalize_chart_window(self, time_value, group_map=None):
+        if group_map and time_value in group_map:
+            return group_map[time_value]
+        if isinstance(time_value, (int, float)):
+            return f"{max(int(time_value), 1)}m"
+        if isinstance(time_value, str) and re.fullmatch(r"\d+", time_value):
+            return f"{max(int(time_value), 1)}m"
+        return time_value
+
     def _normalize_chart_start_range(self, time_value, timezone_name=None):
         if isinstance(time_value, (int, float)):
             return f"-{self._normalize_chart_window(time_value)}"

--- a/openwisp_monitoring/db/backends/influxdb2/client.py
+++ b/openwisp_monitoring/db/backends/influxdb2/client.py
@@ -493,6 +493,9 @@ class DatabaseClient(BaseTimeseriesClient):
     def _serialize_flux_time(self, value):
         return value.isoformat().replace("+00:00", "Z")
 
+    # smallest representable interval added to the stop of a range
+    _RANGE_STOP_EPSILON = timedelta(microseconds=1)
+
     def _format_flux_time(self, value, timezone_name=None):
         if isinstance(value, datetime):
             if value.tzinfo is None:
@@ -518,6 +521,20 @@ class DatabaseClient(BaseTimeseriesClient):
                     value = value.replace(tzinfo=timezone.utc)
             return f'time(v: "{self._serialize_flux_time(value)}")'
         return value
+
+    def _format_flux_range_stop(self, value, timezone_name=None):
+        """Returns the stop of a range which includes the given end date.
+
+        The stop of a Flux range is exclusive, while the InfluxDB 1 backend
+        includes the points which match the end date exactly.
+        """
+        if isinstance(value, str):
+            parsed_value, _ = self._parse_flux_time(value)
+            if parsed_value is not None:
+                value = parsed_value
+        if isinstance(value, datetime):
+            value += self._RANGE_STOP_EPSILON
+        return self._format_flux_time(value, timezone_name=timezone_name)
 
     def _normalize_chart_start_range(self, time_value, timezone_name=None):
         if isinstance(time_value, (int, float)):
@@ -1239,7 +1256,7 @@ class DatabaseClient(BaseTimeseriesClient):
             time_val = self._normalize_chart_window(time)
             start_range = f"-{time_val}"
         if params.get("end_date"):
-            end_range = self._format_flux_time(
+            end_range = self._format_flux_range_stop(
                 params["end_date"], timezone_name=timezone_name
             )
             flux_query += f" |> range(start: {start_range}, stop: {end_range})"
@@ -1328,7 +1345,7 @@ class DatabaseClient(BaseTimeseriesClient):
             time_start = f"-{time_val}"
         end_range = ""
         if params.get("end_date"):
-            formatted_end = self._format_flux_time(
+            formatted_end = self._format_flux_range_stop(
                 params["end_date"], timezone_name=timezone_name
             )
             end_range = f", stop: {formatted_end}"

--- a/openwisp_monitoring/db/backends/influxdb2/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb2/tests.py
@@ -1090,7 +1090,7 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
         )
         self.assertIn(f'from(bucket: "{self.timeseries_db.db_name}")', query)
         self.assertIn('start: time(v: "2024-03-25T00:00:00Z")', query)
-        self.assertIn('stop: time(v: "2024-03-26T00:00:00Z")', query)
+        self.assertIn('stop: time(v: "2024-03-26T00:00:00.000001Z")', query)
         self.assertIn('r.content_type == "config.device"', query)
         self.assertIn('r.object_id == "device-id"', query)
         self.assertIn('r._field == "cpu_usage"', query)
@@ -1119,7 +1119,7 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
         )
 
         self.assertIn('start: time(v: "2024-03-25T04:30:00Z")', query)
-        self.assertIn('stop: time(v: "2024-03-25T05:30:00Z")', query)
+        self.assertIn('stop: time(v: "2024-03-25T05:30:00.000001Z")', query)
 
     def test_generated_query_converts_naive_chart_range_from_timezone_to_utc(self):
         query = self.timeseries_db.get_query(
@@ -1135,7 +1135,7 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             timezone="Asia/Kolkata",
         )
         self.assertIn('range(start: time(v: "2024-03-25T04:30:00Z")', query)
-        self.assertIn('stop: time(v: "2024-03-25T05:30:00Z"))', query)
+        self.assertIn('stop: time(v: "2024-03-25T05:30:00.000001Z"))', query)
 
     def test_get_query_escapes_default_chart_filters(self):
         query = self.timeseries_db.get_query(
@@ -1180,6 +1180,32 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             self.timeseries_db._format_flux_time("2024-03-26"),
             'time(v: "2024-03-26T00:00:00Z")',
         )
+
+    def test_get_query_includes_the_end_date(self):
+        """The stop of a Flux range is exclusive, unlike InfluxDB 1."""
+        params = {
+            "key": "cpu",
+            "field_name": "cpu_usage",
+            "time": "2024-03-25 00:00:00",
+            "end_date": "2024-03-26 00:00:00",
+        }
+        templated_query = self.timeseries_db.get_query(
+            chart_type="scatter",
+            params=params,
+            time="1d",
+            group_map={"1d": "10m"},
+            query=chart_query["cpu"]["influxdb2"],
+            timezone="UTC",
+        )
+        default_query = self.timeseries_db.get_query(
+            chart_type="scatter",
+            params=params,
+            time="1d",
+            group_map={"1d": "10m"},
+            timezone="UTC",
+        )
+        for query in (templated_query, default_query):
+            self.assertIn('stop: time(v: "2024-03-26T00:00:00.000001Z")', query)
 
     def test_get_query_does_not_interpolate_unsafe_end_date(self):
         """Prevent end-date injection from appending malicious Flux stages."""

--- a/openwisp_monitoring/db/backends/influxdb2/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb2/tests.py
@@ -733,6 +733,38 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             datetime(2262, 4, 11, 23, 47, 16, 854775, tzinfo=timezone.utc),
         )
 
+    @patch.object(DatabaseClient, "_delete_api")
+    def test_delete_metric_data_at_timestamp(self, mock_delete_api):
+        timestamp = datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc)
+        self.timeseries_db.delete_metric_data(key="cpu", timestamp=timestamp)
+        start, stop, predicate = mock_delete_api.delete.call_args[0][:3]
+        self.assertEqual(start, timestamp)
+        # the stop of the range is exclusive
+        self.assertEqual(stop, timestamp + timedelta(milliseconds=1))
+        self.assertIn('_measurement="cpu"', predicate)
+
+    @patch.object(DatabaseClient, "_delete_api")
+    def test_delete_metric_data_at_naive_timestamp(self, mock_delete_api):
+        self.timeseries_db.delete_metric_data(
+            key="cpu", timestamp=datetime(2026, 8, 19, 10, 30)
+        )
+        start = mock_delete_api.delete.call_args[0][0]
+        self.assertEqual(start, datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc))
+
+    @patch.object(DatabaseClient, "_delete_api")
+    def test_delete_metric_data_at_string_timestamp(self, mock_delete_api):
+        self.timeseries_db.delete_metric_data(
+            key="cpu", timestamp="2026-08-19T10:30:00+00:00"
+        )
+        start = mock_delete_api.delete.call_args[0][0]
+        self.assertEqual(start, datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc))
+
+    def test_delete_metric_data_rejects_invalid_timestamp(self):
+        with patch.object(self.timeseries_db, "_delete_api") as mock_delete_api:
+            with self.assertRaises(ValueError):
+                self.timeseries_db.delete_metric_data(key="cpu", timestamp="invalid")
+        mock_delete_api.delete.assert_not_called()
+
     def test_delete_metric_data_rejects_unsafe_tag_keys(self):
         with patch.object(self.timeseries_db, "_delete_api") as mock_delete_api:
             with self.assertRaises(ValueError):
@@ -838,7 +870,7 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
         )
         flux_query = mock_query.call_args[0][0]
         self.assertIn(
-            'contains(value: r.organization_id, set: ["org1", "org2"])',
+            'contains(value: r.organization_id, set: ["__all__", "org1", "org2"])',
             flux_query,
         )
         self.assertIn(
@@ -849,7 +881,6 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             'contains(value: r.floorplan_id, set: ["fp1", "fp2"])',
             flux_query,
         )
-        self.assertNotIn("__all__", flux_query)
 
     def test_get_top_fields_empty_result(self):
         """Test top field selection returns empty list when no data is found."""
@@ -1375,7 +1406,7 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             fields=["rx_bytes", "tx_bytes"],
         )
         self.assertIn(
-            'contains(value: r.organization_id, set: ["org1", "org2"])',
+            'contains(value: r.organization_id, set: ["__all__", "org1", "org2"])',
             query,
         )
         self.assertIn('contains(value: r.location_id, set: ["loc1", "loc2"])', query)
@@ -1383,7 +1414,6 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             'contains(value: r.floorplan_id, set: ["fp1", "fp2"])',
             query,
         )
-        self.assertNotIn("__all__", query)
 
     def test_get_query_wifi_clients_count_distinct(self):
         """Test Flux query for wifi_clients using distinct() + count()."""

--- a/openwisp_monitoring/db/backends/influxdb2/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb2/tests.py
@@ -740,7 +740,7 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
         start, stop, predicate = mock_delete_api.delete.call_args[0][:3]
         self.assertEqual(start, timestamp)
         # the stop of the range is exclusive
-        self.assertEqual(stop, timestamp + timedelta(milliseconds=1))
+        self.assertEqual(stop, "2026-08-19T10:30:00.000000001Z")
         self.assertIn('_measurement="cpu"', predicate)
 
     @patch.object(DatabaseClient, "_delete_api")
@@ -749,7 +749,9 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             key="cpu", timestamp=datetime(2026, 8, 19, 10, 30)
         )
         start = mock_delete_api.delete.call_args[0][0]
+        stop = mock_delete_api.delete.call_args[0][1]
         self.assertEqual(start, datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc))
+        self.assertEqual(stop, "2026-08-19T10:30:00.000000001Z")
 
     @patch.object(DatabaseClient, "_delete_api")
     def test_delete_metric_data_at_string_timestamp(self, mock_delete_api):
@@ -757,7 +759,9 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
             key="cpu", timestamp="2026-08-19T10:30:00+00:00"
         )
         start = mock_delete_api.delete.call_args[0][0]
+        stop = mock_delete_api.delete.call_args[0][1]
         self.assertEqual(start, datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc))
+        self.assertEqual(stop, "2026-08-19T10:30:00.000000001Z")
 
     def test_delete_metric_data_rejects_invalid_timestamp(self):
         with patch.object(self.timeseries_db, "_delete_api") as mock_delete_api:
@@ -2143,6 +2147,21 @@ class TestInfluxDb2ClientIntegration(
         self.assertEqual(self._read_metric(general_metric), [])
         timeseries_db.delete_metric_data(key=short_metric.key)
         self.assertEqual(self._read_metric(short_metric, retention_policy=SHORT_RP), [])
+
+    def test_delete_metric_data_at_timestamp_preserves_neighboring_point(self):
+        metric = self._create_general_metric(name="delete-neighboring-point")
+        timestamp = datetime(2026, 8, 19, 10, 30, tzinfo=timezone.utc)
+        self._write_metric(metric, 100, time=timestamp, check=False)
+        self._write_metric(
+            metric,
+            200,
+            time=timestamp + timedelta(microseconds=1),
+            check=False,
+        )
+        timeseries_db.delete_metric_data(key=metric.key, timestamp=timestamp)
+        points = self._read_metric(metric)
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0]["value"], 200)
 
     def test_delete_metric_data_without_filters_clears_default_and_short_buckets(self):
         general_metric = self._create_general_metric(name="delete-all-general")

--- a/openwisp_monitoring/db/backends/influxdb2/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb2/tests.py
@@ -71,21 +71,6 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
     def test_backend_name(self):
         self.assertEqual(self.timeseries_db.backend_name, "influxdb2")
 
-    def test_normalize_chart_window(self):
-        cases = (
-            ("1d", {"1d": "10m"}, "10m"),
-            (5, None, "5m"),
-            (0, None, "1m"),
-            ("5", None, "5m"),
-            ("10m", None, "10m"),
-        )
-        for time_value, group_map, expected in cases:
-            with self.subTest(time_value=time_value, group_map=group_map):
-                self.assertEqual(
-                    self.timeseries_db._normalize_chart_window(time_value, group_map),
-                    expected,
-                )
-
     def test_forbidden_queries(self):
         """Test that forbidden words are rejected in Flux queries."""
         queries = [

--- a/openwisp_monitoring/db/backends/influxdb2/tests.py
+++ b/openwisp_monitoring/db/backends/influxdb2/tests.py
@@ -71,6 +71,21 @@ class TestInfluxDb2Client(RequireTimeseriesBackendMixin, TestCase):
     def test_backend_name(self):
         self.assertEqual(self.timeseries_db.backend_name, "influxdb2")
 
+    def test_normalize_chart_window(self):
+        cases = (
+            ("1d", {"1d": "10m"}, "10m"),
+            (5, None, "5m"),
+            (0, None, "1m"),
+            ("5", None, "5m"),
+            ("10m", None, "10m"),
+        )
+        for time_value, group_map, expected in cases:
+            with self.subTest(time_value=time_value, group_map=group_map):
+                self.assertEqual(
+                    self.timeseries_db._normalize_chart_window(time_value, group_map),
+                    expected,
+                )
+
     def test_forbidden_queries(self):
         """Test that forbidden words are rejected in Flux queries."""
         queries = [

--- a/openwisp_monitoring/db/backends/tests.py
+++ b/openwisp_monitoring/db/backends/tests.py
@@ -177,6 +177,22 @@ class TestBackendContract(SimpleTestCase):
                 for attr in attrs:
                     self.assertNotIn(attr, client.__dict__)
 
+    def test_normalize_chart_window(self):
+        client = DummyTimeseriesClient()
+        cases = (
+            ("1d", {"1d": "10m"}, "10m"),
+            (5, None, "5m"),
+            (0, None, "1m"),
+            ("5", None, "5m"),
+            ("10m", None, "10m"),
+        )
+        for time_value, group_map, expected in cases:
+            with self.subTest(time_value=time_value, group_map=group_map):
+                self.assertEqual(
+                    client._normalize_chart_window(time_value, group_map),
+                    expected,
+                )
+
 
 class TestBackendLoader(SimpleTestCase):
     def _build_valid_backend(self):

--- a/openwisp_monitoring/db/backends/tests.py
+++ b/openwisp_monitoring/db/backends/tests.py
@@ -128,6 +128,22 @@ class TestBackendContract(SimpleTestCase):
         },
     }
 
+    def test_normalize_chart_window(self):
+        client = DummyTimeseriesClient()
+        cases = (
+            ("1d", {"1d": "10m"}, "10m"),
+            (5, None, "5m"),
+            (0, None, "1m"),
+            ("5", None, "5m"),
+            ("10m", None, "10m"),
+        )
+        for time_value, group_map, expected in cases:
+            with self.subTest(time_value=time_value, group_map=group_map):
+                self.assertEqual(
+                    client._normalize_chart_window(time_value, group_map),
+                    expected,
+                )
+
     def test_backends_implement_contract(self):
         required_chart_keys = _get_chart_keys_from_configuration()
         for backend_path, config in self.backend_configs.items():

--- a/openwisp_monitoring/db/backends/tests.py
+++ b/openwisp_monitoring/db/backends/tests.py
@@ -121,6 +121,11 @@ class TestBackendContract(SimpleTestCase):
             "HOST": "localhost",
             "PORT": "8086",
         },
+        "openwisp_monitoring.db.backends.elasticsearch": {
+            "BACKEND": "openwisp_monitoring.db.backends.elasticsearch",
+            "NAME": "openwisp2",
+            "URL": "http://localhost:9200",
+        },
     }
 
     def test_backends_implement_contract(self):
@@ -159,6 +164,7 @@ class TestBackendContract(SimpleTestCase):
                 "_delete_api",
                 "use_udp",
             ),
+            "openwisp_monitoring.db.backends.elasticsearch": ("db",),
         }
         for backend_path, attrs in backend_cached_attrs.items():
             with self.subTest(backend=backend_path):

--- a/openwisp_monitoring/db/backends/tests.py
+++ b/openwisp_monitoring/db/backends/tests.py
@@ -177,22 +177,6 @@ class TestBackendContract(SimpleTestCase):
                 for attr in attrs:
                     self.assertNotIn(attr, client.__dict__)
 
-    def test_normalize_chart_window(self):
-        client = DummyTimeseriesClient()
-        cases = (
-            ("1d", {"1d": "10m"}, "10m"),
-            (5, None, "5m"),
-            (0, None, "1m"),
-            ("5", None, "5m"),
-            ("10m", None, "10m"),
-        )
-        for time_value, group_map, expected in cases:
-            with self.subTest(time_value=time_value, group_map=group_map):
-                self.assertEqual(
-                    client._normalize_chart_window(time_value, group_map),
-                    expected,
-                )
-
 
 class TestBackendLoader(SimpleTestCase):
     def _build_valid_backend(self):

--- a/openwisp_monitoring/db/backends/tests.py
+++ b/openwisp_monitoring/db/backends/tests.py
@@ -193,6 +193,21 @@ class TestBackendContract(SimpleTestCase):
                 for attr in attrs:
                     self.assertNotIn(attr, client.__dict__)
 
+    def test_get_default_chart_query_forwards_object_scope_to_resolver(self):
+        resolver = MagicMock(return_value="SELECT value FROM cpu")
+        client = DummyTimeseriesClient().attach_queries(
+            BackendQueryBundle(
+                chart_query={"cpu": {"dummy": "SELECT * FROM cpu"}},
+                default_chart_query=SimpleNamespace(resolve=resolver),
+                device_data_query="SELECT data FROM {measurement}",
+            )
+        )
+        self.assertEqual(
+            client.get_default_chart_query(has_object_scope=True),
+            "SELECT value FROM cpu",
+        )
+        resolver.assert_called_once_with(has_object_scope=True)
+
 
 class TestBackendLoader(SimpleTestCase):
     def _build_valid_backend(self):

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -638,7 +638,9 @@ class AbstractChart(TimeStampedEditableModel):
     def summary_query(self):
         query = self.config_dict.get("summary_query", None)
         if query:
-            return query[timeseries_db.backend_name]
+            # backends which derive the summary from the chart query
+            # do not need to define a summary query
+            return query.get(timeseries_db.backend_name)
 
     @property
     def top_fields(self):

--- a/openwisp_monitoring/monitoring/tasks.py
+++ b/openwisp_monitoring/monitoring/tasks.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from celery import shared_task
 from django.core.exceptions import ObjectDoesNotExist
 from swapper import load_model
@@ -49,6 +51,8 @@ def timeseries_write(
 
 def _timeseries_write(name, values, metric=None, check_threshold_kwargs=None, **kwargs):
     """Handles writes synchronously when using UDP mode."""
+    if timeseries_db.requires_write_operation_id:
+        kwargs.setdefault("operation_id", uuid4().hex)
     if timeseries_db.use_udp:
         func = timeseries_write
     else:
@@ -82,6 +86,9 @@ def timeseries_batch_write(self, data):
 
 def _timeseries_batch_write(data):
     """If the timeseries database is using UDP to write data, then write data synchronously."""
+    if timeseries_db.requires_write_operation_id:
+        for item in data:
+            item.setdefault("operation_id", uuid4().hex)
     if timeseries_db.use_udp:
         timeseries_batch_write(data=data)
     else:

--- a/openwisp_monitoring/monitoring/tests/__init__.py
+++ b/openwisp_monitoring/monitoring/tests/__init__.py
@@ -74,11 +74,12 @@ def _elasticsearch_metric(name, field, aggregation="avg"):
     return {"name": name, "field": field, "agg": aggregation}
 
 
-def _elasticsearch_chart(*metrics, dynamic_aggregation=None):
+def _elasticsearch_chart(*metrics, dynamic_aggregation=None, end_date=True):
     query = {
         "__openwisp_query_type": "chart",
         "aggregate": True,
         "metrics": list(metrics),
+        "end_date": end_date,
     }
     if dynamic_aggregation:
         query["dynamic_metric"] = {"agg": dynamic_aggregation}
@@ -148,7 +149,9 @@ charts = {
                 " |> sum()"
                 " |> map(fn: (r) => ({{r with _value: float(v: r._value)}}))"
             ),
-            "elasticsearch": _elasticsearch_chart(dynamic_aggregation="sum"),
+            "elasticsearch": _elasticsearch_chart(
+                dynamic_aggregation="sum", end_date=False
+            ),
         },
     },
     "dummy": {
@@ -326,7 +329,9 @@ charts = {
                 "{content_type_filter}{object_id_filter}{field_filter}"
                 " |> mean()"
             ),
-            "elasticsearch": _elasticsearch_chart(dynamic_aggregation="avg"),
+            "elasticsearch": _elasticsearch_chart(
+                dynamic_aggregation="avg", end_date=False
+            ),
         },
     },
 }

--- a/openwisp_monitoring/monitoring/tests/__init__.py
+++ b/openwisp_monitoring/monitoring/tests/__init__.py
@@ -243,6 +243,7 @@ charts = {
                 "metric": _elasticsearch_metric("{field_name}", "{field_name}", "sum"),
                 "group_by": "metric_num",
                 "cumulative": True,
+                "object_scope": False,
             },
         },
         "summary_query": {
@@ -262,6 +263,7 @@ charts = {
                 "aggregate": True,
                 "metric": _elasticsearch_metric("{field_name}", "{field_name}", "sum"),
                 "group_by": "metric_num",
+                "object_scope": False,
             },
         },
     },

--- a/openwisp_monitoring/monitoring/tests/__init__.py
+++ b/openwisp_monitoring/monitoring/tests/__init__.py
@@ -70,6 +70,29 @@ class RequireTimeseriesBackendMixin:
         super().setUpClass()
 
 
+def _elasticsearch_metric(name, field, aggregation="avg"):
+    return {"name": name, "field": field, "agg": aggregation}
+
+
+def _elasticsearch_chart(*metrics, dynamic_aggregation=None):
+    query = {
+        "__openwisp_query_type": "chart",
+        "aggregate": True,
+        "metrics": list(metrics),
+    }
+    if dynamic_aggregation:
+        query["dynamic_metric"] = {"agg": dynamic_aggregation}
+    return query
+
+
+def _elasticsearch_raw_chart(*fields):
+    return {
+        "__openwisp_query_type": "raw_chart",
+        "aggregate": False,
+        "fields": list(fields),
+    }
+
+
 # these custom metric configurations are used for automated testing purposes
 metrics = {
     "test_metric": {
@@ -125,6 +148,7 @@ charts = {
                 " |> sum()"
                 " |> map(fn: (r) => ({{r with _value: float(v: r._value)}}))"
             ),
+            "elasticsearch": _elasticsearch_chart(dynamic_aggregation="sum"),
         },
     },
     "dummy": {
@@ -141,7 +165,16 @@ charts = {
         "description": "Bugged chart for testing purposes.",
         "unit": "bugs",
         "order": 999,
-        "query": {"influxdb": "BAD", "influxdb2": "BAD"},
+        "query": {
+            "influxdb": "BAD",
+            "influxdb2": "BAD",
+            "elasticsearch": {
+                "size": 0,
+                "aggs": {
+                    "value": {"avg": {"field": "indexed_fields.numeric.{field_name}"}}
+                },
+            },
+        },
     },
     "default": {
         "type": "line",
@@ -159,6 +192,7 @@ charts = {
                 '|> filter(fn: (r) => r._measurement == "{key}")'
                 "{content_type_filter}{object_id_filter}{field_filter}"
             ),
+            "elasticsearch": _elasticsearch_raw_chart("{field_name}"),
         },
     },
     "multiple_test": {
@@ -178,6 +212,7 @@ charts = {
                 "{content_type_filter}{object_id_filter}"
                 ' |> filter(fn: (r) => r._field == "{field_name}" or r._field == "value2")'
             ),
+            "elasticsearch": _elasticsearch_raw_chart("{field_name}", "value2"),
         },
     },
     "group_by_tag": {
@@ -199,6 +234,13 @@ charts = {
                 " |> aggregateWindow(every: {window}, fn: sum, createEmpty: false)"
                 " |> cumulativeSum()"
             ),
+            "elasticsearch": {
+                "__openwisp_query_type": "grouped_chart",
+                "aggregate": True,
+                "metric": _elasticsearch_metric("{field_name}", "{field_name}", "sum"),
+                "group_by": "metric_num",
+                "cumulative": True,
+            },
         },
         "summary_query": {
             "influxdb": (
@@ -212,6 +254,12 @@ charts = {
                 ' |> group(columns: ["metric_num"])'
                 " |> sum()"
             ),
+            "elasticsearch": {
+                "__openwisp_query_type": "grouped_chart",
+                "aggregate": True,
+                "metric": _elasticsearch_metric("{field_name}", "{field_name}", "sum"),
+                "group_by": "metric_num",
+            },
         },
     },
     "mean_test": {
@@ -231,6 +279,9 @@ charts = {
                 "{content_type_filter}{object_id_filter}{field_filter}"
                 " |> mean()"
                 ' |> duplicate(column: "_stop", as: "_time")'
+            ),
+            "elasticsearch": _elasticsearch_chart(
+                _elasticsearch_metric("{field_name}", "{field_name}")
             ),
         },
     },
@@ -252,6 +303,9 @@ charts = {
                 " |> sum()"
                 ' |> duplicate(column: "_stop", as: "_time")'
             ),
+            "elasticsearch": _elasticsearch_chart(
+                _elasticsearch_metric("{field_name}", "{field_name}", "sum")
+            ),
         },
     },
     "top_fields_mean": {
@@ -272,6 +326,7 @@ charts = {
                 "{content_type_filter}{object_id_filter}{field_filter}"
                 " |> mean()"
             ),
+            "elasticsearch": _elasticsearch_chart(dynamic_aggregation="avg"),
         },
     },
 }

--- a/openwisp_monitoring/monitoring/tests/test_charts.py
+++ b/openwisp_monitoring/monitoring/tests/test_charts.py
@@ -365,7 +365,8 @@ class TestChartsBackendMixin(
             extra_tags={"ifname": "wlan0"},
         )
         c = self._create_chart(metric=m, test_data=False, configuration="wifi_clients")
-        m.write("00:14:5c:00:00:00")
+        # UDP writes are not synchronous, _write_metric waits for the point
+        self._write_metric(m, "00:14:5c:00:00:00")
         c.save()
         return c
 

--- a/openwisp_monitoring/monitoring/tests/test_db_creation.py
+++ b/openwisp_monitoring/monitoring/tests/test_db_creation.py
@@ -50,3 +50,16 @@ class TestDatabaseInfluxDb2(TestDatabaseRetryMixin):
     )
     def test_check_retry(self, mock, sleep_mock):
         self._assert_check_retry(mock, sleep_mock)
+
+
+@tag("elasticsearch")
+class TestDatabaseElasticsearch(TestDatabaseRetryMixin):
+    expected_backend = "elasticsearch"
+
+    @patch("openwisp_monitoring.utils.sleep")
+    @patch(
+        "openwisp_monitoring.db.backends.elasticsearch.client.DatabaseClient._ensure_data_stream_resources",
+        side_effect=ConnectionError(),
+    )
+    def test_check_retry(self, mock, sleep_mock):
+        self._assert_check_retry(mock, sleep_mock)

--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -338,14 +338,15 @@ class TestModels(TestMonitoringMixin, TestCase):
     @tag("flaky_with_udp_writes")
     def test_metric_post_write_signals_emitted(self):
         om = self._create_object_metric()
+        write_time = timezone.now()
         with catch_signal(post_metric_write) as handler:
-            om.write(3, current=True, time=start_time)
+            om.write(3, current=True, time=write_time)
             handler.assert_called_once_with(
                 sender=Metric,
                 metric=om,
                 values={om.field_name: 3},
                 signal=post_metric_write,
-                time=start_time.isoformat(),
+                time=write_time.isoformat(),
                 current=True,
             )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 openwisp-controller @ https://github.com/openwisp/openwisp-controller/archive/refs/heads/1.3.tar.gz
 influxdb~=5.3.2 # python client for InfluxDB1.8 backend
 influxdb-client~=1.50.0 # python client for InfluxDB2 backend
+elasticsearch>=9.0.0,<10.0.0 # python client for Elasticsearch 9.x backend
 django-nested-admin~=4.1.6
 python-dateutil>=2.9.0.post0,<3.0.0

--- a/runtests
+++ b/runtests
@@ -7,27 +7,42 @@ TSDB="${TSDB:-influxdb}"
 UDP="${TIMESERIES_UDP:-}"
 
 # Treat only explicit truthy values as UDP, so TIMESERIES_UDP=0 uses HTTP.
-case "${UDP,,}" in
+UDP_NORMALIZED=$(printf '%s' "$UDP" | tr '[:upper:]' '[:lower:]')
+case "$UDP_NORMALIZED" in
     1|true|yes|on) UDP=1 ;;
     *) UDP="" ;;
 esac
 
-if [ "$TSDB" != "influxdb" ] && [ "$TSDB" != "influxdb2" ]; then
+if [ "$TSDB" != "influxdb" ] && [ "$TSDB" != "influxdb2" ] && [ "$TSDB" != "elasticsearch" ]; then
     echo "Unsupported TSDB: $TSDB" >&2
-    echo "Supported values: influxdb, influxdb2" >&2
+    echo "Supported values: influxdb, influxdb2, elasticsearch" >&2
     exit 1
 fi
 
+if [ "$TSDB" = "elasticsearch" ] && [ -n "$UDP" ]; then
+    echo "Elasticsearch does not support UDP writes." >&2
+    exit 1
+fi
+
+TEST_ARGS=("$@")
+if [ "$TSDB" = "elasticsearch" ] && [ "$#" -eq 0 ]; then
+    TEST_ARGS=(
+        openwisp_monitoring.db.backends.elasticsearch.tests
+        openwisp_monitoring.db.backends.tests
+        openwisp_monitoring.monitoring.tests.test_db_creation
+    )
+fi
+
 if [ -z "$UDP" ]; then
-    TIMESERIES_BACKEND="$TSDB" coverage run runtests.py "$@"
+    TIMESERIES_BACKEND="$TSDB" coverage run runtests.py "${TEST_ARGS[@]}"
     # test extensibility only on the default TSDB
     if [ "$TSDB" = "influxdb" ]; then
         SAMPLE_APP=1 TIMESERIES_BACKEND="$TSDB" coverage run runtests.py \
-            "$@" --exclude-tag=selenium_tests
+            "${TEST_ARGS[@]}" --exclude-tag=selenium_tests
     fi
 else
     TIMESERIES_UDP=1 TIMESERIES_BACKEND="$TSDB" coverage run runtests.py \
-        "$@" --exclude-tag=selenium_tests
+        "${TEST_ARGS[@]}" --exclude-tag=selenium_tests
 fi
 
 coverage combine

--- a/runtests
+++ b/runtests
@@ -24,26 +24,16 @@ if [ "$TSDB" = "elasticsearch" ] && [ -n "$UDP" ]; then
     exit 1
 fi
 
-TEST_ARGS=("$@")
-if [ "$TSDB" = "elasticsearch" ] && [ "$#" -eq 0 ]; then
-    TEST_ARGS=(
-        openwisp_monitoring.db.backends.elasticsearch.tests
-        openwisp_monitoring.db.backends.tests
-        openwisp_monitoring.monitoring.tests.test_db_creation
-        openwisp_monitoring.monitoring.tests.test_charts.TestCharts
-    )
-fi
-
 if [ -z "$UDP" ]; then
-    TIMESERIES_BACKEND="$TSDB" coverage run runtests.py "${TEST_ARGS[@]}"
+    TIMESERIES_BACKEND="$TSDB" coverage run runtests.py "$@"
     # test extensibility only on the default TSDB
     if [ "$TSDB" = "influxdb" ]; then
         SAMPLE_APP=1 TIMESERIES_BACKEND="$TSDB" coverage run runtests.py \
-            "${TEST_ARGS[@]}" --exclude-tag=selenium_tests
+            "$@" --exclude-tag=selenium_tests
     fi
 else
     TIMESERIES_UDP=1 TIMESERIES_BACKEND="$TSDB" coverage run runtests.py \
-        "${TEST_ARGS[@]}" --exclude-tag=selenium_tests
+        "$@" --exclude-tag=selenium_tests
 fi
 
 coverage combine

--- a/runtests
+++ b/runtests
@@ -30,6 +30,7 @@ if [ "$TSDB" = "elasticsearch" ] && [ "$#" -eq 0 ]; then
         openwisp_monitoring.db.backends.elasticsearch.tests
         openwisp_monitoring.db.backends.tests
         openwisp_monitoring.monitoring.tests.test_db_creation
+        openwisp_monitoring.monitoring.tests.test_charts.TestCharts
     )
 fi
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -61,6 +61,43 @@ elif TIMESERIES_BACKEND == "influxdb2":
         # Telegraf, so the influxdb2 backend needs separate listener settings.
         "OPTIONS": {"udp_writes": False, "udp_port": 8089},
     }
+elif TIMESERIES_BACKEND == "elasticsearch":
+    # These defaults mirror the elasticsearch and redis containers defined in
+    # the repository docker-compose.yml, so most local development setups only
+    # need to export TIMESERIES_BACKEND=elasticsearch.
+    TIMESERIES_DATABASE = {
+        "BACKEND": "openwisp_monitoring.db.backends.elasticsearch",
+        "NAME": os.getenv(
+            "ELASTICSEARCH_NAME", os.getenv("TIMESERIES_DB", "openwisp2")
+        ),
+    }
+    if os.getenv("ELASTICSEARCH_CLOUD_ID"):
+        TIMESERIES_DATABASE["CLOUD_ID"] = os.getenv("ELASTICSEARCH_CLOUD_ID")
+    else:
+        TIMESERIES_DATABASE["URL"] = os.getenv(
+            "ELASTICSEARCH_URL",
+            "http://{host}:{port}".format(
+                host=os.getenv("ELASTICSEARCH_HOST", "localhost"),
+                port=os.getenv("ELASTICSEARCH_PORT", "9200"),
+            ),
+        )
+    if os.getenv("ELASTICSEARCH_API_KEY"):
+        TIMESERIES_DATABASE["API_KEY"] = os.getenv("ELASTICSEARCH_API_KEY")
+    elif os.getenv("ELASTICSEARCH_BEARER_AUTH"):
+        TIMESERIES_DATABASE["BEARER_AUTH"] = os.getenv("ELASTICSEARCH_BEARER_AUTH")
+    elif os.getenv("ELASTICSEARCH_USER") and os.getenv("ELASTICSEARCH_PASSWORD"):
+        TIMESERIES_DATABASE["USER"] = os.getenv("ELASTICSEARCH_USER")
+        TIMESERIES_DATABASE["PASSWORD"] = os.getenv("ELASTICSEARCH_PASSWORD")
+    for env_var, setting in (
+        ("ELASTICSEARCH_CA_CERTS", "CA_CERTS"),
+        ("ELASTICSEARCH_SSL_ASSERT_FINGERPRINT", "SSL_ASSERT_FINGERPRINT"),
+    ):
+        if os.getenv(env_var):
+            TIMESERIES_DATABASE[setting] = os.getenv(env_var)
+    if os.getenv("ELASTICSEARCH_VERIFY_CERTS"):
+        TIMESERIES_DATABASE["VERIFY_CERTS"] = (
+            os.getenv("ELASTICSEARCH_VERIFY_CERTS").strip().lower() in TRUTHY_ENV_VALUES
+        )
 else:
     raise ValueError(f'Unsupported TIMESERIES_BACKEND "{TIMESERIES_BACKEND}"')
 if TESTING:
@@ -75,6 +112,8 @@ if TESTING:
             "udp_host": os.getenv("INFLUXDB2_UDP_HOST", "localhost"),
             "udp_port": int(os.getenv("INFLUXDB2_UDP_PORT", 8091)),
         }
+    elif TIMESERIES_BACKEND == "elasticsearch":
+        udp_options = TIMESERIES_DATABASE.get("OPTIONS", {})
     TIMESERIES_DATABASE["OPTIONS"] = udp_options
 
 SECRET_KEY = "fn)t*+$)ugeyip6-#txyy$5wf2ervc0d2n#h)qb)y5@ly$t*@w"

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -3,6 +3,7 @@ import sys
 from datetime import timedelta
 
 from celery.schedules import crontab
+from django.core.exceptions import ImproperlyConfigured
 
 TESTING = "test" in sys.argv
 SHELL = "shell" in sys.argv or "shell_plus" in sys.argv
@@ -30,6 +31,7 @@ if TESTING and "--exclude-tag=selenium_tests" not in sys.argv:
 
 TIMESERIES_BACKEND = os.getenv("TIMESERIES_BACKEND", "influxdb")
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+FALSEY_ENV_VALUES = {"0", "false", "no", "off"}
 if TIMESERIES_BACKEND == "influxdb":
     TIMESERIES_DATABASE = {
         "BACKEND": "openwisp_monitoring.db.backends.influxdb",
@@ -85,7 +87,7 @@ elif TIMESERIES_BACKEND == "elasticsearch":
         TIMESERIES_DATABASE["API_KEY"] = os.getenv("ELASTICSEARCH_API_KEY")
     elif os.getenv("ELASTICSEARCH_BEARER_AUTH"):
         TIMESERIES_DATABASE["BEARER_AUTH"] = os.getenv("ELASTICSEARCH_BEARER_AUTH")
-    elif os.getenv("ELASTICSEARCH_USER") and os.getenv("ELASTICSEARCH_PASSWORD"):
+    elif os.getenv("ELASTICSEARCH_USER") or os.getenv("ELASTICSEARCH_PASSWORD"):
         TIMESERIES_DATABASE["USER"] = os.getenv("ELASTICSEARCH_USER")
         TIMESERIES_DATABASE["PASSWORD"] = os.getenv("ELASTICSEARCH_PASSWORD")
     for env_var, setting in (
@@ -95,9 +97,12 @@ elif TIMESERIES_BACKEND == "elasticsearch":
         if os.getenv(env_var):
             TIMESERIES_DATABASE[setting] = os.getenv(env_var)
     if os.getenv("ELASTICSEARCH_VERIFY_CERTS"):
-        TIMESERIES_DATABASE["VERIFY_CERTS"] = (
-            os.getenv("ELASTICSEARCH_VERIFY_CERTS").strip().lower() in TRUTHY_ENV_VALUES
-        )
+        verify_certs = os.getenv("ELASTICSEARCH_VERIFY_CERTS").strip().lower()
+        if verify_certs not in TRUTHY_ENV_VALUES | FALSEY_ENV_VALUES:
+            raise ImproperlyConfigured(
+                '"ELASTICSEARCH_VERIFY_CERTS" must be a boolean value.'
+            )
+        TIMESERIES_DATABASE["VERIFY_CERTS"] = verify_certs in TRUTHY_ENV_VALUES
 else:
     raise ValueError(f'Unsupported TIMESERIES_BACKEND "{TIMESERIES_BACKEND}"')
 if TESTING:


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #786

## Description of Changes

This branch adds Elasticsearch 9 support behind the common TSDB interface, allowing OpenWISP Monitoring to use Elasticsearch as a time series backend without changing the higher-level device, metric, and chart logic.

The implementation follows the same abstraction used by the existing InfluxDB backends. Elasticsearch data is stored using time series data streams, with one document per metric point, ILM-based retention handling, and backend-specific query definitions for the existing monitoring charts.

## Changes

- Added a new `elasticsearch` backend implementing the shared TSDB client contract.
- Used the official Elasticsearch Python client with Elasticsearch 9-compatible connection and authentication options.
- Added TSDS data stream support with index templates, lifecycle policies, retention-specific streams, and namespace-safe cleanup.
- Implemented write, batch write, read, delete, retention policy, device data, and chart query compatibility methods.
- Added Elasticsearch chart and summary query definitions for the existing monitoring charts.
- Updated backend loading/configuration so Elasticsearch can be selected through `TIMESERIES_DATABASE`.
- Updated Docker/settings/docs so Elasticsearch can be started and used during local development.