### PR TITLE
[feature] Skip monitoring on deactivated devices and disabled organizations #811 #812

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
           pip install -U pip wheel setuptools
           pip install -r requirements-test.txt
           pip install -U -e .
+          pip install --upgrade --force-reinstall --no-deps --no-cache-dir https://github.com/openwisp/openwisp-users/tarball/issues/522-disabled-org
+          pip install --upgrade --force-reinstall --no-deps --no-cache-dir https://github.com/openwisp/openwisp-controller/tarball/issues/1393-disabled-org
           pip install -U ${{ matrix.django-version }}
           sudo npm install -g prettier
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ If instructions conflict, repository config and CI workflows win first, official
 
 - Watch for cross-tenant data leaks, permission bypasses, unsafe query construction, excessive metric ingestion, insecure credentials, and secrets.
 - Preserve validation around metric payloads, device data, alert configuration, time series queries, URLs, and backend credentials.
+- Objects belonging to a disabled organization must be readable and deletable; creation and updates must be blocked across all relevant write paths. This applies to objects with either a direct or chained/nested relationship to the organization. No other operations should be permitted, except for ordinary cleanup operations.
+- Operations on deactivated devices must be blocked, except for read-only access and cleanup operations required to maintain consistency. Creation, updates, provisioning, configuration, and other mutating operations must not be performed for deactivated devices.
 
 ## Troubleshooting
 

--- a/docs/user/alerts.rst
+++ b/docs/user/alerts.rst
@@ -31,6 +31,11 @@ setting includes:
     :ref:`openwisp_monitoring_metrics` setting, or on a per-device basis
     as explained in the :doc:`device-checks-and-alert-settings` section.
 
+.. important::
+
+    Alert notifications are not sent for devices belonging to disabled
+    organizations or for deactivated devices.
+
 The built-in alerts are explained below.
 
 .. _ping_alert:

