### PR TITLE
[fix] Fixed viewport shift on full screen exit

### DIFF
--- a/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
+++ b/openwisp_monitoring/monitoring/static/monitoring/js/chart-utils.js
@@ -142,6 +142,10 @@ django.jQuery(
             if (!isMonitoringChartsLocation()) {
               return;
             }
+            // Ignore relayouts caused by viewport changes, such as fullscreen exit.
+            if (!eventEnd && !eventStart && eventdata["xaxis.autorange"] !== true) {
+              return;
+            }
             // When the chart is zoomed out, then load charts with initial zoom level
             if (!eventEnd && !eventStart) {
               localStorage.setItem(isChartZoomed, false);

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -230,6 +230,28 @@ class TestDashboardCharts(
             ).get_attribute("innerHTML"),
         )
 
+    def test_chart_resize_does_not_reload_dashboard(self):
+        self.create_test_data()
+        self.login()
+        self.wait_for_visibility(
+            By.CSS_SELECTOR, "#chart-0 .js-plotly-plot", timeout=10
+        )
+        self.web_driver.execute_script("""
+            window.dashboardChartRequests = 0;
+            const originalAjax = django.jQuery.ajax;
+            django.jQuery.ajax = function () {
+              window.dashboardChartRequests += 1;
+              return originalAjax.apply(this, arguments);
+            };
+            document.querySelector('#chart-0 .js-plotly-plot').emit(
+              'plotly_relayout',
+              { autosize: true },
+            );
+        """)
+        self.assertEqual(
+            self.web_driver.execute_script("return window.dashboardChartRequests;"), 0
+        )
+
 
 @tag("selenium_tests")
 class TestWifiSessionInlineAdmin(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Related to #705.

## Description of Changes

Ignore Plotly relayout events caused by viewport changes, such as exiting fullscreen. Previously these events were treated as chart resets, triggering a dashboard API request and scrolling the dashboard to the chart container after the response.