### PR TITLE
[fix] Reset metric health for unknown devices #841

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ Core code lives in `openwisp_monitoring/`:
 
 If instructions conflict, repository config and CI workflows win first, official docs next, and this file is supplemental.
 
+## Repository Rules
+
+- `DeviceMonitoring.status == "unknown"` means every metric related to that device has unknown health. Always use `DeviceMonitoring.update_status()` to change a device status. For large sets of devices, iterate over `DeviceMonitoring` records with `iterator()` and call `update_status()` on each record. Do not use `QuerySet.update()` for device monitoring statuses.
+
 ## Contributing Guidelines
 
 - Before editing, inspect the relevant implementation, tests, documentation, and configuration. Follow existing repository patterns and do not invent behavior or requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ If instructions conflict, repository config and CI workflows win first, official
 
 ## Repository Rules
 
-- `DeviceMonitoring.status == "unknown"` means every metric related to that device has unknown health. Always use `DeviceMonitoring.update_status()` to change a device status. For large sets of devices, iterate over `DeviceMonitoring` records with `iterator()` and call `update_status()` on each record. Do not use `QuerySet.update()` for device monitoring statuses.
+- `DeviceMonitoring.status == "unknown"` means every metric related to that device has unknown health. Use `DeviceMonitoring.update_status()` to change a device status whenever possible. A performance-critical bulk update may set a status directly with `QuerySet.update()`, but a background task must subsequently iterate through the affected `DeviceMonitoring` records with `iterator()` and call `update_status()` to perform its remaining cleanup operations.
 
 ## Contributing Guidelines
 

--- a/docs/user/device-health-status.rst
+++ b/docs/user/device-health-status.rst
@@ -10,8 +10,8 @@ The possible values for the health status field
 Whenever a new device is created it will have ``UNKNOWN`` as it's default
 Heath Status.
 
-It implies that the system has not assessed the health of the device or
-any of its related metrics yet.
+It implies that the current health of the device and its related metrics
+is unknown.
 
 ``OK``
 ------

--- a/docs/user/device-health-status.rst
+++ b/docs/user/device-health-status.rst
@@ -10,8 +10,8 @@ The possible values for the health status field
 Whenever a new device is created it will have ``UNKNOWN`` as it's default
 Heath Status.
 
-It implies that the system doesn't know whether the device is reachable
-yet.
+It implies that the system has not assessed the health of the device or
+any of its related metrics yet.
 
 ``OK``
 ------