--- a/docs/user/checks.rst
+++ b/docs/user/checks.rst
@@ -14,6 +14,11 @@ Active checks are periodic background tasks executed by `Celery workers
 These workers perform the enabled checks and store their results in the
 time series database.
 
+.. important::
+
+    Checks are not created or executed for devices in disabled
+    organizations or for deactivated devices.
+
 The built-in checks and the related django settings available in OpenWISP
 Monitoring are described below.
 

--- a/docs/user/wifi-sessions.rst
+++ b/docs/user/wifi-sessions.rst
@@ -21,6 +21,13 @@ You can disable this feature by configuring
 :ref:`OPENWISP_MONITORING_WIFI_SESSIONS_ENABLED
 <openwisp_monitoring_wifi_sessions_enabled>` setting.
 
+.. important::
+
+    When an **organization is disabled**, all open WiFi sessions for its
+    devices are closed, and no new sessions are recorded.
+
+    No new WiFi sessions are recorded for **deactivated devices**.
+
 You can also view open WiFi sessions of a device directly from the
 device's change admin under the "WiFi Sessions" tab.
 

--- a/openwisp_monitoring/admin.py
+++ b/openwisp_monitoring/admin.py
@@ -1,4 +1,26 @@
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.utils.translation import gettext_lazy as _
+
 from .utils import is_monitoring_blocked
+
+
+class MonitoringBlockedObjectFormMixin:
+    """Rejects admin form submissions for blocked monitoring targets."""
+
+    def clean(self):
+        cleaned_data = super().clean()
+        content_type = cleaned_data.get("content_type")
+        object_id = cleaned_data.get("object_id")
+        if content_type and object_id:
+            try:
+                obj = content_type.get_object_for_this_type(pk=object_id)
+            except ObjectDoesNotExist:
+                obj = None
+            if is_monitoring_blocked(obj):
+                raise ValidationError(
+                    _("Monitoring is blocked for the selected object.")
+                )
+        return cleaned_data
 
 
 class DisabledOrgReadOnlyMixin:

--- a/openwisp_monitoring/admin.py
+++ b/openwisp_monitoring/admin.py
@@ -1,0 +1,40 @@
+class DisabledOrgReadOnlyMixin:
+    """Makes objects of a disabled organization or a deactivated device
+    read-only in the admin.
+
+    Deletion stays allowed, consistently with
+    ``openwisp_users.multitenancy.MultitenantAdminMixin``.
+    """
+
+    def _get_related_object(self, obj):
+        """Walks ``content_object``/``metric`` down to the leaf object."""
+        if obj is None:
+            return None
+        content_object = getattr(obj, "content_object", None)
+        if content_object is not None:
+            return content_object
+        metric = getattr(obj, "metric", None)
+        if metric is not None:
+            return self._get_related_object(metric)
+        return obj
+
+    def _is_write_blocked(self, obj):
+        related = self._get_related_object(obj)
+        if related is None:
+            return False
+        if hasattr(related, "is_deactivated") and related.is_deactivated():
+            return True
+        organization = getattr(related, "organization", None)
+        return organization is not None and not organization.is_active
+
+    def has_change_permission(self, request, obj=None):
+        perm = super().has_change_permission(request, obj)
+        return perm and not self._is_write_blocked(obj)
+
+
+class DisabledOrgReadOnlyInlineMixin(DisabledOrgReadOnlyMixin):
+    """Inline flavour: ``has_add_permission`` also receives the parent object."""
+
+    def has_add_permission(self, request, obj=None):
+        perm = super().has_add_permission(request, obj)
+        return perm and not self._is_write_blocked(obj)

--- a/openwisp_monitoring/admin.py
+++ b/openwisp_monitoring/admin.py
@@ -1,3 +1,6 @@
+from .utils import is_monitoring_blocked
+
+
 class DisabledOrgReadOnlyMixin:
     """Makes objects of a disabled organization or a deactivated device
     read-only in the admin.
@@ -18,18 +21,9 @@ class DisabledOrgReadOnlyMixin:
             return self._get_related_object(metric)
         return obj
 
-    def _is_write_blocked(self, obj):
-        related = self._get_related_object(obj)
-        if related is None:
-            return False
-        if hasattr(related, "is_deactivated") and related.is_deactivated():
-            return True
-        organization = getattr(related, "organization", None)
-        return organization is not None and not organization.is_active
-
     def has_change_permission(self, request, obj=None):
         perm = super().has_change_permission(request, obj)
-        return perm and not self._is_write_blocked(obj)
+        return perm and not is_monitoring_blocked(self._get_related_object(obj))
 
 
 class DisabledOrgReadOnlyInlineMixin(DisabledOrgReadOnlyMixin):
@@ -37,4 +31,4 @@ class DisabledOrgReadOnlyInlineMixin(DisabledOrgReadOnlyMixin):
 
     def has_add_permission(self, request, obj=None):
         perm = super().has_add_permission(request, obj)
-        return perm and not self._is_write_blocked(obj)
+        return perm and not is_monitoring_blocked(self._get_related_object(obj))

--- a/openwisp_monitoring/check/admin.py
+++ b/openwisp_monitoring/check/admin.py
@@ -1,15 +1,21 @@
 from django.contrib import admin
+from django.forms import ModelForm
 from swapper import load_model
 
 from openwisp_utils.admin import TimeReadonlyAdminMixin
 
-from ..admin import DisabledOrgReadOnlyMixin
+from ..admin import DisabledOrgReadOnlyMixin, MonitoringBlockedObjectFormMixin
 
 Check = load_model("check", "Check")
 
 
+class CheckForm(MonitoringBlockedObjectFormMixin, ModelForm):
+    pass
+
+
 @admin.register(Check)
 class CheckAdmin(DisabledOrgReadOnlyMixin, TimeReadonlyAdminMixin, admin.ModelAdmin):
+    form = CheckForm
     list_display = ["__str__", "check_type", "created", "modified"]
     search_fields = ["name", "object_id"]
     # TODO: filters

--- a/openwisp_monitoring/check/admin.py
+++ b/openwisp_monitoring/check/admin.py
@@ -3,11 +3,13 @@ from swapper import load_model
 
 from openwisp_utils.admin import TimeReadonlyAdminMixin
 
+from ..admin import DisabledOrgReadOnlyMixin
+
 Check = load_model("check", "Check")
 
 
 @admin.register(Check)
-class CheckAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
+class CheckAdmin(DisabledOrgReadOnlyMixin, TimeReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ["__str__", "check_type", "created", "modified"]
     search_fields = ["name", "object_id"]
     # TODO: filters

--- a/openwisp_monitoring/check/base/models.py
+++ b/openwisp_monitoring/check/base/models.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from openwisp_utils.base import TimeStampedEditableModel
 
-from ...utils import transaction_on_commit
+from ...utils import is_monitoring_blocked, transaction_on_commit
 from .. import settings as app_settings
 from ..tasks import auto_create_check
 
@@ -91,13 +91,7 @@ class AbstractCheck(TimeStampedEditableModel):
 
     def perform_check(self, store=True):
         """Initializes check instance and calls the check method."""
-        if (
-            hasattr(self.content_object, "is_deactivated")
-            and self.content_object.is_deactivated()
-        ) or (
-            hasattr(self.content_object, "organization_id")
-            and self.content_object.organization.is_active is False
-        ):
+        if is_monitoring_blocked(self.content_object):
             return
         return self.check_instance.timed_check(store=True)
 
@@ -114,6 +108,8 @@ class AbstractCheck(TimeStampedEditableModel):
 
 
 def _auto_check_receiver(sender, instance, **kwargs):
+    if is_monitoring_blocked(instance):
+        return
     model = sender.__name__.lower()
     app_label = sender._meta.app_label
     object_id = str(instance.pk)

--- a/openwisp_monitoring/check/tasks.py
+++ b/openwisp_monitoring/check/tasks.py
@@ -55,6 +55,9 @@ def run_checks(checks=None):
         .values("id")
         .iterator()
     )
+    # Checks have a generic foreign key, so filtering blocked targets here
+    # would add coupling in this module. The check type class is reponsible
+    # for verifying if the target is blocked and skipping the check if needed.
     for check in iterator:
         perform_check.delay(check["id"])
 

--- a/openwisp_monitoring/check/tasks.py
+++ b/openwisp_monitoring/check/tasks.py
@@ -10,6 +10,7 @@ from swapper import load_model
 
 from openwisp_utils.tasks import OpenwispCeleryTask
 
+from ..utils import is_monitoring_blocked
 from . import settings as app_settings
 
 logger = logging.getLogger(__name__)
@@ -96,8 +97,22 @@ def auto_create_check(
     # create new check only if necessary
     if has_check:
         return
+    is_migration = content_type_model is not None
     content_type_model = content_type_model or ContentType
     ct = content_type_model.objects.get_by_natural_key(app_label=app_label, model=model)
+    if not is_migration:
+        # Historical models used by migrations don't retain custom
+        # methods such as "model_class()" or "is_deactivated()", so
+        # this check only applies to the live signal/task path.
+        model_class = ct.model_class()
+        try:
+            instance = model_class.objects.select_related("organization").get(
+                pk=object_id
+            )
+        except ObjectDoesNotExist:
+            return
+        if is_monitoring_blocked(instance):
+            return
     check = Check(
         name=check_name,
         check_type=check_type,

--- a/openwisp_monitoring/check/tests/test_admin.py
+++ b/openwisp_monitoring/check/tests/test_admin.py
@@ -9,6 +9,14 @@ Check = load_model("check", "Check")
 
 @tag("flaky_with_udp_writes")
 class TestAdmin(TestDeviceMonitoringMixin, TransactionTestCase):
+    def test_check_admin_change_permission(self):
+        d = self._create_device(organization=self._create_org())
+        check = Check.objects.filter(object_id=d.pk).first()
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        check_admin = admin.site._registry[Check]
+        self.assertTrue(check_admin.has_change_permission(request, check))
+
     def test_check_admin_disabled_organization_read_only(self):
         org = self._create_org()
         d = self._create_device(organization=org)

--- a/openwisp_monitoring/check/tests/test_admin.py
+++ b/openwisp_monitoring/check/tests/test_admin.py
@@ -1,0 +1,32 @@
+from django.contrib import admin
+from django.test import RequestFactory, TransactionTestCase, tag
+from swapper import load_model
+
+from ...device.tests import TestDeviceMonitoringMixin
+
+Check = load_model("check", "Check")
+
+
+@tag("flaky_with_udp_writes")
+class TestAdmin(TestDeviceMonitoringMixin, TransactionTestCase):
+    def test_check_admin_disabled_organization_read_only(self):
+        org = self._create_org()
+        d = self._create_device(organization=org)
+        check = Check.objects.filter(object_id=d.pk).first()
+        org.is_active = False
+        org.save()
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        check_admin = admin.site._registry[Check]
+        self.assertFalse(check_admin.has_change_permission(request, check))
+        self.assertTrue(check_admin.has_delete_permission(request, check))
+
+    def test_check_admin_deactivated_device_read_only(self):
+        d = self._create_device(organization=self._create_org())
+        check = Check.objects.filter(object_id=d.pk).first()
+        d.deactivate()
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        check_admin = admin.site._registry[Check]
+        self.assertFalse(check_admin.has_change_permission(request, check))
+        self.assertTrue(check_admin.has_delete_permission(request, check))

--- a/openwisp_monitoring/check/tests/test_admin.py
+++ b/openwisp_monitoring/check/tests/test_admin.py
@@ -1,14 +1,87 @@
 from django.contrib import admin
+from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TransactionTestCase, tag
+from django.urls import reverse
 from swapper import load_model
 
 from ...device.tests import TestDeviceMonitoringMixin
+from .. import settings as app_settings
+from . import Device
 
 Check = load_model("check", "Check")
 
 
 @tag("flaky_with_udp_writes")
 class TestAdmin(TestDeviceMonitoringMixin, TransactionTestCase):
+    def _check_data(self, device, check=None):
+        check_type = check.check_type if check else app_settings.CHECK_CLASSES[0][0]
+        return {
+            "name": check.name if check else "Test check",
+            "is_active": "on",
+            "description": "",
+            "content_type": ContentType.objects.get_for_model(Device).pk,
+            "object_id": str(device.pk),
+            "check_type": check_type,
+            "params": "{}",
+        }
+
+    def _post_check(self, device, check=None):
+        if check:
+            url = reverse(
+                f"admin:{Check._meta.app_label}_{Check._meta.model_name}_change",
+                args=[check.pk],
+            )
+        else:
+            url = reverse(f"admin:{Check._meta.app_label}_{Check._meta.model_name}_add")
+        return self.client.post(url, self._check_data(device, check))
+
+    def test_check_admin_form_blocks_deactivated_device(self):
+        source_device = self._create_device(
+            organization=self._create_org(name="source org", slug="source-org")
+        )
+        check = Check.objects.filter(object_id=source_device.pk).first()
+        device = self._create_device(
+            name="blocked-device",
+            mac_address="00:11:22:33:44:66",
+            organization=self._get_org(),
+        )
+        device.deactivate()
+        self.client.force_login(self._get_admin())
+        for instance in (None, check):
+            with self.subTest(instance=instance is not None):
+                response = self._post_check(device, check=instance)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, "Monitoring is blocked")
+
+    def test_check_admin_form_blocks_disabled_organization(self):
+        source_device = self._create_device(
+            organization=self._create_org(name="source org", slug="source-org")
+        )
+        check = Check.objects.filter(object_id=source_device.pk).first()
+        organization = self._get_org()
+        device = self._create_device(
+            name="disabled-device",
+            mac_address="00:11:22:33:44:66",
+            organization=self._get_org(),
+        )
+        organization.is_active = False
+        organization.save()
+        self.client.force_login(self._get_admin())
+        for instance in (None, check):
+            with self.subTest(instance=instance is not None):
+                response = self._post_check(device, check=instance)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, "Monitoring is blocked")
+
+    def test_check_admin_form_allows_active_device(self):
+        device = self._create_device(organization=self._create_org())
+        self.client.force_login(self._get_admin())
+        response = self._post_check(device)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            Check.objects.filter(object_id=device.pk, name="Test check").count(), 1
+        )
+
     def test_check_admin_change_permission(self):
         d = self._create_device(organization=self._create_org())
         check = Check.objects.filter(object_id=d.pk).first()

--- a/openwisp_monitoring/check/tests/test_models.py
+++ b/openwisp_monitoring/check/tests/test_models.py
@@ -380,7 +380,7 @@ class TestModels(AutoWifiClientCheck, TestDeviceMonitoringMixin, TransactionTest
 
     def test_device_organization_disabled_check_not_performed(self):
         org = self._create_org()
-        config = self._create_config(status="modified", organization=org)
+        self._create_config(status="modified", organization=org)
         self.assertEqual(Check.objects.count(), 5)
         check = Check.objects.filter(check_type=self._CONFIG_APPLIED).first()
         org.is_active = False

--- a/openwisp_monitoring/check/tests/test_models.py
+++ b/openwisp_monitoring/check/tests/test_models.py
@@ -184,8 +184,13 @@ class TestModels(AutoWifiClientCheck, TestDeviceMonitoringMixin, TransactionTest
 
     def test_auto_check_not_created_for_disabled_organization(self):
         self.assertEqual(Check.objects.count(), 0)
-        self._create_device(organization=self._create_org(is_active=False))
-        self.assertEqual(Check.objects.count(), 0)
+        self._create_device(organization=self._create_org())
+        self.assertEqual(Check.objects.count(), 5)
+        disabled_org = self._create_org(
+            name="disabled org", slug="disabled-org", is_active=False
+        )
+        self._create_device(organization=disabled_org)
+        self.assertEqual(Check.objects.count(), 5)
 
     def test_auto_check_not_created_for_deactivated_device(self):
         device = self._create_device(organization=self._create_org())

--- a/openwisp_monitoring/check/tests/test_models.py
+++ b/openwisp_monitoring/check/tests/test_models.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.test import TransactionTestCase, tag
 from django.utils.timezone import now
@@ -181,6 +182,25 @@ class TestModels(AutoWifiClientCheck, TestDeviceMonitoringMixin, TransactionTest
             self.assertEqual(c1.content_object, d)
             self.assertEqual(self._DATA_COLLECTED, c1.check_type)
 
+    def test_auto_check_not_created_for_disabled_organization(self):
+        self.assertEqual(Check.objects.count(), 0)
+        self._create_device(organization=self._create_org(is_active=False))
+        self.assertEqual(Check.objects.count(), 0)
+
+    def test_auto_check_not_created_for_deactivated_device(self):
+        device = self._create_device(organization=self._create_org())
+        Check.objects.all().delete()
+        device.deactivate()
+        ct = ContentType.objects.get_for_model(Device)
+        auto_create_check(
+            model=ct.model,
+            app_label=ct.app_label,
+            object_id=str(device.pk),
+            check_type=self._PING,
+            check_name="Ping",
+        )
+        self.assertEqual(Check.objects.count(), 0)
+
     def test_device_deleted(self):
         self.assertEqual(Check.objects.count(), 0)
         d = self._create_device(organization=self._create_org())
@@ -359,11 +379,12 @@ class TestModels(AutoWifiClientCheck, TestDeviceMonitoringMixin, TransactionTest
         self.assertIsNone(c2.perform_check())
 
     def test_device_organization_disabled_check_not_performed(self):
-        self._create_config(
-            status="modified", organization=self._create_org(is_active=False)
-        )
+        org = self._create_org()
+        config = self._create_config(status="modified", organization=org)
         self.assertEqual(Check.objects.count(), 5)
         check = Check.objects.filter(check_type=self._CONFIG_APPLIED).first()
+        org.is_active = False
+        org.save()
         with patch(f"{self._CONFIG_APPLIED}.check") as mocked_check:
             check.perform_check()
         mocked_check.assert_not_called()

--- a/openwisp_monitoring/device/admin.py
+++ b/openwisp_monitoring/device/admin.py
@@ -29,6 +29,7 @@ from openwisp_controller.geo.admin import DeviceLocationInline
 from openwisp_users.multitenancy import MultitenantAdminMixin
 from openwisp_utils.admin import ReadOnlyAdmin
 
+from ..admin import DisabledOrgReadOnlyInlineMixin
 from ..monitoring.admin import MetricAdmin
 from ..settings import MONITORING_API_BASEURL, MONITORING_API_URLCONF
 from . import settings as app_settings
@@ -120,10 +121,6 @@ class DeactivatedDeviceReadOnlyInlinePermissionMixin(
         perm = super().has_change_permission(request, obj)
         return self._has_permission(request, obj, perm)
 
-    def has_view_permission(self, request, obj=None):
-        perm = super().has_view_permission(request, obj)
-        return self._has_permission(request, obj, perm)
-
     def has_delete_permission(self, request, obj=None):
         perm = super().has_delete_permission(request, obj)
         return self._has_permission(request, obj, perm)
@@ -188,7 +185,9 @@ class AlertSettingsForm(ModelForm):
         return super().save(commit)
 
 
-class AlertSettingsInline(InlinePermissionMixin, NestedStackedInline):
+class AlertSettingsInline(
+    DisabledOrgReadOnlyInlineMixin, InlinePermissionMixin, NestedStackedInline
+):
     model = AlertSettings
     extra = 1
     max_num = 1
@@ -430,7 +429,7 @@ class DeviceAdmin(BaseDeviceAdmin, NestedModelAdmin):
         for inline in inlines:
             if not hasattr(inline, "sortable_options"):
                 inline.sortable_options = {"disabled": True}
-        if not obj or obj._state.adding or obj.organization.is_active is False:
+        if not obj or obj._state.adding:
             inlines.remove(CheckInline)
             inlines.remove(MetricInline)
         return inlines

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -167,11 +167,6 @@ class DeviceMetricView(
 
     def post(self, request, pk):
         self.instance = self.get_object(pk)
-        if self.instance._is_deactivated:
-            # If the device is deactivated, do not accept data.
-            # We don't use "Device.is_deactivated()" to avoid
-            # generating query for the related config.
-            raise Http404
         self.instance.data = request.data
         # validate incoming data
         try:

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -109,7 +109,7 @@ class DeviceMetricView(
 
     model = DeviceData
     queryset = (
-        DeviceData.objects.filter(organization__is_active=True)
+        DeviceData.objects.filter(organization__is_active=True, _is_deactivated=False)
         .only(
             "_is_deactivated",
             "id",

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -37,6 +37,7 @@ from openwisp_users.api.permissions import DjangoModelPermissions, IsOrganizatio
 from openwisp_utils.api.pagination import OpenWispPagination
 
 from ...settings import CACHE_TIMEOUT
+from ...utils import is_monitoring_blocked
 from ...views import MonitoringApiViewMixin
 from ..schema import schema
 from ..signals import device_metrics_received
@@ -108,14 +109,12 @@ class DeviceMetricView(
     """
 
     model = DeviceData
-    queryset = (
-        DeviceData.objects.filter(organization__is_active=True, _is_deactivated=False)
-        .only(
-            "_is_deactivated",
-            "id",
-            "key",
-        )
-        .all()
+    queryset = DeviceData.objects.select_related("organization").only(
+        "_is_deactivated",
+        "id",
+        "key",
+        "organization__id",
+        "organization__is_active",
     )
     serializer_class = serializers.Serializer
     permission_classes = [DevicePermission]
@@ -167,6 +166,8 @@ class DeviceMetricView(
 
     def post(self, request, pk):
         self.instance = self.get_object(pk)
+        if is_monitoring_blocked(self.instance):
+            raise Http404
         self.instance.data = request.data
         # validate incoming data
         try:

--- a/openwisp_monitoring/device/apps.py
+++ b/openwisp_monitoring/device/apps.py
@@ -16,6 +16,7 @@ from openwisp_controller.config.signals import (
 )
 from openwisp_controller.connection import settings as connection_settings
 from openwisp_controller.connection.signals import is_working_changed
+from openwisp_users.signals import organization_disabled
 from openwisp_utils.admin_theme import (
     register_dashboard_chart,
     register_dashboard_template,
@@ -82,7 +83,6 @@ class DeviceMonitoringConfig(AppConfig):
         DeviceLocation = load_model("geo", "DeviceLocation")
         Metric = load_model("monitoring", "Metric")
         Chart = load_model("monitoring", "Chart")
-        Organization = load_model("openwisp_users", "Organization")
 
         post_save.connect(
             self.device_post_save_receiver,
@@ -144,10 +144,9 @@ class DeviceMonitoringConfig(AppConfig):
             sender=DeviceLocation,
             dispatch_uid="post_delete_devicelocation_invalidate_devicedata_cache",
         )
-        post_save.connect(
-            self.organization_post_save_receiver,
-            sender=Organization,
-            dispatch_uid="post_save_organization_disabled_monitoring",
+        organization_disabled.connect(
+            self.organization_disabled_receiver,
+            dispatch_uid="monitoring_organization_disabled",
         )
         device_deactivated.connect(
             DeviceMonitoring.handle_deactivated_device,
@@ -184,11 +183,10 @@ class DeviceMonitoringConfig(AppConfig):
         instance.metrics.all().delete()
 
     @classmethod
-    def organization_post_save_receiver(cls, instance, *args, **kwargs):
-        if instance.is_active is False:
-            from .tasks import handle_disabled_organization
+    def organization_disabled_receiver(cls, instance, **kwargs):
+        from .tasks import handle_disabled_organization
 
-            handle_disabled_organization.delay(str(instance.id))
+        handle_disabled_organization.delay(str(instance.pk))
 
     def device_recovery_detection(self):
         if not app_settings.DEVICE_RECOVERY_DETECTION:
@@ -247,6 +245,8 @@ class DeviceMonitoringConfig(AppConfig):
 
         Check = load_model("check", "Check")
         device = instance.device
+        if device.is_deactivated() or not device.organization.is_active:
+            return
         device_monitoring = device.monitoring
         # if old_is_working is None, it's a new device connection which wasn't
         # ever used yet, so nothing is really changing and we don't need to do anything
@@ -324,10 +324,24 @@ class DeviceMonitoringConfig(AppConfig):
         from ..check.tasks import perform_check
 
         DeviceData = load_model("device_monitoring", "DeviceData")
-        device = DeviceData.objects.get(config=instance)
-        check = device.checks.filter(check_type__contains="ConfigApplied").first()
-        if check:
-            transaction_on_commit(lambda: perform_check.delay(check.pk))
+
+        def perform_config_applied_check():
+            device = DeviceData.objects.filter(
+                config=instance,
+                _is_deactivated=False,
+                organization__is_active=True,
+            ).first()
+            if device is None:
+                return
+            check = device.checks.filter(check_type__contains="ConfigApplied").first()
+            if check is None:
+                return
+            perform_check.delay(check.pk)
+
+        # openwisp-controller sends this signal synchronously inside
+        # Config.save(), so we defer the lookup and enqueue until the
+        # transaction commits to avoid acting on uncommitted state.
+        transaction_on_commit(perform_config_applied_check)
 
     def set_update_config_model(self):
         if not getattr(settings, "OPENWISP_UPDATE_CONFIG_MODEL", None):

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -375,6 +375,10 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
                 transaction, even when the status is already set to ``value``.
         """
         with transaction.atomic():
+            monitoring = self.__class__.objects.select_for_update().get(pk=self.pk)
+            if monitoring.status == "deactivated":
+                self.status = monitoring.status
+                return
             # If the status is being set to "unknown" reset the related metrics
             # to "factory default". This allows the system to easily recalculate
             # the status if the device is reactivated.
@@ -387,11 +391,14 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
                 self.device.management_ip = ""
                 self.device.save(update_fields=["management_ip"])
             # don't trigger save nor emit signal if status is not changing
-            if self.status == value:
+            if monitoring.status == value:
+                self.status = monitoring.status
                 return
+            monitoring.status = value
+            monitoring.full_clean()
+            # Save the freshly locked row, not the potentially stale self instance.
+            monitoring.save()
             self.status = value
-            self.full_clean()
-            self.save()
 
         transaction.on_commit(
             lambda: health_status_changed.send(

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -493,15 +493,14 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
         Clears the management IP of all devices belonging to a disabled
         organization.
 
-        Don't update the device's monitoring status here because it will
-        be automatically updated when the device is deactivated.
-
         Parameters: - organization_id (int): The ID of the disabled
         organization.
 
         Returns: - None
         """
-        monitoring = cls.objects.filter(device__organization_id=organization_id)
+        monitoring = cls.objects.filter(
+            device__organization_id=organization_id
+        ).exclude(status="deactivated")
         # Preserve the bulk update for large organizations: disabling an
         # organization is not a health-status change and has its own signal.
         monitoring.update(status="unknown")

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -62,10 +62,13 @@ class AbstractDeviceData(object):
     @cache_memoize(CACHE_TIMEOUT)
     def get_devicedata(cls, pk):
         obj = (
-            cls.objects.select_related("devicelocation")
+            cls.objects.select_related("devicelocation", "organization")
             .only(
                 "id",
                 "organization_id",
+                "organization__id",
+                "organization__is_active",
+                "_is_deactivated",
                 "devicelocation__location_id",
                 "devicelocation__floorplan_id",
             )
@@ -479,7 +482,10 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
         """Handles the disabling of an organization.
 
         Clears the management IP of all devices belonging to a disabled
-        organization and set their monitoring status to 'unknown'.
+        organization.
+
+        Don't update the device's monitoring status here because it will
+        be automatically updated when the device is deactivated.
 
         Parameters: - organization_id (int): The ID of the disabled
         organization.
@@ -626,3 +632,10 @@ class AbstractWifiSession(TimeStampedEditableModel):
             and AbstractDeviceMonitoring.is_metric_critical(metric)
         ):
             tasks.offline_device_close_session.delay(device_id=target.pk)
+
+    @classmethod
+    def close_organization_sessions(cls, organization_id):
+        """Closes the open sessions of a disabled organization's devices."""
+        cls.objects.filter(
+            device__organization_id=organization_id, stop_time__isnull=True
+        ).update(stop_time=now())

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -365,7 +365,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
     class Meta:
         abstract = True
 
-    def update_status(self, value, clear_management_ip=False):
+    def update_status(self, value, clear_management_ip=False, allow_deactivated=False):
         """Updates the device health status and related state.
 
         Args:
@@ -373,10 +373,12 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
                 health states.
             clear_management_ip: Clears the device management IP in the same
                 transaction, even when the status is already set to ``value``.
+            allow_deactivated: Allows the activation handler to reset a
+                deactivated status.
         """
         with transaction.atomic():
             monitoring = self.__class__.objects.select_for_update().get(pk=self.pk)
-            if monitoring.status == "deactivated":
+            if monitoring.status == "deactivated" and not allow_deactivated:
                 self.status = monitoring.status
                 return
             # If the status is being set to "unknown" reset the related metrics
@@ -530,7 +532,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        instance.monitoring.update_status("unknown")
+        instance.monitoring.update_status("unknown", allow_deactivated=True)
 
     @classmethod
     def _get_critical_metric_keys(cls):

--- a/openwisp_monitoring/device/tasks.py
+++ b/openwisp_monitoring/device/tasks.py
@@ -9,6 +9,7 @@ from swapper import load_model
 from openwisp_utils.tasks import OpenwispCeleryTask
 
 from ..check.tasks import perform_check
+from ..utils import is_monitoring_blocked
 from . import settings as app_settings
 
 logger = logging.getLogger(__name__)
@@ -89,10 +90,12 @@ def offline_device_close_session(device_id):
 def write_device_metrics(pk, data, time=None, current=False):
     DeviceData = load_model("device_monitoring", "DeviceData")
     try:
-        device_data = DeviceData.objects.select_related("organization").get(
-            pk=pk, _is_deactivated=False, organization__is_active=True
-        )
+        device_data = DeviceData.objects.select_related(
+            "organization", "devicelocation"
+        ).get(pk=pk)
     except DeviceData.DoesNotExist:
+        return
+    if is_monitoring_blocked(device_data):
         return
     device_data.writer.write(data, time, current)
 

--- a/openwisp_monitoring/device/tasks.py
+++ b/openwisp_monitoring/device/tasks.py
@@ -9,6 +9,7 @@ from swapper import load_model
 from openwisp_utils.tasks import OpenwispCeleryTask
 
 from ..check.tasks import perform_check
+from . import settings as app_settings
 
 logger = logging.getLogger(__name__)
 
@@ -25,9 +26,13 @@ def trigger_device_critical_checks(pk, recovery=True):
     """
     DeviceData = load_model("device_monitoring", "DeviceData")
     try:
-        device = DeviceData.objects.select_related("monitoring").get(pk=pk)
+        device = DeviceData.objects.select_related("monitoring", "organization").get(
+            pk=pk
+        )
     except ObjectDoesNotExist:
         logger.warning(f"The device with uuid {pk} has been deleted")
+        return
+    if device.is_deactivated() or not device.organization.is_active:
         return
     check_ids = list(
         device.checks.filter(
@@ -84,7 +89,9 @@ def offline_device_close_session(device_id):
 def write_device_metrics(pk, data, time=None, current=False):
     DeviceData = load_model("device_monitoring", "DeviceData")
     try:
-        device_data = DeviceData.get_devicedata(str(pk))
+        device_data = DeviceData.objects.select_related("organization").get(
+            pk=pk, _is_deactivated=False, organization__is_active=True
+        )
     except DeviceData.DoesNotExist:
         return
     device_data.writer.write(data, time, current)
@@ -92,5 +99,17 @@ def write_device_metrics(pk, data, time=None, current=False):
 
 @shared_task(base=OpenwispCeleryTask)
 def handle_disabled_organization(organization_id):
+    from .api.views import DeviceMetricView
+
+    Device = load_model("config", "Device")
+    DeviceData = load_model("device_monitoring", "DeviceData")
     DeviceMonitoring = load_model("device_monitoring", "DeviceMonitoring")
     DeviceMonitoring.handle_disabled_organization(organization_id)
+    if app_settings.WIFI_SESSIONS_ENABLED:
+        WifiSession = load_model("device_monitoring", "WifiSession")
+        WifiSession.close_organization_sessions(organization_id)
+    for device in (
+        Device.objects.filter(organization_id=organization_id).only("id").iterator()
+    ):
+        DeviceData.invalidate_cache(device)
+        DeviceMetricView.invalidate_get_device_cache(device)

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -1,13 +1,14 @@
 from copy import deepcopy
 
 import django
+from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db import connection
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import datetime, now, timedelta
 from freezegun import freeze_time
@@ -19,7 +20,7 @@ from openwisp_controller.geo.tests.utils import TestGeoMixin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 
 from ...check.settings import CHECK_CLASSES
-from ..admin import CheckInline, CheckInlineFormSet
+from ..admin import AlertSettingsInline, CheckInline, CheckInlineFormSet
 from . import DeviceMonitoringTestCase, TestWifiClientSessionMixin
 
 Chart = load_model("monitoring", "Chart")
@@ -43,7 +44,10 @@ metric_model_name = get_model_name("monitoring", "Metric").lower().replace(".", 
 
 
 class TestAdmin(
-    TestWifiClientSessionMixin, TestImportExportMixin, DeviceMonitoringTestCase
+    TestWifiClientSessionMixin,
+    TestImportExportMixin,
+    TestMultitenantAdminMixin,
+    DeviceMonitoringTestCase,
 ):
     """Test the additions of openwisp-monitoring to DeviceAdmin"""
 
@@ -386,12 +390,44 @@ class TestAdmin(
         response = self.client.get(url)
         self.assertContains(response, "<h2>Status</h2>")
         self.assertContains(response, "<h2>Charts</h2>")
-        self.assertNotContains(
+        self.assertContains(
             response, self._get_inline_admin_heading("Checks"), html=True
         )
-        self.assertNotContains(
+        self.assertContains(
             response, self._get_inline_admin_heading("Alert Settings"), html=True
         )
+
+    def test_device_disabled_org_admin_inline_readonly(self):
+        self.create_test_data()
+        device = Device.objects.first()
+        active_device = self._create_device(
+            name="active-device", organization=self._create_org(name="active-org")
+        )
+        org = device.organization
+        org.is_active = False
+        org.save()
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        device_admin = admin.site._registry[Device]
+        self._test_disabled_org_admin_inline_readonly(
+            device_admin,
+            device,
+            active_obj=active_device,
+            inline_models=(CheckInline,),
+            user=request.user,
+        )
+
+    def test_device_alertsettings_inline_readonly_for_deactivated_device(self):
+        device = self._create_device(organization=self._create_org())
+        metric = self._create_object_metric(content_object=device)
+        self._create_alert_settings(metric=metric)
+        device.deactivate()
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        inline = AlertSettingsInline(Metric, admin.site)
+        self.assertFalse(inline.has_add_permission(request, metric))
+        self.assertFalse(inline.has_change_permission(request, metric))
+        self.assertTrue(inline.has_delete_permission(request, metric))
 
     def test_remove_invalid_interface(self):
         d = self._create_device(organization=self._create_org())

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -20,12 +20,7 @@ from openwisp_controller.geo.tests.utils import TestGeoMixin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 
 from ...check.settings import CHECK_CLASSES
-from ..admin import (
-    AlertSettingsInline,
-    CheckInline,
-    CheckInlineFormSet,
-    MetricInline,
-)
+from ..admin import AlertSettingsInline, CheckInline, CheckInlineFormSet, MetricInline
 from . import DeviceMonitoringTestCase, TestWifiClientSessionMixin
 
 Chart = load_model("monitoring", "Chart")

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -20,7 +20,12 @@ from openwisp_controller.geo.tests.utils import TestGeoMixin
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 
 from ...check.settings import CHECK_CLASSES
-from ..admin import AlertSettingsInline, CheckInline, CheckInlineFormSet
+from ..admin import (
+    AlertSettingsInline,
+    CheckInline,
+    CheckInlineFormSet,
+    MetricInline,
+)
 from . import DeviceMonitoringTestCase, TestWifiClientSessionMixin
 
 Chart = load_model("monitoring", "Chart")
@@ -415,6 +420,22 @@ class TestAdmin(
             active_obj=active_device,
             inline_models=(CheckInline,),
             user=request.user,
+        )
+        metric_inline = next(
+            inline
+            for inline in device_admin.get_inline_instances(request, device)
+            if isinstance(inline, MetricInline)
+        )
+        self.assertFalse(metric_inline.has_add_permission(request, device))
+        self.assertFalse(metric_inline.has_change_permission(request, device))
+        self.assertFalse(metric_inline.has_delete_permission(request, device))
+        active_metric_inline = next(
+            inline
+            for inline in device_admin.get_inline_instances(request, active_device)
+            if isinstance(inline, MetricInline)
+        )
+        self.assertTrue(
+            active_metric_inline.has_change_permission(request, active_device)
         )
 
     def test_device_alertsettings_inline_readonly_for_deactivated_device(self):

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -167,7 +167,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         self.assertEqual(self.metric_queryset.count(), 0)
         self.assertEqual(self.chart_queryset.count(), 0)
         data = {"type": "DeviceMonitoring"}
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             r = self._post_data(d.id, d.key, data)
         self.assertEqual(r.status_code, 200)
         # Add 1 for general metric and chart
@@ -281,7 +281,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         with self.assertNumQueries(21 + additional_queries):
             response = self._post_data(device.id, device.key, data2)
         # Ensure cache is working
-        with self.assertNumQueries(13 + additional_queries):
+        with self.assertNumQueries(14 + additional_queries):
             response = self._post_data(device.id, device.key, data2)
         self.assertEqual(response.status_code, 200)
         # Add 1 for general metric and chart
@@ -370,7 +370,8 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             self._post_data(device.id, device.key, self._data()).status_code, 200
         )
         organization.is_active = False
-        organization.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            organization.save()
         response = self._post_data(device.id, device.key, self._data())
         self.assertEqual(response.status_code, 404)
 
@@ -392,7 +393,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         self.create_test_data(no_resources=True)
         device = self.device_model.objects.first()
         data = {"type": "DeviceMonitoring"}
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             response = self._post_data(device.id, device.key, data)
 
         # Deactivating the device will invalidate the cache.
@@ -440,9 +441,9 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
     def test_get_device_metrics_200(self):
         dd = self.create_test_data()
         d = self.device_model.objects.get(pk=dd.pk)
-        with self.assertNumQueries(17):
-            r = self.client.get(self._url(d.pk, d.key))
         with self.assertNumQueries(16):
+            r = self.client.get(self._url(d.pk, d.key))
+        with self.assertNumQueries(15):
             r = self.client.get(self._url(d.pk, d.key))
         self.assertEqual(r.status_code, 200)
 

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -278,10 +278,10 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         # this speeds up the test by reducing requests made
         del data2["resources"]
         additional_queries = 0 if self._is_timeseries_udp_writes else 1
-        with self.assertNumQueries(21 + additional_queries):
+        with self.assertNumQueries(32 + additional_queries):
             response = self._post_data(device.id, device.key, data2)
         # Ensure cache is working
-        with self.assertNumQueries(14 + additional_queries):
+        with self.assertNumQueries(25 + additional_queries):
             response = self._post_data(device.id, device.key, data2)
         self.assertEqual(response.status_code, 200)
         # Add 1 for general metric and chart

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -2065,6 +2065,8 @@ class TestWifiSessionApi(
         self._login_admin()
         list_response = self.client.get(reverse("monitoring:api_wifi_session_list"))
         self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(list_response.data["count"], 1)
+        self.assertEqual(list_response.data["results"][0]["id"], str(wifi_session.id))
         detail_response = self.client.get(
             reverse("monitoring:api_wifi_session_detail", args=[wifi_session.id])
         )

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -1434,7 +1434,8 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             name="CPU usage", configuration="cpu", object_id=d.id
         )
         values = {"cpu_usage": 0.0, "load_1": 0.0, "load_5": 0.0, "load_15": 0.0}
-        time = start_time.strftime("%d-%m-%Y_%H:%M:%S.%f")
+        signal_time = timezone.now()
+        time = signal_time.strftime("%d-%m-%Y_%H:%M:%S.%f")
         with catch_signal(post_metric_write) as handler:
             self._post_data(d.id, d.key, data, time=time)
         signal_calls = handler.call_args_list
@@ -1447,7 +1448,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             signal=post_metric_write,
             sender=Metric,
             values=values,
-            time=start_time.isoformat(),
+            time=signal_time.isoformat(),
             current=False,
         )
         self.assertEqual(signal_calls[0][1], expected_arguments)

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -363,6 +363,28 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
         self.assertEqual(self.metric_queryset.count(), 0)
         self.assertEqual(self.chart_queryset.count(), 0)
 
+    def test_404_disabled_organization_with_cached_device(self):
+        organization = self._create_org()
+        device = self._create_device(organization=organization)
+        self.assertEqual(
+            self._post_data(device.id, device.key, self._data()).status_code, 200
+        )
+        organization.is_active = False
+        organization.save()
+        response = self._post_data(device.id, device.key, self._data())
+        self.assertEqual(response.status_code, 404)
+
+    def test_disabled_organization_read_api_allowed(self):
+        org = self._create_org(is_active=False)
+        device = self._create_device(organization=org)
+        device_list_url = reverse("monitoring:api_monitoring_device_list")
+        response = self.client.get(device_list_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        metric_list_url = reverse("monitoring:api_device_metric_list", args=[device.pk])
+        response = self.client.get(metric_list_url)
+        self.assertEqual(response.status_code, 200)
+
     def test_device_activate_deactivate(self):
         # "self.create_test_data" creates a device and makes
         # a POST request to DeviceMetricView ensuring that
@@ -2034,6 +2056,18 @@ class TestWifiSessionApi(
         serializer_dict = self._serialize_wifi_session(ws, list_single=True)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0], serializer_dict)
+
+    def test_wifi_session_read_allowed_disabled_organization(self):
+        org = self._create_org(is_active=False)
+        device = self._create_device(organization=org)
+        wifi_session = self._create_wifi_session(device=device)
+        self._login_admin()
+        list_response = self.client.get(reverse("monitoring:api_wifi_session_list"))
+        self.assertEqual(list_response.status_code, 200)
+        detail_response = self.client.get(
+            reverse("monitoring:api_wifi_session_detail", args=[wifi_session.id])
+        )
+        self.assertEqual(detail_response.status_code, 200)
 
     def test_wifi_session_list_unauthorized(self):
         device = self._create_device()

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -976,6 +976,37 @@ class TestDeviceMonitoring(
 class TestTransactionDeviceMonitoring(
     CreateConnectionsMixin, MonitoringTestMixin, DeviceMonitoringTransactionTestcase
 ):
+    def test_disabled_organization_statuses(self):
+        for status in ("problem", "critical"):
+            with self.subTest(status=status):
+                device_monitoring, _, _, _ = self._create_env()
+                device_monitoring.update_status(status)
+                DeviceMonitoring.handle_disabled_organization(
+                    device_monitoring.device.organization_id
+                )
+                device_monitoring.refresh_from_db()
+                self.assertEqual(device_monitoring.status, "unknown")
+
+        with self.subTest("Deactivated device remains deactivated"):
+            device_monitoring, _, _, _ = self._create_env()
+            device_monitoring.device.deactivate()
+            DeviceMonitoring.handle_disabled_organization(
+                device_monitoring.device.organization_id
+            )
+            device_monitoring.refresh_from_db()
+            self.assertEqual(device_monitoring.status, "deactivated")
+
+        with self.subTest(
+            "Deactivation after organization handling remains deactivated"
+        ):
+            device_monitoring, _, _, _ = self._create_env()
+            DeviceMonitoring.handle_disabled_organization(
+                device_monitoring.device.organization_id
+            )
+            device_monitoring.device.deactivate()
+            device_monitoring.refresh_from_db()
+            self.assertEqual(device_monitoring.status, "deactivated")
+
     def test_unknown_status_rollback(self):
         dm, ping, load, process_count = self._create_env()
         with transaction.atomic():

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -16,9 +16,14 @@ from openwisp_utils.tests import catch_signal
 
 from ...db import timeseries_db
 from ...monitoring import settings as monitoring_settings
+from ...monitoring.signals import pre_metric_write, threshold_crossed
 from .. import settings as app_settings
 from ..signals import health_status_changed
-from ..tasks import delete_wifi_clients_and_sessions, trigger_device_critical_checks
+from ..tasks import (
+    delete_wifi_clients_and_sessions,
+    trigger_device_critical_checks,
+    write_device_metrics,
+)
 from ..utils import get_device_cache_key
 from . import (
     DeviceMonitoringTestCase,
@@ -952,8 +957,17 @@ class TestDeviceMonitoring(
         org = device.organization
         with self.assertNumQueries(10):
             DeviceMonitoring.handle_disabled_organization(org.pk)
+            
+    def test_update_status_does_not_override_deactivated(self):
+        device_monitoring, _, _, _ = self._create_env()
+        device_monitoring.device.deactivate()
+        for status in ("critical", "ok", "unknown"):
+            with self.subTest(status=status):
+                device_monitoring.update_status(status)
+                device_monitoring.refresh_from_db()
+                self.assertEqual(device_monitoring.status, "deactivated")
+        device_monitoring.device.activate()
         device_monitoring.refresh_from_db()
-        device.refresh_from_db()
         self.assertEqual(device_monitoring.status, "unknown")
         self.assertEqual(device.management_ip, None)
         self._assert_unknown(ping, load, process_count)
@@ -969,6 +983,48 @@ class TestDeviceMonitoring(
         self.assertEqual(other_monitoring.device.management_ip, "10.10.0.7")
         self.assertTrue(unrelated_ping.is_healthy)
         self.assertTrue(unrelated_ping.is_healthy_tolerant)
+
+    @patch("openwisp_monitoring.device.writer.DeviceDataWriter.write")
+    def test_write_device_metrics_skips_deactivated_device(self, write):
+        device = self._create_device(organization=self._create_org())
+        DeviceData.get_devicedata(str(device.pk))
+        device.deactivate()
+        write_device_metrics(str(device.pk), self._sample_data)
+        write.assert_not_called()
+
+    @patch("openwisp_monitoring.device.writer.DeviceDataWriter.write")
+    def test_write_device_metrics_skips_disabled_organization(self, write):
+        device = self._create_device(organization=self._create_org())
+        DeviceData.get_devicedata(str(device.pk))
+        device.organization.is_active = False
+        device.organization.save()
+        write_device_metrics(str(device.pk), self._sample_data)
+        write.assert_not_called()
+
+    @patch("openwisp_monitoring.monitoring.base.models._timeseries_batch_write")
+    @patch("openwisp_monitoring.monitoring.base.models._timeseries_write")
+    def test_blocked_metric_writes_have_no_side_effects(
+        self, timeseries_write, timeseries_batch_write
+    ):
+        device = self._create_device(organization=self._create_org())
+        metric = self._create_object_metric(content_object=device)
+        self._create_alert_settings(
+            metric=metric, custom_operator=">", custom_threshold=1, custom_tolerance=0
+        )
+        device.deactivate()
+        is_healthy = metric.is_healthy
+        is_healthy_tolerant = metric.is_healthy_tolerant
+        with catch_signal(pre_metric_write) as pre_write_handler:
+            with catch_signal(threshold_crossed) as threshold_handler:
+                metric.write(2)
+                Metric.batch_write([(metric, {"value": 2})])
+        metric.refresh_from_db()
+        self.assertEqual(metric.is_healthy, is_healthy)
+        self.assertEqual(metric.is_healthy_tolerant, is_healthy_tolerant)
+        pre_write_handler.assert_not_called()
+        threshold_handler.assert_not_called()
+        timeseries_write.assert_not_called()
+        timeseries_batch_write.assert_not_called()
 
     def test_handle_deactivate_activate_device(self):
         device_monitoring, ping, load, process_count = self._create_env()
@@ -1029,6 +1085,40 @@ class TestTransactionDeviceMonitoring(
         self.assertEqual(dm.device.management_ip, "10.10.0.5")
         self.assertTrue(ping.is_healthy)
         self.assertTrue(ping.is_healthy_tolerant)
+    @patch(
+        "openwisp_monitoring.device.api.views.DeviceMetricView.invalidate_get_device_cache"
+    )
+    @patch("openwisp_monitoring.device.base.models.AbstractDeviceData.invalidate_cache")
+    def test_handle_disabled_organization(self, mocked_dd_cache, mocked_view_cache):
+        device_monitoring, _, _, _ = self._create_env()
+        device = device_monitoring.device
+        device.management_ip = "10.10.0.5"
+        device.save()
+        self.assertEqual(device_monitoring.status, "ok")
+        wifi_client = WifiClient(mac_address="22:33:44:55:66:77")
+        wifi_client.full_clean()
+        wifi_client.save()
+        wifi_session = WifiSession(
+            device=device,
+            wifi_client=wifi_client,
+            ssid="Free Public WiFi",
+            interface_name="wlan0",
+        )
+        wifi_session.full_clean()
+        wifi_session.save()
+        org = device.organization
+        org.is_active = False
+        org.save(update_fields=["is_active"])
+        device_monitoring.refresh_from_db()
+        device.refresh_from_db()
+        wifi_session.refresh_from_db()
+        self.assertEqual(device_monitoring.status, "deactivated")
+        self.assertEqual(device.management_ip, None)
+        self.assertIsNotNone(wifi_session.stop_time)
+        mocked_dd_cache.assert_called_once()
+        self.assertEqual(mocked_dd_cache.call_args.args[0].pk, device.pk)
+        mocked_view_cache.assert_called_once()
+        self.assertEqual(mocked_view_cache.call_args.args[0].pk, device.pk)
 
     @patch("openwisp_monitoring.device.tasks.perform_check.delay")
     def test_stuck_problem_regression(self, mocked):
@@ -1109,6 +1199,20 @@ class TestWifiClientSession(TestWifiClientSessionMixin, TestCase):
     def tearDown(self):
         super().tearDown()
         cache.clear()
+
+    def test_no_wifi_session_created_for_disabled_organization(self):
+        org = self._create_org(is_active=False)
+        device = self._create_device(organization=org)
+        write_device_metrics(str(device.pk), self._sample_data)
+        self.assertEqual(WifiSession.objects.count(), 0)
+        self.assertEqual(WifiClient.objects.count(), 0)
+
+    def test_no_wifi_session_created_for_deactivated_device(self):
+        device = self._create_device(organization=self._create_org())
+        device.deactivate()
+        write_device_metrics(str(device.pk), self._sample_data)
+        self.assertEqual(WifiSession.objects.count(), 0)
+        self.assertEqual(WifiClient.objects.count(), 0)
 
     def test_wifi_client_session_created(self):
         data = self._sample_data

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -256,8 +256,11 @@ class MonitoringTestMixin(object):
         d = self._create_device(**kwargs)
         return DeviceData(pk=d.pk)
 
-    def _create_env(self):
-        d = self._create_device()
+    def _create_env(self, organization=None):
+        if organization is None:
+            d = self._create_device()
+        else:
+            d = self._create_device(organization=organization)
         dm = d.monitoring
         dm.update_status("ok")
         ping = self._create_object_metric(configuration="ping", content_object=d)
@@ -979,7 +982,9 @@ class TestTransactionDeviceMonitoring(
     def test_disabled_organization_statuses(self):
         for status in ("problem", "critical"):
             with self.subTest(status=status):
-                device_monitoring, _, _, _ = self._create_env()
+                device_monitoring, _, _, _ = self._create_env(
+                    organization=self._create_org(name=f"status-{status}")
+                )
                 device_monitoring.update_status(status)
                 DeviceMonitoring.handle_disabled_organization(
                     device_monitoring.device.organization_id
@@ -988,7 +993,9 @@ class TestTransactionDeviceMonitoring(
                 self.assertEqual(device_monitoring.status, "unknown")
 
         with self.subTest("Deactivated device remains deactivated"):
-            device_monitoring, _, _, _ = self._create_env()
+            device_monitoring, _, _, _ = self._create_env(
+                organization=self._create_org(name="deactivated-device")
+            )
             device_monitoring.device.deactivate()
             DeviceMonitoring.handle_disabled_organization(
                 device_monitoring.device.organization_id
@@ -999,7 +1006,9 @@ class TestTransactionDeviceMonitoring(
         with self.subTest(
             "Deactivation after organization handling remains deactivated"
         ):
-            device_monitoring, _, _, _ = self._create_env()
+            device_monitoring, _, _, _ = self._create_env(
+                organization=self._create_org(name="deactivated-after-handling")
+            )
             DeviceMonitoring.handle_disabled_organization(
                 device_monitoring.device.organization_id
             )
@@ -1060,7 +1069,7 @@ class TestTransactionDeviceMonitoring(
         device_monitoring.refresh_from_db()
         device.refresh_from_db()
         wifi_session.refresh_from_db()
-        self.assertEqual(device_monitoring.status, "unknown")
+        self.assertEqual(device_monitoring.status, "deactivated")
         self.assertEqual(device.management_ip, None)
         self.assertIsNotNone(wifi_session.stop_time)
         mocked_dd_cache.assert_called_once()

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -913,50 +913,6 @@ class TestDeviceMonitoring(
         self.assertEqual(self._read_metric(ping1, allow_empty=True), [])
         self.assertNotEqual(self._read_metric(ping2), [])
 
-    def test_handle_disabled_organization(self):
-        device_monitoring, ping, load, process_count = self._create_env()
-        device = device_monitoring.device
-        other_device_monitoring = self._create_device(
-            name="same-org-device",
-            mac_address="22:33:44:55:66:77",
-            organization=device.organization,
-        ).monitoring
-        same_org_ping = self._create_object_metric(
-            configuration="ping", content_object=other_device_monitoring.device
-        )
-        self._create_alert_settings(
-            metric=same_org_ping,
-            custom_operator="<",
-            custom_threshold=1,
-            custom_tolerance=0,
-        )
-        other_monitoring = self._create_device(
-            organization=self._create_org(name="other org", slug="other-org")
-        ).monitoring
-        other_monitoring.update_status("ok")
-        unrelated_ping = self._create_object_metric(
-            configuration="ping", content_object=other_monitoring.device
-        )
-        self._create_alert_settings(
-            metric=unrelated_ping,
-            custom_operator="<",
-            custom_threshold=1,
-            custom_tolerance=0,
-        )
-        device.management_ip = "10.10.0.5"
-        device.save()
-        other_device_monitoring.device.management_ip = "10.10.0.6"
-        other_device_monitoring.device.save()
-        other_monitoring.device.management_ip = "10.10.0.7"
-        other_monitoring.device.save()
-        ping.write(1)
-        same_org_ping.write(1)
-        unrelated_ping.write(1)
-        self.assertEqual(device_monitoring.status, "ok")
-        org = device.organization
-        with self.assertNumQueries(10):
-            DeviceMonitoring.handle_disabled_organization(org.pk)
-            
     def test_update_status_does_not_override_deactivated(self):
         device_monitoring, _, _, _ = self._create_env()
         device_monitoring.device.deactivate()
@@ -968,20 +924,6 @@ class TestDeviceMonitoring(
         device_monitoring.device.activate()
         device_monitoring.refresh_from_db()
         self.assertEqual(device_monitoring.status, "unknown")
-        self.assertEqual(device.management_ip, None)
-        self._assert_unknown(ping, load, process_count)
-        other_device_monitoring.refresh_from_db()
-        other_device_monitoring.device.refresh_from_db()
-        self.assertEqual(other_device_monitoring.status, "unknown")
-        self.assertIsNone(other_device_monitoring.device.management_ip)
-        self._assert_unknown(same_org_ping)
-        other_monitoring.refresh_from_db()
-        other_monitoring.device.refresh_from_db()
-        unrelated_ping.refresh_from_db()
-        self.assertEqual(other_monitoring.status, "ok")
-        self.assertEqual(other_monitoring.device.management_ip, "10.10.0.7")
-        self.assertTrue(unrelated_ping.is_healthy)
-        self.assertTrue(unrelated_ping.is_healthy_tolerant)
 
     @patch("openwisp_monitoring.device.writer.DeviceDataWriter.write")
     def test_write_device_metrics_skips_deactivated_device(self, write):
@@ -1059,6 +1001,7 @@ class TestTransactionDeviceMonitoring(
         self.assertEqual(dm.device.management_ip, "10.10.0.5")
         self.assertTrue(ping.is_healthy)
         self.assertTrue(ping.is_healthy_tolerant)
+
     @patch(
         "openwisp_monitoring.device.api.views.DeviceMetricView.invalidate_get_device_cache"
     )

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -16,7 +16,6 @@ from openwisp_utils.tests import catch_signal
 
 from ...db import timeseries_db
 from ...monitoring import settings as monitoring_settings
-from ...monitoring.signals import pre_metric_write, threshold_crossed
 from .. import settings as app_settings
 from ..signals import health_status_changed
 from ..tasks import (
@@ -1000,31 +999,6 @@ class TestDeviceMonitoring(
         device.organization.save()
         write_device_metrics(str(device.pk), self._sample_data)
         write.assert_not_called()
-
-    @patch("openwisp_monitoring.monitoring.base.models._timeseries_batch_write")
-    @patch("openwisp_monitoring.monitoring.base.models._timeseries_write")
-    def test_blocked_metric_writes_have_no_side_effects(
-        self, timeseries_write, timeseries_batch_write
-    ):
-        device = self._create_device(organization=self._create_org())
-        metric = self._create_object_metric(content_object=device)
-        self._create_alert_settings(
-            metric=metric, custom_operator=">", custom_threshold=1, custom_tolerance=0
-        )
-        device.deactivate()
-        is_healthy = metric.is_healthy
-        is_healthy_tolerant = metric.is_healthy_tolerant
-        with catch_signal(pre_metric_write) as pre_write_handler:
-            with catch_signal(threshold_crossed) as threshold_handler:
-                metric.write(2)
-                Metric.batch_write([(metric, {"value": 2})])
-        metric.refresh_from_db()
-        self.assertEqual(metric.is_healthy, is_healthy)
-        self.assertEqual(metric.is_healthy_tolerant, is_healthy_tolerant)
-        pre_write_handler.assert_not_called()
-        threshold_handler.assert_not_called()
-        timeseries_write.assert_not_called()
-        timeseries_batch_write.assert_not_called()
 
     def test_handle_deactivate_activate_device(self):
         device_monitoring, ping, load, process_count = self._create_env()

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -1029,7 +1029,7 @@ class TestTransactionDeviceMonitoring(
         device_monitoring.refresh_from_db()
         device.refresh_from_db()
         wifi_session.refresh_from_db()
-        self.assertEqual(device_monitoring.status, "deactivated")
+        self.assertEqual(device_monitoring.status, "unknown")
         self.assertEqual(device.management_ip, None)
         self.assertIsNotNone(wifi_session.stop_time)
         mocked_dd_cache.assert_called_once()

--- a/openwisp_monitoring/device/tests/test_transactions.py
+++ b/openwisp_monitoring/device/tests/test_transactions.py
@@ -73,6 +73,12 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
     def test_config_status_changed_receiver_deactivated_device(self, mock_method):
         c = self._create_config(status="applied", organization=self._create_org())
         c.device.deactivate()
+        c.config = {"general": {"description": "test"}}
+        c.full_clean()
+        with catch_signal(config_status_changed) as handler:
+            c.save()
+            handler.assert_called_once()
+        self.assertEqual(c.status, "modified")
         mock_method.assert_not_called()
 
     @patch.object(Check, "perform_check")

--- a/openwisp_monitoring/device/tests/test_transactions.py
+++ b/openwisp_monitoring/device/tests/test_transactions.py
@@ -36,6 +36,91 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
         self.assertEqual(c.status, "modified")
         self.assertEqual(mock_method.call_count, 1)
 
+    @patch("openwisp_monitoring.device.tasks.handle_disabled_organization.delay")
+    def test_organization_disabled_signal_dispatch(self, mocked_task):
+        with self.subTest("creating a disabled organization sends no signal"):
+            org = self._create_org(is_active=False)
+            mocked_task.assert_not_called()
+        with self.subTest("disabling an active organization dispatches once"):
+            org.is_active = True
+            org.save()
+            org.is_active = False
+            org.save()
+            mocked_task.assert_called_once_with(str(org.pk))
+        with self.subTest("re-saving an already disabled organization is a no-op"):
+            mocked_task.reset_mock()
+            org.save()
+            mocked_task.assert_not_called()
+        with self.subTest("re-enabling an organization does not dispatch"):
+            org.is_active = True
+            org.save()
+            mocked_task.assert_not_called()
+
+    @patch("openwisp_monitoring.check.tasks.perform_check.delay")
+    def test_config_status_changed_receiver_disabled_organization(self, mock_method):
+        c = self._create_config(
+            status="applied", organization=self._create_org(is_active=False)
+        )
+        c.config = {"general": {"description": "test"}}
+        c.full_clean()
+        with catch_signal(config_status_changed) as handler:
+            c.save()
+            handler.assert_called_once()
+        self.assertEqual(c.status, "modified")
+        mock_method.assert_not_called()
+
+    @patch("openwisp_monitoring.check.tasks.perform_check.delay")
+    def test_config_status_changed_receiver_deactivated_device(self, mock_method):
+        c = self._create_config(status="applied", organization=self._create_org())
+        c.device.deactivate()
+        mock_method.assert_not_called()
+
+    @patch.object(Check, "perform_check")
+    def test_is_working_changed_disabled_organization(self, perform_check):
+        org = self._create_org()
+        d = self._create_device(organization=org)
+        dm = d.monitoring
+        dm.status = "ok"
+        dm.save()
+        self._delete_non_ping_checks()
+        org.is_active = False
+        org.save()
+        c = Credentials.objects.create()
+        dc = DeviceConnection.objects.create(credentials=c, device=d)
+        dc.is_working = False
+        dc.save()
+        perform_check.assert_not_called()
+
+    @patch.object(Check, "perform_check")
+    def test_is_working_changed_deactivated_device(self, perform_check):
+        d = self._create_device(organization=self._create_org())
+        dm = d.monitoring
+        dm.status = "ok"
+        dm.save()
+        self._delete_non_ping_checks()
+        d.deactivate()
+        c = Credentials.objects.create()
+        dc = DeviceConnection.objects.create(credentials=c, device=d)
+        dc.is_working = False
+        dc.save()
+        perform_check.assert_not_called()
+
+    @patch.object(Check, "perform_check")
+    def test_trigger_device_critical_checks_disabled_organization(self, perform_check):
+        dm = self._create_device_monitoring()
+        org = dm.device.organization
+        org.is_active = False
+        org.save()
+        trigger_device_critical_checks.delay(dm.device.pk)
+        perform_check.assert_not_called()
+
+    @patch.object(Check, "perform_check")
+    def test_trigger_device_critical_checks_deactivated_device(self, perform_check):
+        dm = self._create_device_monitoring()
+        dm.device.deactivate()
+        trigger_device_critical_checks.delay(dm.device.pk)
+        perform_check.assert_not_called()
+
     @patch.object(Ping, "_command", return_value=_FPING_REACHABLE)
     def test_trigger_device_recovery_task(self, mocked_method):
         d = self._create_device(organization=self._create_org())

--- a/openwisp_monitoring/monitoring/admin.py
+++ b/openwisp_monitoring/monitoring/admin.py
@@ -6,6 +6,8 @@ from swapper import load_model
 
 from openwisp_utils.admin import TimeReadonlyAdminMixin
 
+from ..admin import DisabledOrgReadOnlyInlineMixin, DisabledOrgReadOnlyMixin
+
 Chart = load_model("monitoring", "Chart")
 Metric = load_model("monitoring", "Metric")
 AlertSettings = load_model("monitoring", "AlertSettings")
@@ -25,13 +27,15 @@ class AlertSettingsForm(ModelForm):
         super().__init__(*args, **kwargs)
 
 
-class AlertSettingsInline(TimeReadonlyAdminMixin, admin.StackedInline):
+class AlertSettingsInline(
+    DisabledOrgReadOnlyInlineMixin, TimeReadonlyAdminMixin, admin.StackedInline
+):
     model = AlertSettings
     form = AlertSettingsForm
     extra = 0
 
 
-class ChartInline(admin.StackedInline):
+class ChartInline(DisabledOrgReadOnlyInlineMixin, admin.StackedInline):
     model = Chart
     extra = 0
     template = "admin/chart_inline.html"
@@ -39,7 +43,7 @@ class ChartInline(admin.StackedInline):
 
 
 @admin.register(Metric)
-class MetricAdmin(TimeReadonlyAdminMixin, VersionAdmin):
+class MetricAdmin(DisabledOrgReadOnlyMixin, TimeReadonlyAdminMixin, VersionAdmin):
     list_display = ["__str__", "created", "modified"]
     readonly_fields = ["is_healthy"]
     search_fields = ["name"]

--- a/openwisp_monitoring/monitoring/admin.py
+++ b/openwisp_monitoring/monitoring/admin.py
@@ -6,7 +6,11 @@ from swapper import load_model
 
 from openwisp_utils.admin import TimeReadonlyAdminMixin
 
-from ..admin import DisabledOrgReadOnlyInlineMixin, DisabledOrgReadOnlyMixin
+from ..admin import (
+    DisabledOrgReadOnlyInlineMixin,
+    DisabledOrgReadOnlyMixin,
+    MonitoringBlockedObjectFormMixin,
+)
 
 Chart = load_model("monitoring", "Chart")
 Metric = load_model("monitoring", "Metric")
@@ -27,6 +31,10 @@ class AlertSettingsForm(ModelForm):
         super().__init__(*args, **kwargs)
 
 
+class MetricForm(MonitoringBlockedObjectFormMixin, ModelForm):
+    pass
+
+
 class AlertSettingsInline(
     DisabledOrgReadOnlyInlineMixin, TimeReadonlyAdminMixin, admin.StackedInline
 ):
@@ -44,6 +52,7 @@ class ChartInline(DisabledOrgReadOnlyInlineMixin, admin.StackedInline):
 
 @admin.register(Metric)
 class MetricAdmin(DisabledOrgReadOnlyMixin, TimeReadonlyAdminMixin, VersionAdmin):
+    form = MetricForm
     list_display = ["__str__", "created", "modified"]
     readonly_fields = ["is_healthy"]
     search_fields = ["name"]

--- a/openwisp_monitoring/monitoring/api/views.py
+++ b/openwisp_monitoring/monitoring/api/views.py
@@ -167,7 +167,7 @@ class DashboardTimeseriesView(ProtectedAPIMixin, MonitoringApiViewMixin, APIView
     def _get_user_managed_orgs(self, request):
         """Return list of dictionary containing organization name and slug in select2 compatible format."""
         orgs = []
-        qs = Organization.objects.only("slug", "name")
+        qs = Organization.objects.only("slug", "name", "is_active")
         if not request.user.is_superuser:
             if len(request.user.organizations_managed) > 1:
                 qs = qs.filter(pk__in=request.user.organizations_managed)

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -27,6 +27,7 @@ from openwisp_utils.base import TimeStampedEditableModel
 
 from ...db import default_chart_query, timeseries_db
 from ...settings import CACHE_TIMEOUT, DEFAULT_CHART_TIME
+from ...utils import is_monitoring_blocked
 from .. import settings as app_settings
 from ..configuration import (
     CHART_CONFIGURATION_CHOICES,
@@ -499,9 +500,15 @@ class AbstractMetric(TimeStampedEditableModel):
 
     def _notify_users(self, notification_type, alert_settings):
         """creates notifications for users"""
-        opts = dict(sender=self, type=notification_type, action_object=alert_settings)
-        if self.content_object is not None:
-            opts["target"] = self.content_object
+        content_object = self.content_object
+        if is_monitoring_blocked(content_object):
+            return
+        opts = dict(
+            sender=self,
+            type=notification_type,
+            action_object=alert_settings,
+            target=content_object,
+        )
         notify.send(**opts)
 
 

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -486,12 +486,13 @@ class AbstractMetric(TimeStampedEditableModel):
         error_dict = {}
         write_data = []
         for metric, kwargs in raw_data:
-            if is_monitoring_blocked(metric.content_object):
-                continue
             try:
-                write_data.append(metric.write(**kwargs, write=False))
+                result = metric.write(**kwargs, write=False)
             except ValueError as error:
                 error_dict[metric.key] = str(error)
+                continue
+            if result is not None:
+                write_data.append(result)
         if write_data:
             _timeseries_batch_write(write_data)
         if error_dict:
@@ -506,8 +507,6 @@ class AbstractMetric(TimeStampedEditableModel):
     def _notify_users(self, notification_type, alert_settings):
         """creates notifications for users"""
         content_object = self.content_object
-        if is_monitoring_blocked(content_object):
-            return
         opts = dict(
             sender=self,
             type=notification_type,

--- a/openwisp_monitoring/monitoring/base/models.py
+++ b/openwisp_monitoring/monitoring/base/models.py
@@ -426,6 +426,8 @@ class AbstractMetric(TimeStampedEditableModel):
         write=True,
     ):
         """write timeseries data"""
+        if is_monitoring_blocked(self.content_object):
+            return
         values = {self.field_name: value}
         if extra_values and isinstance(extra_values, dict):
             for key in extra_values.keys():
@@ -484,11 +486,14 @@ class AbstractMetric(TimeStampedEditableModel):
         error_dict = {}
         write_data = []
         for metric, kwargs in raw_data:
+            if is_monitoring_blocked(metric.content_object):
+                continue
             try:
                 write_data.append(metric.write(**kwargs, write=False))
             except ValueError as error:
                 error_dict[metric.key] = str(error)
-        _timeseries_batch_write(write_data)
+        if write_data:
+            _timeseries_batch_write(write_data)
         if error_dict:
             raise ValueError(error_dict)
 

--- a/openwisp_monitoring/monitoring/tasks.py
+++ b/openwisp_monitoring/monitoring/tasks.py
@@ -6,43 +6,57 @@ from openwisp_utils.tasks import OpenwispCeleryTask
 
 from ..db import timeseries_db
 from ..db.exceptions import TimeseriesWriteException
+from ..utils import is_monitoring_blocked
 from .settings import RETRY_OPTIONS
 from .signals import post_metric_write
+
+
+def _get_metric(metric):
+    if not metric:
+        return None
+    Metric = load_model("monitoring", "Metric")
+    if isinstance(metric, Metric):
+        return metric
+    try:
+        return Metric.objects.select_related("alertsettings").get(pk=metric)
+    except ObjectDoesNotExist:
+        return None
 
 
 def _metric_post_write(name, values, metric, check_threshold_kwargs=None, **kwargs):
     if not metric or not check_threshold_kwargs:
         return
-    try:
-        Metric = load_model("monitoring", "Metric")
-        if not isinstance(metric, Metric):
-            metric = Metric.objects.select_related("alertsettings").get(pk=metric)
-    except ObjectDoesNotExist:
+    metric = _get_metric(metric)
+    if metric is None:
         # The metric can be deleted by the time threshold is being checked.
         # This can happen as the task is being run async.
-        pass
-    else:
-        metric.check_threshold(**check_threshold_kwargs)
-        signal_kwargs = dict(
-            sender=metric.__class__,
-            metric=metric,
-            values=values,
-            time=kwargs.get("timestamp"),
-            current=kwargs.get("current", "False"),
-        )
-        post_metric_write.send(**signal_kwargs)
+        return
+    if is_monitoring_blocked(metric.content_object):
+        return
+    metric.check_threshold(**check_threshold_kwargs)
+    signal_kwargs = dict(
+        sender=metric.__class__,
+        metric=metric,
+        values=values,
+        time=kwargs.get("timestamp"),
+        current=kwargs.get("current", "False"),
+    )
+    post_metric_write.send(**signal_kwargs)
 
 
 @shared_task(
     base=OpenwispCeleryTask,
     bind=True,
     autoretry_for=(TimeseriesWriteException,),
-    **RETRY_OPTIONS
+    **RETRY_OPTIONS,
 )
 def timeseries_write(
     self, name, values, metric=None, check_threshold_kwargs=None, **kwargs
 ):
     """Writes and retries with exponential backoff on failures."""
+    metric = _get_metric(metric)
+    if metric is not None and is_monitoring_blocked(metric.content_object):
+        return
     timeseries_db.write(name, values, **kwargs)
     _metric_post_write(name, values, metric, check_threshold_kwargs, **kwargs)
 
@@ -59,7 +73,7 @@ def _timeseries_write(name, values, metric=None, check_threshold_kwargs=None, **
         values=values,
         metric=metric,
         check_threshold_kwargs=check_threshold_kwargs,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -67,7 +81,7 @@ def _timeseries_write(name, values, metric=None, check_threshold_kwargs=None, **
     base=OpenwispCeleryTask,
     bind=True,
     autoretry_for=(TimeseriesWriteException,),
-    **RETRY_OPTIONS
+    **RETRY_OPTIONS,
 )
 def timeseries_batch_write(self, data):
     """Writes data in batches.
@@ -75,6 +89,16 @@ def timeseries_batch_write(self, data):
     Similar to timeseries_write function above, but operates on list of
     metric data (batch operation)
     """
+    data = [
+        metric_data
+        for metric_data in data
+        if not (
+            (metric := _get_metric(metric_data.get("metric")))
+            and is_monitoring_blocked(metric.content_object)
+        )
+    ]
+    if not data:
+        return
     timeseries_db.batch_write(data)
     for metric_data in data:
         _metric_post_write(**metric_data)

--- a/openwisp_monitoring/monitoring/tasks.py
+++ b/openwisp_monitoring/monitoring/tasks.py
@@ -31,8 +31,6 @@ def _metric_post_write(name, values, metric, check_threshold_kwargs=None, **kwar
         # The metric can be deleted by the time threshold is being checked.
         # This can happen as the task is being run async.
         return
-    if is_monitoring_blocked(metric.content_object):
-        return
     metric.check_threshold(**check_threshold_kwargs)
     signal_kwargs = dict(
         sender=metric.__class__,
@@ -77,6 +75,35 @@ def _timeseries_write(name, values, metric=None, check_threshold_kwargs=None, **
     )
 
 
+def _filter_blocked_batch_data(data):
+    """Drops entries whose target is blocked, checking each unique target once."""
+    Metric = load_model("monitoring", "Metric")
+    pks_to_fetch = {
+        metric_data["metric"]
+        for metric_data in data
+        if metric_data.get("metric") and not isinstance(metric_data["metric"], Metric)
+    }
+    fetched_metrics = Metric.objects.in_bulk(pks_to_fetch) if pks_to_fetch else {}
+    blocked_targets = {}
+    filtered_data = []
+    for metric_data in data:
+        raw_metric = metric_data.get("metric")
+        metric = (
+            raw_metric
+            if isinstance(raw_metric, Metric)
+            else fetched_metrics.get(raw_metric)
+        )
+        if metric is None:
+            filtered_data.append(metric_data)
+            continue
+        target_key = (metric.content_type_id, metric.object_id)
+        if target_key not in blocked_targets:
+            blocked_targets[target_key] = is_monitoring_blocked(metric.content_object)
+        if not blocked_targets[target_key]:
+            filtered_data.append(metric_data)
+    return filtered_data
+
+
 @shared_task(
     base=OpenwispCeleryTask,
     bind=True,
@@ -89,14 +116,9 @@ def timeseries_batch_write(self, data):
     Similar to timeseries_write function above, but operates on list of
     metric data (batch operation)
     """
-    data = [
-        metric_data
-        for metric_data in data
-        if not (
-            (metric := _get_metric(metric_data.get("metric")))
-            and is_monitoring_blocked(metric.content_object)
-        )
-    ]
+    if not data:
+        return
+    data = _filter_blocked_batch_data(data)
     if not data:
         return
     timeseries_db.batch_write(data)

--- a/openwisp_monitoring/monitoring/tests/test_admin.py
+++ b/openwisp_monitoring/monitoring/tests/test_admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from swapper import load_model
@@ -17,6 +18,89 @@ class TestAdmin(TestDeviceMonitoringMixin, TestCase):
         User = get_user_model()
         u = User.objects.create_superuser("admin", "admin", "test@test.com")
         self.client.force_login(u)
+
+    def _metric_data(self, device, metric=None):
+        data = {
+            "name": metric.name if metric else "Test metric",
+            "key": "",
+            "field_name": "",
+            "configuration": metric.configuration if metric else "test_metric",
+            "content_type": ContentType.objects.get_for_model(device).pk,
+            "object_id": str(device.pk),
+            "main_tags": "{}",
+            "extra_tags": "{}",
+        }
+        for prefix in ("chart_set", "alertsettings"):
+            data.update(
+                {
+                    f"{prefix}-TOTAL_FORMS": "0",
+                    f"{prefix}-INITIAL_FORMS": "0",
+                    f"{prefix}-MIN_NUM_FORMS": "0",
+                    f"{prefix}-MAX_NUM_FORMS": "1000",
+                }
+            )
+        return data
+
+    def _post_metric(self, device, metric=None):
+        if metric:
+            url = reverse(
+                f"admin:{Metric._meta.app_label}_{Metric._meta.model_name}_change",
+                args=[metric.pk],
+            )
+        else:
+            url = reverse(
+                f"admin:{Metric._meta.app_label}_{Metric._meta.model_name}_add"
+            )
+        return self.client.post(url, self._metric_data(device, metric))
+
+    def test_metric_admin_form_blocks_deactivated_device(self):
+        source_device = self._create_device(
+            organization=self._create_org(name="source org", slug="source-org")
+        )
+        metric = self._create_object_metric(content_object=source_device)
+        device = self._create_device(
+            name="blocked-device",
+            mac_address="00:11:22:33:44:66",
+            organization=self._get_org(),
+        )
+        device.deactivate()
+        self._login_admin()
+        for instance in (None, metric):
+            with self.subTest(instance=instance is not None):
+                response = self._post_metric(device, metric=instance)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, "Monitoring is blocked")
+
+    def test_metric_admin_form_blocks_disabled_organization(self):
+        source_device = self._create_device(
+            organization=self._create_org(name="source org", slug="source-org")
+        )
+        metric = self._create_object_metric(content_object=source_device)
+        organization = self._get_org()
+        device = self._create_device(
+            name="disabled-device",
+            mac_address="00:11:22:33:44:66",
+            organization=self._get_org(),
+        )
+        organization.is_active = False
+        organization.save()
+        self._login_admin()
+        for instance in (None, metric):
+            with self.subTest(instance=instance is not None):
+                response = self._post_metric(device, metric=instance)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, "Monitoring is blocked")
+
+    def test_metric_admin_form_allows_active_device(self):
+        device = self._create_device(organization=self._create_org())
+        metric = self._create_object_metric(content_object=device)
+        self._login_admin()
+        response = self._post_metric(device, metric)
+        self.assertEqual(
+            response.status_code,
+            302,
+            response.content.decode(),
+        )
 
     def test_metric_admin(self):
         m = self._create_general_metric()

--- a/openwisp_monitoring/monitoring/tests/test_admin.py
+++ b/openwisp_monitoring/monitoring/tests/test_admin.py
@@ -1,11 +1,15 @@
+from django.contrib import admin
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from swapper import load_model
 
-from . import TestMonitoringMixin
+from ...device.tests import TestDeviceMonitoringMixin
+
+Metric = load_model("monitoring", "Metric")
 
 
-class TestAdmin(TestMonitoringMixin, TestCase):
+class TestAdmin(TestDeviceMonitoringMixin, TestCase):
     app_label = "monitoring"
     check_app_label = "check"
 
@@ -34,6 +38,39 @@ class TestAdmin(TestMonitoringMixin, TestCase):
         self.assertContains(r, '<option value="&lt;" selected>less than</option>')
         self.assertContains(r, 'name="alertsettings-0-custom_threshold" value="1"')
         self.assertContains(r, 'name="alertsettings-0-custom_tolerance" value="30"')
+
+    def test_metric_admin_disabled_organization_read_only(self):
+        device = self._create_device(organization=self._create_org(is_active=False))
+        metric = self._create_object_metric(content_object=device)
+        self._create_alert_settings(metric=metric)
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        metric_admin = admin.site._registry[Metric]
+        self.assertFalse(metric_admin.has_change_permission(request, metric))
+        self.assertTrue(metric_admin.has_delete_permission(request, metric))
+        for inline_class in metric_admin.inlines:
+            with self.subTest(inline=inline_class.__name__):
+                inline = inline_class(Metric, admin.site)
+                self.assertFalse(inline.has_add_permission(request, metric))
+                self.assertFalse(inline.has_change_permission(request, metric))
+                self.assertTrue(inline.has_delete_permission(request, metric))
+
+    def test_metric_admin_deactivated_device_read_only(self):
+        device = self._create_device(organization=self._create_org())
+        device.deactivate()
+        metric = self._create_object_metric(content_object=device)
+        self._create_alert_settings(metric=metric)
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        metric_admin = admin.site._registry[Metric]
+        self.assertFalse(metric_admin.has_change_permission(request, metric))
+        self.assertTrue(metric_admin.has_delete_permission(request, metric))
+        for inline_class in metric_admin.inlines:
+            with self.subTest(inline=inline_class.__name__):
+                inline = inline_class(Metric, admin.site)
+                self.assertFalse(inline.has_add_permission(request, metric))
+                self.assertFalse(inline.has_change_permission(request, metric))
+                self.assertTrue(inline.has_delete_permission(request, metric))
 
     def test_admin_menu_groups(self):
         # Test menu group (openwisp-utils menu group) for Metric and Check models

--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -337,14 +337,15 @@ class TestModels(TestMonitoringMixin, TestCase):
 
     def test_metric_post_write_signals_emitted(self):
         om = self._create_object_metric()
+        signal_time = timezone.now()
         with catch_signal(post_metric_write) as handler:
-            om.write(3, current=True, time=start_time)
+            om.write(3, current=True, time=signal_time)
             handler.assert_called_once_with(
                 sender=Metric,
                 metric=om,
                 values={om.field_name: 3},
                 signal=post_metric_write,
-                time=start_time.isoformat(),
+                time=signal_time.isoformat(),
                 current=True,
             )
 

--- a/openwisp_monitoring/monitoring/tests/test_models.py
+++ b/openwisp_monitoring/monitoring/tests/test_models.py
@@ -13,9 +13,11 @@ from swapper import load_model
 
 from openwisp_utils.tests import catch_signal
 
+from ...device.tests import DeviceMonitoringTestCase
 from .. import settings as app_settings
 from ..exceptions import InvalidChartConfigException, InvalidMetricConfigException
 from ..signals import post_metric_write, pre_metric_write, threshold_crossed
+from ..tasks import timeseries_batch_write, timeseries_write
 from . import TestMonitoringMixin
 
 start_time = timezone.now()
@@ -471,3 +473,84 @@ class TestModels(TestMonitoringMixin, TestCase):
         self.assertEqual(m.field_name, "test_related_3")
         # alert_field same as field_name
         self.assertEqual(m.alert_field, "test_related_3")
+
+
+class TestBlockedMetricWrites(DeviceMonitoringTestCase):
+    def _create_blocked_metric(self):
+        device = self._create_device(organization=self._create_org())
+        metric = self._create_object_metric(content_object=device)
+        device.deactivate()
+        return metric
+
+    @patch("openwisp_monitoring.monitoring.base.models._timeseries_write")
+    @patch("openwisp_monitoring.monitoring.base.models.pre_metric_write.send")
+    def test_blocked_metric_write_has_no_side_effects(
+        self, mocked_signal, mocked_write
+    ):
+        metric = self._create_blocked_metric()
+        metric.is_healthy = True
+        metric.is_healthy_tolerant = True
+        metric.save(update_fields=["is_healthy", "is_healthy_tolerant"])
+        self.assertIsNone(metric.write(1))
+        metric.refresh_from_db()
+        self.assertEqual(metric.is_healthy, True)
+        self.assertEqual(metric.is_healthy_tolerant, True)
+        mocked_signal.assert_not_called()
+        mocked_write.assert_not_called()
+
+    @patch("openwisp_monitoring.monitoring.base.models._timeseries_batch_write")
+    def test_batch_write_skips_blocked_metrics(self, mocked_write):
+        blocked_metric = self._create_blocked_metric()
+        active_metric = self._create_object_metric(
+            content_object=self._create_device(
+                name="active-device",
+                mac_address="00:11:22:33:44:66",
+                organization=self._get_org(),
+            )
+        )
+        Metric.batch_write(
+            [(blocked_metric, {"value": 1}), (active_metric, {"value": 1})]
+        )
+        mocked_write.assert_called_once()
+        self.assertEqual(len(mocked_write.call_args.args[0]), 1)
+        self.assertEqual(mocked_write.call_args.args[0][0]["metric"], active_metric)
+
+    @patch("openwisp_monitoring.monitoring.tasks.post_metric_write.send")
+    @patch("openwisp_monitoring.monitoring.tasks.timeseries_db.write")
+    def test_queued_metric_write_revalidates_target(self, mocked_write, mocked_signal):
+        metric = self._create_object_metric(
+            content_object=self._create_device(organization=self._create_org())
+        )
+        metric.is_healthy = True
+        metric.is_healthy_tolerant = True
+        metric.save(update_fields=["is_healthy", "is_healthy_tolerant"])
+        data = metric.write(1, write=False)
+        data["metric"] = metric.pk
+        metric.content_object.organization.is_active = False
+        metric.content_object.organization.save(update_fields=["is_active"])
+        timeseries_write.run(**data)
+        metric.refresh_from_db()
+        self.assertEqual(metric.is_healthy, True)
+        self.assertEqual(metric.is_healthy_tolerant, True)
+        mocked_write.assert_not_called()
+        mocked_signal.assert_not_called()
+
+    @patch("openwisp_monitoring.monitoring.tasks.post_metric_write.send")
+    @patch("openwisp_monitoring.monitoring.tasks.timeseries_db.batch_write")
+    def test_queued_metric_batch_revalidates_target(self, mocked_write, mocked_signal):
+        metric = self._create_object_metric(
+            content_object=self._create_device(organization=self._create_org())
+        )
+        metric.is_healthy = True
+        metric.is_healthy_tolerant = True
+        metric.save(update_fields=["is_healthy", "is_healthy_tolerant"])
+        data = metric.write(1, write=False)
+        data["metric"] = metric.pk
+        metric.content_object.organization.is_active = False
+        metric.content_object.organization.save(update_fields=["is_active"])
+        timeseries_batch_write.run([data])
+        metric.refresh_from_db()
+        self.assertEqual(metric.is_healthy, True)
+        self.assertEqual(metric.is_healthy_tolerant, True)
+        mocked_write.assert_not_called()
+        mocked_signal.assert_not_called()

--- a/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
+++ b/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
@@ -518,6 +518,7 @@ class TestMonitoringNotifications(DeviceMonitoringTestCase):
             m.write(99)
         m.refresh_from_db()
         self.assertEqual(m.is_healthy, False)
+        self.assertEqual(m.is_healthy_tolerant, False)
         self.assertEqual(Notification.objects.count(), 0)
 
     def test_alerts_deactivated_device(self):
@@ -534,6 +535,7 @@ class TestMonitoringNotifications(DeviceMonitoringTestCase):
             m.write(99)
         m.refresh_from_db()
         self.assertEqual(m.is_healthy, False)
+        self.assertEqual(m.is_healthy_tolerant, False)
         self.assertEqual(Notification.objects.count(), 0)
 
     def test_alert_field(self):

--- a/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
+++ b/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
@@ -517,8 +517,8 @@ class TestMonitoringNotifications(DeviceMonitoringTestCase):
         with freeze_time(ten_minutes_after):
             m.write(99)
         m.refresh_from_db()
-        self.assertEqual(m.is_healthy, False)
-        self.assertEqual(m.is_healthy_tolerant, False)
+        self.assertEqual(m.is_healthy, True)
+        self.assertEqual(m.is_healthy_tolerant, True)
         self.assertEqual(Notification.objects.count(), 0)
 
     def test_alerts_deactivated_device(self):
@@ -534,8 +534,8 @@ class TestMonitoringNotifications(DeviceMonitoringTestCase):
         with freeze_time(ten_minutes_after):
             m.write(99)
         m.refresh_from_db()
-        self.assertEqual(m.is_healthy, False)
-        self.assertEqual(m.is_healthy_tolerant, False)
+        self.assertEqual(m.is_healthy, True)
+        self.assertEqual(m.is_healthy_tolerant, True)
         self.assertEqual(Notification.objects.count(), 0)
 
     def test_alert_field(self):

--- a/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
+++ b/openwisp_monitoring/monitoring/tests/test_monitoring_notifications.py
@@ -505,6 +505,37 @@ class TestMonitoringNotifications(DeviceMonitoringTestCase):
         self.assertEqual(d.monitoring.status, "problem")
         self.assertEqual(Notification.objects.count(), 0)
 
+    def test_alerts_disabled_organization(self):
+        self._create_admin()
+        d = self._create_device(organization=self._create_org(is_active=False))
+        m = self._create_general_metric(name="load", content_object=d)
+        self._create_alert_settings(
+            metric=m, custom_operator=">", custom_threshold=90, custom_tolerance=1
+        )
+        with freeze_time(start_time):
+            m.write(99)
+        with freeze_time(ten_minutes_after):
+            m.write(99)
+        m.refresh_from_db()
+        self.assertEqual(m.is_healthy, False)
+        self.assertEqual(Notification.objects.count(), 0)
+
+    def test_alerts_deactivated_device(self):
+        self._create_admin()
+        d = self._create_device(organization=self._create_org())
+        d.deactivate()
+        m = self._create_general_metric(name="load", content_object=d)
+        self._create_alert_settings(
+            metric=m, custom_operator=">", custom_threshold=90, custom_tolerance=1
+        )
+        with freeze_time(start_time):
+            m.write(99)
+        with freeze_time(ten_minutes_after):
+            m.write(99)
+        m.refresh_from_db()
+        self.assertEqual(m.is_healthy, False)
+        self.assertEqual(Notification.objects.count(), 0)
+
     def test_alert_field(self):
         admin = self._create_admin()
 

--- a/openwisp_monitoring/utils.py
+++ b/openwisp_monitoring/utils.py
@@ -33,3 +33,21 @@ def retry(method):
                     raise err
 
     return wrapper
+
+
+def is_write_blocked(content_type, object_id):
+    """Return whether a generic relation targets a blocked object."""
+    if content_type is None or not object_id:
+        return False
+    model = content_type.model_class()
+    if model is None:
+        return False
+    field_names = {field.name for field in model._meta.get_fields()}
+    if "_is_deactivated" not in field_names and "organization" not in field_names:
+        return False
+    queryset = model._default_manager.filter(pk=object_id)
+    if "_is_deactivated" in field_names:
+        queryset = queryset.filter(_is_deactivated=False)
+    if "organization" in field_names:
+        queryset = queryset.filter(organization__is_active=True)
+    return not queryset.exists()

--- a/openwisp_monitoring/utils.py
+++ b/openwisp_monitoring/utils.py
@@ -35,19 +35,18 @@ def retry(method):
     return wrapper
 
 
-def is_write_blocked(content_type, object_id):
-    """Return whether a generic relation targets a blocked object."""
-    if content_type is None or not object_id:
+def is_monitoring_blocked(obj):
+    """
+    Whether monitoring operations must be skipped for a related object.
+
+    Duck-typed so it works across generic relations: a deactivated
+    device or a device belonging to a disabled organization blocks
+    monitoring, everything else (None, non-device content objects) does
+    not.
+    """
+    if obj is None:
         return False
-    model = content_type.model_class()
-    if model is None:
-        return False
-    field_names = {field.name for field in model._meta.get_fields()}
-    if "_is_deactivated" not in field_names and "organization" not in field_names:
-        return False
-    queryset = model._default_manager.filter(pk=object_id)
-    if "_is_deactivated" in field_names:
-        queryset = queryset.filter(_is_deactivated=False)
-    if "organization" in field_names:
-        queryset = queryset.filter(organization__is_active=True)
-    return not queryset.exists()
+    if hasattr(obj, "is_deactivated") and obj.is_deactivated():
+        return True
+    organization = getattr(obj, "organization", None)
+    return organization is not None and not organization.is_active


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

<!-- Please [open a new issue](https://github.com/openwisp/openwisp-monitoring/issues/new/choose) if there isn't an existing issue yet. -->

Closes #811
Closes #812

## Description of Changes

Skip monitoring on deactivated devices and disabled organizations

## Blockers 

- [ ] https://github.com/openwisp/openwisp-users/pull/542
- [ ] https://github.com/openwisp/openwisp-controller/pull/1456

## Screenshots 

**Charts are rendered for a deactivated device from disabled organization**

<img width="1354" height="1848" alt="image" src="https://github.com/user-attachments/assets/7ec9210d-c4c9-41be-a923-942c8407020d" />

**Check inline on the device page is rendered as readonly**

<img width="1354" height="946" alt="image" src="https://github.com/user-attachments/assets/c7511821-a7ab-4780-bb9f-ee3bdf03a093" />


**AlertSettings inline on the device page is rendered as readonly**

<img width="1354" height="2417" alt="image" src="https://github.com/user-attachments/assets/aa97c104-ee4c-4936-b82d-735c6d174cb2" />


**Checks related to disabed org / deactivated devices are rendered as readonly**

<img width="1354" height="829" alt="image" src="https://github.com/user-attachments/assets/c149deb3-aff0-4d5a-a305-21344b8cfad7" />

**Metrics related to disabled org / deactivated device are rendered as readonly**

<img width="1354" height="2046" alt="image" src="https://github.com/user-attachments/assets/c01f31bf-1f58-4cf0-b4ed-82f747735c54" />
