### PR TITLE
[fix] Fixed devices stuck in PROBLEM status #830

### DIFF
--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -426,16 +426,21 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
             monitoring = target.monitoring
         except DeviceMonitoring.DoesNotExist:
             monitoring = DeviceMonitoring.objects.create(device=target)
+        monitoring.update_status(monitoring._get_status_from_metrics())
 
-        status = "ok" if metric.is_healthy else "problem"
+    def _get_status_from_metrics(self):
+        """Returns the device status from related metric health."""
+        status = "ok"
         unhealthy_critical_metrics = 0
-        for related_metric in monitoring.related_metrics.filter(is_healthy=False):
+        for related_metric in self.related_metrics.filter(is_healthy=False):
             status = "problem"
-            if monitoring.is_metric_critical(related_metric):
+            if self.is_metric_critical(related_metric):
                 unhealthy_critical_metrics += 1
-        if unhealthy_critical_metrics == len(app_settings.CRITICAL_DEVICE_METRICS):
+        if app_settings.CRITICAL_DEVICE_METRICS and unhealthy_critical_metrics == len(
+            app_settings.CRITICAL_DEVICE_METRICS
+        ):
             status = "critical"
-        monitoring.update_status(status)
+        return status
 
     @staticmethod
     def is_metric_critical(metric):

--- a/openwisp_monitoring/device/tasks.py
+++ b/openwisp_monitoring/device/tasks.py
@@ -39,7 +39,11 @@ def trigger_device_critical_checks(pk, recovery=True):
         device.monitoring.update_status(status)
         return
     if recovery and device.monitoring.status == "critical":
-        device.monitoring.update_status("problem")
+        status = device.monitoring._get_status_from_metrics()
+        # If metrics no longer imply critical status, move to problem.
+        # The checks triggered below will confirm if the device is ok.
+        if status != "critical":
+            device.monitoring.update_status("problem")
     for check_id in check_ids:
         perform_check.delay(check_id)
 

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -928,6 +928,28 @@ class TestDeviceMonitoring(
 class TestTransactionDeviceMonitoring(
     CreateConnectionsMixin, MonitoringTestMixin, DeviceMonitoringTransactionTestcase
 ):
+    @patch("openwisp_monitoring.device.tasks.perform_check.delay")
+    def test_stuck_problem_regression(self, mocked):
+        """Regression test for https://github.com/openwisp/openwisp-monitoring/issues/830."""
+        dm, ping, load, process_count = self._create_env()
+        data_collected = self._create_object_metric(
+            configuration="data_collected", content_object=dm.device
+        )
+        self._create_alert_settings(
+            metric=data_collected,
+            custom_operator="<",
+            custom_threshold=1,
+            custom_tolerance=0,
+        )
+        ping.write(0)
+        data_collected.write(0)
+        dm.refresh_from_db()
+        self.assertEqual(dm.status, "critical")
+        trigger_device_critical_checks.delay(dm.device.pk)
+        dm.refresh_from_db()
+        self.assertEqual(dm.status, "critical")
+        self.assertEqual(mocked.call_count, len(dm.get_critical_checks()))
+
     def test_critical_status_recovered_by_monitoring_metrics(self):
         dm, ping, load, process_count = self._create_env()
         config_applied = self._create_object_metric(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #830

## Description of Changes

Devices that failed all critical checks could remain stuck in problem status instead of being marked critical. This happened when recovery checks were triggered while the critical metric state had not changed, preventing the status from being recalculated.