--- a/openwisp_monitoring/check/tests/test_data_collected.py
+++ b/openwisp_monitoring/check/tests/test_data_collected.py
@@ -33,8 +33,7 @@ class TestDataCollected(
 
     def _create_device(self, monitoring_status="ok", *args, **kwargs):
         device = super()._create_device(*args, **kwargs)
-        device.monitoring.status = monitoring_status
-        device.monitoring.save()
+        device.monitoring.update_status(monitoring_status)
         return device
 
     def test_store_result(self):

--- a/openwisp_monitoring/check/tests/test_wifi_client.py
+++ b/openwisp_monitoring/check/tests/test_wifi_client.py
@@ -32,8 +32,7 @@ class TestWifiClient(
 
     def _create_device(self, monitoring_status="ok", *args, **kwargs):
         device = super()._create_device(*args, **kwargs)
-        device.monitoring.status = monitoring_status
-        device.monitoring.save()
+        device.monitoring.update_status(monitoring_status)
         return device
 
     def test_store_result(self):
@@ -104,8 +103,7 @@ class TestWifiClient(
             min_mocked.assert_not_called()
 
         with self.subTest("Test check skipped when device status is critical"):
-            device.monitoring.status = "critical"
-            device.monitoring.save()
+            device.monitoring.update_status("critical")
             result = check.perform_check()
             self.assertEqual(result, None)
             max_mocked.assert_not_called()

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -362,21 +362,33 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
     class Meta:
         abstract = True
 
-    def update_status(self, value):
+    def update_status(self, value, clear_management_ip=False):
+        """Updates the device health status and related state.
+
+        Args:
+            value: Target health status. ``unknown`` resets all related metric
+                health states.
+            clear_management_ip: Clears the device management IP in the same
+                transaction, even when the status is already set to ``value``.
+        """
         with transaction.atomic():
+            # If the status is being set to "unknown" reset the related metrics
+            # to "factory default". This allows the system to easily recalculate
+            # the status if the device is reactivated.
             if value == "unknown":
-                # Reset health even if the status is already unknown.
                 self.related_metrics.update(is_healthy=None, is_healthy_tolerant=None)
+            # Clear device management_ip when offline or explicitly requested.
+            if (
+                value == "critical" and app_settings.AUTO_CLEAR_MANAGEMENT_IP
+            ) or clear_management_ip:
+                self.device.management_ip = ""
+                self.device.save(update_fields=["management_ip"])
             # don't trigger save nor emit signal if status is not changing
             if self.status == value:
                 return
             self.status = value
             self.full_clean()
             self.save()
-            # clear device management_ip when device is offline
-            if self.status == "critical" and app_settings.AUTO_CLEAR_MANAGEMENT_IP:
-                self.device.management_ip = None
-                self.device.save(update_fields=["management_ip"])
 
         transaction.on_commit(
             lambda: health_status_changed.send(
@@ -474,15 +486,11 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        monitoring = cls.objects.select_related("device").filter(
-            device__organization_id=organization_id
-        )
+        monitoring = cls.objects.filter(device__organization_id=organization_id)
+        monitoring.update(status="unknown")
         # Process one device at a time to avoid loading a large organization in memory.
-        for instance in monitoring.iterator():
-            with transaction.atomic():
-                instance.device.management_ip = ""
-                instance.device.save(update_fields=["management_ip"])
-                instance.update_status("unknown")
+        for instance in monitoring.select_related("device").iterator():
+            instance.update_status("unknown", clear_management_ip=True)
 
     @classmethod
     def handle_deactivated_device(cls, instance, **kwargs):
@@ -495,9 +503,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        monitoring = cls.objects.filter(device_id=instance.id).first()
-        if monitoring:
-            monitoring.update_status("deactivated")
+        instance.monitoring.update_status("deactivated")
 
     @classmethod
     def handle_activated_device(cls, instance, **kwargs):
@@ -510,9 +516,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        monitoring = cls.objects.filter(device_id=instance.id).first()
-        if monitoring:
-            monitoring.update_status("unknown")
+        instance.monitoring.update_status("unknown")
 
     @classmethod
     def _get_critical_metric_keys(cls):

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -495,7 +495,9 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        instance.monitoring.update_status("deactivated")
+        monitoring = cls.objects.filter(device_id=instance.id).first()
+        if monitoring:
+            monitoring.update_status("deactivated")
 
     @classmethod
     def handle_activated_device(cls, instance, **kwargs):
@@ -508,7 +510,9 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        instance.monitoring.update_status("unknown")
+        monitoring = cls.objects.filter(device_id=instance.id).first()
+        if monitoring:
+            monitoring.update_status("unknown")
 
     @classmethod
     def _get_critical_metric_keys(cls):

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -8,7 +8,7 @@ from cache_memoize import cache_memoize
 from dateutil.relativedelta import relativedelta
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.module_loading import import_string
@@ -363,16 +363,20 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
         abstract = True
 
     def update_status(self, value):
-        # don't trigger save nor emit signal if status is not changing
-        if self.status == value:
-            return
-        self.status = value
-        self.full_clean()
-        self.save()
-        # clear device management_ip when device is offline
-        if self.status == "critical" and app_settings.AUTO_CLEAR_MANAGEMENT_IP:
-            self.device.management_ip = None
-            self.device.save(update_fields=["management_ip"])
+        with transaction.atomic():
+            if value == "unknown":
+                # Reset health even if the status is already unknown.
+                self.related_metrics.update(is_healthy=None, is_healthy_tolerant=None)
+            # don't trigger save nor emit signal if status is not changing
+            if self.status == value:
+                return
+            self.status = value
+            self.full_clean()
+            self.save()
+            # clear device management_ip when device is offline
+            if self.status == "critical" and app_settings.AUTO_CLEAR_MANAGEMENT_IP:
+                self.device.management_ip = None
+                self.device.save(update_fields=["management_ip"])
 
         health_status_changed.send(sender=self.__class__, instance=self, status=value)
 
@@ -466,12 +470,15 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        load_model("config", "Device").objects.filter(
-            organization_id=organization_id
-        ).update(management_ip="")
-        cls.objects.filter(device__organization_id=organization_id).update(
-            status="unknown"
+        monitoring = cls.objects.select_related("device").filter(
+            device__organization_id=organization_id
         )
+        # Process one device at a time to avoid loading a large organization in memory.
+        for instance in monitoring.iterator():
+            with transaction.atomic():
+                instance.device.management_ip = ""
+                instance.device.save(update_fields=["management_ip"])
+                instance.update_status("unknown")
 
     @classmethod
     def handle_deactivated_device(cls, instance, **kwargs):
@@ -484,7 +491,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        cls.objects.filter(device_id=instance.id).update(status="deactivated")
+        instance.monitoring.update_status("deactivated")
 
     @classmethod
     def handle_activated_device(cls, instance, **kwargs):
@@ -497,7 +504,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
 
         Returns: - None
         """
-        cls.objects.filter(device_id=instance.id).update(status="unknown")
+        instance.monitoring.update_status("unknown")
 
     @classmethod
     def _get_critical_metric_keys(cls):

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -345,7 +345,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
         _("health status"),
         db_index=True,
         help_text=_(
-            '"{0}" means the health of the device and its related metrics is unknown; \n'
+            '"{0}" means the device status is unknown; \n'
             '"{1}" means the device is operating normally; \n'
             '"{2}" means the device is having issues but it\'s still communicating with the server; \n'
             '"{3}" means the device is not communicating with the server;\n'
@@ -487,8 +487,9 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
         Returns: - None
         """
         monitoring = cls.objects.filter(device__organization_id=organization_id)
+        # Preserve the bulk update for large organizations: disabling an
+        # organization is not a health-status change and has its own signal.
         monitoring.update(status="unknown")
-        # Process one device at a time to avoid loading a large organization in memory.
         for instance in monitoring.select_related("device").iterator():
             instance.update_status("unknown", clear_management_ip=True)
 

--- a/openwisp_monitoring/device/base/models.py
+++ b/openwisp_monitoring/device/base/models.py
@@ -345,7 +345,7 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
         _("health status"),
         db_index=True,
         help_text=_(
-            '"{0}" means the device has been recently added; \n'
+            '"{0}" means the health of the device and its related metrics is unknown; \n'
             '"{1}" means the device is operating normally; \n'
             '"{2}" means the device is having issues but it\'s still communicating with the server; \n'
             '"{3}" means the device is not communicating with the server;\n'
@@ -378,7 +378,11 @@ class AbstractDeviceMonitoring(TimeStampedEditableModel):
                 self.device.management_ip = None
                 self.device.save(update_fields=["management_ip"])
 
-        health_status_changed.send(sender=self.__class__, instance=self, status=value)
+        transaction.on_commit(
+            lambda: health_status_changed.send(
+                sender=self.__class__, instance=self, status=value
+            )
+        )
 
     @property
     def related_metrics(self):

--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -48,8 +48,7 @@ class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
     def _create_device_monitoring(self):
         d = self._create_device(organization=self._create_org())
         dm = d.monitoring
-        dm.status = "ok"
-        dm.save()
+        dm.update_status("ok")
         return dm
 
     def _transform_wireless_interface_test_data(self, data):

--- a/openwisp_monitoring/device/tests/test_admin.py
+++ b/openwisp_monitoring/device/tests/test_admin.py
@@ -994,8 +994,7 @@ class TestAdmin(
         org = self._create_org()
         device = self._create_device(organization=org, name="test-device")
         dm = device.monitoring
-        dm.status = "ok"
-        dm.save()
+        dm.update_status("ok")
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
         with self.subTest("filter hidden when monitoring__status is not set"):
             response = self.client.get(url)
@@ -1027,16 +1026,14 @@ class TestAdmin(
         org = self._get_org()
         device_ping = self._create_device(organization=org, name="ping-problem-device")
         dm_ping = device_ping.monitoring
-        dm_ping.status = "problem"
-        dm_ping.save()
+        dm_ping.update_status("problem")
         device_memory = self._create_device(
             organization=org,
             name="memory-problem-device",
             mac_address="00:11:22:33:44:57",
         )
         dm_memory = device_memory.monitoring
-        dm_memory.status = "problem"
-        dm_memory.save()
+        dm_memory.update_status("problem")
         device_ct = ContentType.objects.get_for_model(Device)
         Metric.objects.create(
             content_type=device_ct,
@@ -1072,8 +1069,7 @@ class TestAdmin(
             mac_address="00:11:22:33:44:57",
         )
         dm = device.monitoring
-        dm.status = "ok"
-        dm.save()
+        dm.update_status("ok")
         device_ct = ContentType.objects.get_for_model(Device)
         Metric.objects.create(
             content_type=device_ct,
@@ -1118,7 +1114,8 @@ class TestAdmin(
             configuration="ping",
             is_healthy=False,
         )
-        DeviceMonitoring.objects.update(status="problem")
+        for monitoring in DeviceMonitoring.objects.iterator():
+            monitoring.update_status("problem")
         operator = self._create_operator(organizations=[org1])
         self.client.force_login(operator)
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
@@ -1133,8 +1130,7 @@ class TestAdmin(
         org = self._create_org()
         device = self._create_device(organization=org, name="problem-device")
         dm = device.monitoring
-        dm.status = "problem"
-        dm.save()
+        dm.update_status("problem")
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
         response = self.client.get(url)
         self.assertContains(
@@ -1151,8 +1147,7 @@ class TestAdmin(
         org = self._create_org()
         device = self._create_device(organization=org, name="ok-device")
         dm = device.monitoring
-        dm.status = "ok"
-        dm.save()
+        dm.update_status("ok")
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
         response = self.client.get(url)
         self.assertContains(
@@ -1166,8 +1161,7 @@ class TestAdmin(
         org = self._create_org()
         device = self._create_device(organization=org, name="unknown-device")
         dm = device.monitoring
-        dm.status = "unknown"
-        dm.save()
+        dm.update_status("unknown")
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
         response = self.client.get(url)
         self.assertNotContains(response, "issues-toggle")
@@ -1176,8 +1170,7 @@ class TestAdmin(
         org = self._create_org()
         device = self._create_device(organization=org, name="deactivated-device")
         dm = device.monitoring
-        dm.status = "deactivated"
-        dm.save()
+        dm.update_status("deactivated")
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
         response = self.client.get(url)
         self.assertNotContains(response, "issues-toggle")
@@ -1186,8 +1179,7 @@ class TestAdmin(
         org = self._create_org()
         device = self._create_device(organization=org, name="critical-device")
         dm = device.monitoring
-        dm.status = "critical"
-        dm.save()
+        dm.update_status("critical")
         url = reverse(f"admin:{self.config_app_label}_device_changelist")
         response = self.client.get(url)
         self.assertNotContains(response, "issues-toggle")

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -494,6 +494,7 @@ class TestDeviceApi(AuthenticationMixin, TestGeoMixin, DeviceMonitoringTestCase)
             )
             # Update device (d2) health status to 'critical'
             d2.monitoring.update_status("critical")
+            d2.refresh_from_db()
             r = self.client.get(f"{url}?monitoring__status=critical")
             self.assertEqual(r.data["count"], 1)
             self._assert_device_info(device=d2, data=r.data["results"][0])

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -1849,8 +1849,7 @@ class TestGeoApi(TestGeoMixin, AuthenticationMixin, DeviceMonitoringTestCase):
             organization=org2,
             model="TP-Link Archer C60",
         )
-        org2_device1.monitoring.status = "ok"
-        org2_device1.monitoring.save()
+        org2_device1.monitoring.update_status("ok")
 
         self._create_object_location(
             content_object=org1_device1,

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -802,6 +802,8 @@ class TestDeviceMonitoring(
 
     def _set_env_unknown(self, load, process_count, ping, dm):
         dm.update_status("unknown")
+        for metric in load, process_count, ping:
+            metric.refresh_from_db()
 
     def test_unknown_ok(self):
         dm, ping, load, process_count = self._create_env()
@@ -960,6 +962,7 @@ class TestDeviceMonitoring(
             device.refresh_from_db()
             self.assertEqual(device_monitoring.status, "unknown")
             self._assert_unknown(ping, load, process_count)
+            ping.refresh_from_db()
             ping.write(1)
             device_monitoring.refresh_from_db()
             self.assertEqual(

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -911,24 +911,43 @@ class TestDeviceMonitoring(
 
     def test_handle_disabled_organization(self):
         device_monitoring, ping, load, process_count = self._create_env()
-        other_monitoring = self._create_device(
-            organization=self._create_org(name="other org", slug="other-org")
+        device = device_monitoring.device
+        other_device_monitoring = self._create_device(
+            name="same-org-device",
+            mac_address="22:33:44:55:66:77",
+            organization=device.organization,
         ).monitoring
-        other_monitoring.update_status("ok")
-        other_ping = self._create_object_metric(
-            configuration="ping", content_object=other_monitoring.device
+        same_org_ping = self._create_object_metric(
+            configuration="ping", content_object=other_device_monitoring.device
         )
         self._create_alert_settings(
-            metric=other_ping,
+            metric=same_org_ping,
             custom_operator="<",
             custom_threshold=1,
             custom_tolerance=0,
         )
-        device = device_monitoring.device
+        other_monitoring = self._create_device(
+            organization=self._create_org(name="other org", slug="other-org")
+        ).monitoring
+        other_monitoring.update_status("ok")
+        unrelated_ping = self._create_object_metric(
+            configuration="ping", content_object=other_monitoring.device
+        )
+        self._create_alert_settings(
+            metric=unrelated_ping,
+            custom_operator="<",
+            custom_threshold=1,
+            custom_tolerance=0,
+        )
         device.management_ip = "10.10.0.5"
         device.save()
+        other_device_monitoring.device.management_ip = "10.10.0.6"
+        other_device_monitoring.device.save()
+        other_monitoring.device.management_ip = "10.10.0.7"
+        other_monitoring.device.save()
         ping.write(1)
-        other_ping.write(1)
+        same_org_ping.write(1)
+        unrelated_ping.write(1)
         self.assertEqual(device_monitoring.status, "ok")
         org = device.organization
         org.is_active = False
@@ -938,11 +957,18 @@ class TestDeviceMonitoring(
         self.assertEqual(device_monitoring.status, "unknown")
         self.assertEqual(device.management_ip, None)
         self._assert_unknown(ping, load, process_count)
+        other_device_monitoring.refresh_from_db()
+        other_device_monitoring.device.refresh_from_db()
+        self.assertEqual(other_device_monitoring.status, "unknown")
+        self.assertIsNone(other_device_monitoring.device.management_ip)
+        self._assert_unknown(same_org_ping)
         other_monitoring.refresh_from_db()
-        other_ping.refresh_from_db()
+        other_monitoring.device.refresh_from_db()
+        unrelated_ping.refresh_from_db()
         self.assertEqual(other_monitoring.status, "ok")
-        self.assertTrue(other_ping.is_healthy)
-        self.assertTrue(other_ping.is_healthy_tolerant)
+        self.assertEqual(other_monitoring.device.management_ip, "10.10.0.7")
+        self.assertTrue(unrelated_ping.is_healthy)
+        self.assertTrue(unrelated_ping.is_healthy_tolerant)
 
     def test_handle_deactivate_activate_device(self):
         device_monitoring, ping, load, process_count = self._create_env()
@@ -965,11 +991,23 @@ class TestDeviceMonitoring(
             ping.refresh_from_db()
             ping.write(1)
             device_monitoring.refresh_from_db()
+            ping.refresh_from_db()
+            self.assertTrue(ping.is_healthy)
+            self.assertTrue(ping.is_healthy_tolerant)
             self.assertEqual(
                 device_monitoring.status,
                 "ok",
                 "A healthy ping did not restore the status after reactivation.",
             )
+
+    def test_lifecycle_without_device_monitoring(self):
+        device = self._create_device()
+        device.monitoring.delete()
+        with self.subTest("deactivation"):
+            device.deactivate()
+
+        with self.subTest("activation"):
+            device.activate()
 
 
 class TestTransactionDeviceMonitoring(

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -782,7 +782,7 @@ class TestDeviceMonitoring(
         self.assertEqual(dm.device.management_ip, "10.10.0.5")
         ping.check_threshold(0)
         self.assertEqual(dm.status, "critical")
-        self.assertIsNone(dm.device.management_ip)
+        self.assertEqual(dm.device.management_ip, "")
 
     @patch("openwisp_monitoring.device.settings.AUTO_CLEAR_MANAGEMENT_IP", False)
     @patch.object(
@@ -950,8 +950,8 @@ class TestDeviceMonitoring(
         unrelated_ping.write(1)
         self.assertEqual(device_monitoring.status, "ok")
         org = device.organization
-        org.is_active = False
-        org.save(update_fields=["is_active"])
+        with self.assertNumQueries(10):
+            DeviceMonitoring.handle_disabled_organization(org.pk)
         device_monitoring.refresh_from_db()
         device.refresh_from_db()
         self.assertEqual(device_monitoring.status, "unknown")
@@ -999,15 +999,6 @@ class TestDeviceMonitoring(
                 "ok",
                 "A healthy ping did not restore the status after reactivation.",
             )
-
-    def test_lifecycle_without_device_monitoring(self):
-        device = self._create_device()
-        device.monitoring.delete()
-        with self.subTest("deactivation"):
-            device.deactivate()
-
-        with self.subTest("activation"):
-            device.activate()
 
 
 class TestTransactionDeviceMonitoring(

--- a/openwisp_monitoring/device/tests/test_models.py
+++ b/openwisp_monitoring/device/tests/test_models.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import transaction
 from django.test import TestCase, tag
 from django.utils.timezone import now, timedelta
 from freezegun import freeze_time
@@ -254,8 +255,7 @@ class MonitoringTestMixin(object):
     def _create_env(self):
         d = self._create_device()
         dm = d.monitoring
-        dm.status = "ok"
-        dm.save()
+        dm.update_status("ok")
         ping = self._create_object_metric(configuration="ping", content_object=d)
         self._create_alert_settings(
             metric=ping, custom_operator="<", custom_threshold=1, custom_tolerance=0
@@ -572,16 +572,14 @@ class TestDeviceData(MonitoringTestMixin, DeviceMonitoringTestCase):
     @patch("openwisp_controller.connection.tasks.logger.info")
     def test_can_be_updated(self, mocked_logger_info):
         device = self._create_device_config()
-        device.monitoring.status = "critical"
-        device.monitoring.save()
+        device.monitoring.update_status("critical")
         update_config.delay(device.pk)
         mocked_logger_info.assert_called_once()
 
     @patch("openwisp_controller.connection.tasks.logger.info")
     def test_can_be_updated_unknown(self, mocked_logger_info):
         device = self._create_device_config()
-        device.monitoring.status = "unknown"
-        device.monitoring.save()
+        device.monitoring.update_status("unknown")
         update_config.delay(device.pk)
         mocked_logger_info.assert_called_once()
 
@@ -597,6 +595,23 @@ class TestDeviceMonitoring(
 ):
     """Test openwisp_monitoring.device.models.DeviceMonitoring"""
 
+    def _assert_unknown(self, *metrics):
+        for metric in metrics:
+            metric.refresh_from_db()
+            self.assertIsNone(
+                metric.is_healthy,
+                "Expected is_healthy to be None because the device status is unknown.",
+            )
+            self.assertIsNone(
+                metric.is_healthy_tolerant,
+                "Expected is_healthy_tolerant to be None because the device status is unknown.",
+            )
+
+    def test_unknown(self):
+        device_monitoring, ping, load, process_count = self._create_env()
+        device_monitoring.update_status("unknown")
+        self._assert_unknown(ping, load, process_count)
+
     def test_disabling_critical_check(self):
         Check = load_model("check", "Check")
         dm, ping, load, process_count = self._create_env()
@@ -606,16 +621,19 @@ class TestDeviceMonitoring(
             content_object=dm.device,
             params={},
         )
+        ping.write(1)
         dm.update_status("ok")
         with catch_signal(health_status_changed) as handler:
-            ping_check_instance.is_active = False
-            ping_check_instance.save()
+            with self.captureOnCommitCallbacks(execute=True):
+                ping_check_instance.is_active = False
+                ping_check_instance.save()
         self.assertEqual(handler.call_count, 1)
         call_args = handler.call_args[1]
         self.assertEqual(call_args["instance"], dm)
         self.assertEqual(call_args["status"], "unknown")
         dm.refresh_from_db()
         self.assertEqual(dm.status, "unknown")
+        self._assert_unknown(ping, load, process_count)
         with self.subTest(
             "Ensure status does not change on saving active critical check"
         ):
@@ -654,21 +672,25 @@ class TestDeviceMonitoring(
             content_object=dm.device,
             params={},
         )
+        ping.write(1)
         dm.update_status("ok")
         with catch_signal(health_status_changed) as handler:
-            ping_check_instance.delete()
+            with self.captureOnCommitCallbacks(execute=True):
+                ping_check_instance.delete()
         self.assertEqual(handler.call_count, 1)
         call_args = handler.call_args[1]
         self.assertEqual(call_args["instance"], dm)
         self.assertEqual(call_args["status"], "unknown")
         dm.refresh_from_db()
         self.assertEqual(dm.status, "unknown")
+        self._assert_unknown(ping, load, process_m)
 
     def test_status_changed(self):
         dm, ping, load, process_count = self._create_env()
         # check signal
         with catch_signal(health_status_changed) as handler:
-            dm.update_status("problem")
+            with self.captureOnCommitCallbacks(execute=True):
+                dm.update_status("problem")
         dm.refresh_from_db()
         self.assertEqual(dm.status, "problem")
         handler.assert_called_once_with(
@@ -779,14 +801,7 @@ class TestDeviceMonitoring(
         self.assertIsNotNone(dm.device.management_ip)
 
     def _set_env_unknown(self, load, process_count, ping, dm):
-        dm.status = "unknown"
-        dm.save()
-        ping.is_healthy = None
-        load.save()
-        load.is_healthy = None
-        ping.save()
-        process_count.is_healthy = None
-        process_count.save()
+        dm.update_status("unknown")
 
     def test_unknown_ok(self):
         dm, ping, load, process_count = self._create_env()
@@ -878,8 +893,7 @@ class TestDeviceMonitoring(
             organization=dm1.device.organization,
         )
         dm2 = device2.monitoring
-        dm2.status = "ok"
-        dm2.save()
+        dm2.update_status("ok")
         ping2 = self._create_object_metric(
             name="ping", key="ping", field_name="reachable", content_object=device2
         )
@@ -894,10 +908,25 @@ class TestDeviceMonitoring(
         self.assertNotEqual(self._read_metric(ping2), [])
 
     def test_handle_disabled_organization(self):
-        device_monitoring, _, _, _ = self._create_env()
+        device_monitoring, ping, load, process_count = self._create_env()
+        other_monitoring = self._create_device(
+            organization=self._create_org(name="other org", slug="other-org")
+        ).monitoring
+        other_monitoring.update_status("ok")
+        other_ping = self._create_object_metric(
+            configuration="ping", content_object=other_monitoring.device
+        )
+        self._create_alert_settings(
+            metric=other_ping,
+            custom_operator="<",
+            custom_threshold=1,
+            custom_tolerance=0,
+        )
         device = device_monitoring.device
         device.management_ip = "10.10.0.5"
         device.save()
+        ping.write(1)
+        other_ping.write(1)
         self.assertEqual(device_monitoring.status, "ok")
         org = device.organization
         org.is_active = False
@@ -906,10 +935,17 @@ class TestDeviceMonitoring(
         device.refresh_from_db()
         self.assertEqual(device_monitoring.status, "unknown")
         self.assertEqual(device.management_ip, None)
+        self._assert_unknown(ping, load, process_count)
+        other_monitoring.refresh_from_db()
+        other_ping.refresh_from_db()
+        self.assertEqual(other_monitoring.status, "ok")
+        self.assertTrue(other_ping.is_healthy)
+        self.assertTrue(other_ping.is_healthy_tolerant)
 
     def test_handle_deactivate_activate_device(self):
-        device_monitoring, _, _, _ = self._create_env()
+        device_monitoring, ping, load, process_count = self._create_env()
         device = device_monitoring.device
+        ping.write(1)
         self.assertEqual(device_monitoring.status, "ok")
 
         with self.subTest("Test deactivation of device"):
@@ -923,11 +959,45 @@ class TestDeviceMonitoring(
             device_monitoring.refresh_from_db()
             device.refresh_from_db()
             self.assertEqual(device_monitoring.status, "unknown")
+            self._assert_unknown(ping, load, process_count)
+            ping.write(1)
+            device_monitoring.refresh_from_db()
+            self.assertEqual(
+                device_monitoring.status,
+                "ok",
+                "A healthy ping did not restore the status after reactivation.",
+            )
 
 
 class TestTransactionDeviceMonitoring(
     CreateConnectionsMixin, MonitoringTestMixin, DeviceMonitoringTransactionTestcase
 ):
+    def test_unknown_status_rollback(self):
+        dm, ping, load, process_count = self._create_env()
+        with transaction.atomic():
+            dm.update_status("unknown")
+            transaction.set_rollback(True)
+        dm.refresh_from_db()
+        ping.refresh_from_db()
+        self.assertEqual(dm.status, "ok")
+        self.assertTrue(ping.is_healthy)
+        self.assertTrue(ping.is_healthy_tolerant)
+
+    def test_disabled_organization_rollback(self):
+        dm, ping, load, process_count = self._create_env()
+        dm.device.management_ip = "10.10.0.5"
+        dm.device.save()
+        with transaction.atomic():
+            DeviceMonitoring.handle_disabled_organization(dm.device.organization_id)
+            transaction.set_rollback(True)
+        dm.refresh_from_db()
+        dm.device.refresh_from_db()
+        ping.refresh_from_db()
+        self.assertEqual(dm.status, "ok")
+        self.assertEqual(dm.device.management_ip, "10.10.0.5")
+        self.assertTrue(ping.is_healthy)
+        self.assertTrue(ping.is_healthy_tolerant)
+
     @patch("openwisp_monitoring.device.tasks.perform_check.delay")
     def test_stuck_problem_regression(self, mocked):
         """Regression test for https://github.com/openwisp/openwisp-monitoring/issues/830."""

--- a/openwisp_monitoring/device/tests/test_recovery.py
+++ b/openwisp_monitoring/device/tests/test_recovery.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.core.cache import cache
+from django.db import transaction
 from swapper import load_model
 
 from ..signals import health_status_changed
@@ -41,15 +42,18 @@ class TestRecovery(DeviceMonitoringTestCase):
     def test_device_recovery_cache_key_set(self):
         dm = self._create_device_monitoring()
         cache_key = get_device_cache_key(device=dm.device)
-        dm.update_status("critical")
+        with self.captureOnCommitCallbacks(execute=True):
+            dm.update_status("critical")
         dm.refresh_from_db()
         self.assertEqual(dm.status, "critical")
         self.assertEqual(cache.get(cache_key), 1)
-        dm.update_status("problem")
+        with self.captureOnCommitCallbacks(execute=True):
+            dm.update_status("problem")
         dm.refresh_from_db()
         self.assertEqual(dm.status, "problem")
         self.assertEqual(cache.get(cache_key), None)
-        dm.update_status("ok")
+        with self.captureOnCommitCallbacks(execute=True):
+            dm.update_status("ok")
         dm.refresh_from_db()
         self.assertEqual(dm.status, "ok")
         self.assertEqual(cache.get(cache_key), None)
@@ -78,6 +82,14 @@ class TestRecovery(DeviceMonitoringTestCase):
 
 
 class TestRecoveryTransaction(DeviceMonitoringTransactionTestcase):
+    def test_status_rollback_does_not_change_recovery_cache(self):
+        dm = self._create_device_monitoring()
+        cache_key = get_device_cache_key(device=dm.device)
+        with transaction.atomic():
+            dm.update_status("critical")
+            transaction.set_rollback(True)
+        self.assertIsNone(cache.get(cache_key))
+
     @patch("openwisp_monitoring.device.tasks.perform_check.delay")
     def test_metrics_received_trigger_device_recovery_checks(self, mocked_task):
         device = self._create_config(organization=self._get_org()).device

--- a/openwisp_monitoring/device/tests/test_transactions.py
+++ b/openwisp_monitoring/device/tests/test_transactions.py
@@ -55,14 +55,12 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
             mock.assert_called_once()
 
     @patch.object(Ping, "_command", return_value=_FPING_UNREACHABLE)
-    @patch.object(DeviceMonitoring, "update_status")
-    def test_trigger_device_recovery_task_regression(
-        self, mocked_update_status, mocked_ping
-    ):
+    def test_trigger_device_recovery_task_regression(self, mocked_ping):
         dm = self._create_device_monitoring()
         dm.device.management_ip = None
         dm.device.save()
-        trigger_device_critical_checks.delay(dm.device.pk)
+        with patch.object(DeviceMonitoring, "update_status") as mocked_update_status:
+            trigger_device_critical_checks.delay(dm.device.pk)
         self.assertTrue(Check.objects.exists())
         # we expect update_status() to be called twice (by the check)
         # and not a third time directly by our code
@@ -72,8 +70,7 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
     def test_is_working_false_true(self, perform_check):
         d = self._create_device()
         dm = d.monitoring
-        dm.status = "unknown"
-        dm.save()
+        dm.update_status("unknown")
         self._delete_non_ping_checks()
         c = Credentials.objects.create()
         dc = DeviceConnection.objects.create(credentials=c, device=d, is_working=False)
@@ -86,8 +83,7 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
     def test_is_working_changed_to_false(self, perform_check):
         d = self._create_device()
         dm = d.monitoring
-        dm.status = "ok"
-        dm.save()
+        dm.update_status("ok")
         self._delete_non_ping_checks()
         c = Credentials.objects.create()
         dc = DeviceConnection.objects.create(credentials=c, device=d)
@@ -100,8 +96,7 @@ class TestTransactions(CreateConnectionsMixin, DeviceMonitoringTransactionTestca
     def test_is_working_none_true(self, notify_send, perform_check):
         d = self._create_device()
         dm = d.monitoring
-        dm.status = "unknown"
-        dm.save()
+        dm.update_status("unknown")
         self._delete_non_ping_checks()
         c = Credentials.objects.create()
         dc = DeviceConnection.objects.create(credentials=c, device=d)

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -380,8 +380,7 @@ class TestDashboardMap(
         d2 = self._create_device(
             name="Test-Device2", mac_address="00:00:00:00:00:02", organization=org
         )
-        d2.monitoring.status = "ok"
-        d2.monitoring.save()
+        d2.monitoring.update_status("ok")
         location = self._create_location(
             type="outdoor", name="Test-Location", organization=org
         )
@@ -1671,8 +1670,7 @@ class TestDeviceAdmin(
             mac_address="00:11:22:33:44:66",
         )
         dm_ok = device_ok.monitoring
-        dm_ok.status = "ok"
-        dm_ok.save()
+        dm_ok.update_status("ok")
         device_disk = self._create_device(
             organization=org,
             name="disk-problem-device",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #841.

## Description of Changes

Ensures that setting a device monitoring status to `unknown` resets the health of every related metric. This allows checks to update the status of the device efficiently if it ever becomes active again.  

## Screenshot

N/A