### PR TITLE
[change] Improved location map health status #849

### DIFF
--- a/docs/user/geo-indoor-maps.rst
+++ b/docs/user/geo-indoor-maps.rst
@@ -1,38 +1,46 @@
 Geographic & Indoor Maps
 ========================
 
-.. image:: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.3/intro.gif
-    :target: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.3/intro.gif
-    :alt: Intro
-
-OpenWISP provides a unified web interface to monitor network status across
-all scales: start with a global geographic overview, drill down into
-specific buildings via indoor maps, and switch between floors to track
-devices in real time.
-
 .. contents:: **Table of contents**:
     :depth: 1
     :local:
 
-.. _monitoring_dashboard_map:
+.. _openwisp_monitoring_geographic_map:
 
-Dashboard Map
--------------
+.. image:: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.3/intro.gif
+    :target: https://raw.githubusercontent.com/openwisp/openwisp-monitoring/docs/docs/1.3/intro.gif
+    :alt: Intro
 
-The dashboard map shows locations with installed devices and provides a
-visual overview of their monitoring status. It is controlled by the boolean
-``OPENWISP_MONITORING_DASHBOARD_MAP`` setting, which defaults to ``True``.
+OpenWISP provides a unified geographic map to monitor network status
+across all scales: start with a global geographic overview, drill down
+into specific buildings via indoor maps, and switch between floors to
+track devices in real time.
 
-The dashboard map requires ``OPENWISP_ADMIN_DASHBOARD_ENABLED`` from
-:ref:`openwisp-utils <utils_admin_dashboard_enabled>` to be set to ``True``.
-Set ``OPENWISP_MONITORING_DASHBOARD_MAP`` to ``False`` to disable the map if
-you do not use OpenWISP geographic features.
+The global map overview shows locations with installed devices and
+provides a visual overview of their monitoring status.
 
 When a location contains multiple devices, its marker reflects the most
-common active health status. Deactivated devices are excluded from this
-calculation. If the most common statuses are tied, a tie including ``ok`` or
-``problem`` is shown as ``problem``; a tie between ``critical`` and
-``unknown`` is shown as ``critical``.
+common active health status.
+
+.. note::
+
+    When a location contains multiple devices and the most common statuses
+    are tied, any tied set including ``ok`` or ``problem`` is shown as
+    ``problem``. A tie limited to ``critical`` and ``unknown`` is shown as
+    ``critical``.
+
+    Deactivated devices are generally excluded from these calculations. If
+    all devices at a location are deactivated, its marker is shown in the
+    deactivated color.
+
+.. seealso::
+
+    The geographic map dashboard is built on top of the :doc:`OpenWISP
+    Utils Dashboard </utils/developer/dashboard>`.
+
+    It is enabled by default and can be disabled with the boolean
+    ``OPENWISP_MONITORING_DASHBOARD_MAP`` setting. See
+    :ref:`openwisp_monitoring_dashboard_map`.
 
 Indoor Map View with Floor Navigation
 -------------------------------------

--- a/docs/user/geo-indoor-maps.rst
+++ b/docs/user/geo-indoor-maps.rst
@@ -14,6 +14,26 @@ devices in real time.
     :depth: 1
     :local:
 
+.. _monitoring_dashboard_map:
+
+Dashboard Map
+-------------
+
+The dashboard map shows locations with installed devices and provides a
+visual overview of their monitoring status. It is controlled by the boolean
+``OPENWISP_MONITORING_DASHBOARD_MAP`` setting, which defaults to ``True``.
+
+The dashboard map requires ``OPENWISP_ADMIN_DASHBOARD_ENABLED`` from
+:ref:`openwisp-utils <utils_admin_dashboard_enabled>` to be set to ``True``.
+Set ``OPENWISP_MONITORING_DASHBOARD_MAP`` to ``False`` to disable the map if
+you do not use OpenWISP geographic features.
+
+When a location contains multiple devices, its marker reflects the most
+common active health status. Deactivated devices are excluded from this
+calculation. If the most common statuses are tied, a tie including ``ok`` or
+``problem`` is shown as ``problem``; a tie between ``critical`` and
+``unknown`` is shown as ``critical``.
+
 Indoor Map View with Floor Navigation
 -------------------------------------
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -44,6 +44,17 @@ Since the detailed explanation is contained in the
 provide just a list of the available endpoints, for further information
 please open the URL of the endpoint in your browser.
 
+List Locations as GeoJSON
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    GET /api/v1/monitoring/geojson/
+
+Returns locations with devices as GeoJSON features. Each feature includes
+the total device count and counts for the ``ok``, ``problem``,
+``critical``, ``unknown``, and ``deactivated`` monitoring statuses.
+
 Retrieve General Monitoring Charts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -79,17 +90,6 @@ multi-tenancy and allows filtering monitoring data by
 
     The ``start`` and ``end`` parameters should be in the format
     ``YYYY-MM-DD H:M:S``, otherwise 400 Bad Response will be returned.
-
-List Locations as GeoJSON
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: text
-
-    GET /api/v1/monitoring/geojson/
-
-Returns locations with devices as GeoJSON features. Each feature includes
-the total device count and counts for the ``ok``, ``problem``,
-``critical``, ``unknown``, and ``deactivated`` monitoring statuses.
 
 Retrieve Device Charts and Device Status Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -80,6 +80,17 @@ multi-tenancy and allows filtering monitoring data by
     The ``start`` and ``end`` parameters should be in the format
     ``YYYY-MM-DD H:M:S``, otherwise 400 Bad Response will be returned.
 
+List Locations as GeoJSON
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+    GET /api/v1/monitoring/geojson/
+
+Returns locations with devices as GeoJSON features. Each feature includes the
+total device count and counts for the ``ok``, ``problem``, ``critical``,
+``unknown``, and ``deactivated`` monitoring statuses.
+
 Retrieve Device Charts and Device Status Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -87,9 +87,9 @@ List Locations as GeoJSON
 
     GET /api/v1/monitoring/geojson/
 
-Returns locations with devices as GeoJSON features. Each feature includes the
-total device count and counts for the ``ok``, ``problem``, ``critical``,
-``unknown``, and ``deactivated`` monitoring statuses.
+Returns locations with devices as GeoJSON features. Each feature includes
+the total device count and counts for the ``ok``, ``problem``,
+``critical``, ``unknown``, and ``deactivated`` monitoring statuses.
 
 Retrieve Device Charts and Device Status Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -313,6 +313,12 @@ devices installed in and provides a visual representation of the
 monitoring status of the devices, this allows to get an overview of the
 network at glance.
 
+When a location contains multiple devices, its marker reflects the most
+common active health status. Deactivated devices are excluded from this
+calculation. If the most common statuses are tied, a tie including ``ok`` or
+``problem`` is shown as ``problem``; a tie between ``critical`` and
+``unknown`` is shown as ``critical``.
+
 This feature is enabled by default and depends on the setting
 ``OPENWISP_ADMIN_DASHBOARD_ENABLED`` from :ref:`openwisp-utils
 <utils_admin_dashboard_enabled>` being set to ``True`` (which is the

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -302,8 +302,19 @@ This setting is independent of celery retry settings.
 ``OPENWISP_MONITORING_DASHBOARD_MAP``
 -------------------------------------
 
-Whether the :ref:`geographic map in the dashboard <monitoring_dashboard_map>`
-is enabled or not.
+============ ========
+**type**:    ``bool``
+**default**: ``True``
+============ ========
+
+Whether the :ref:`geographic map in the dashboard
+<openwisp_monitoring_geographic_map>` is enabled or not.
+
+Set it to ``False`` if you do not use geographic features of OpenWISP.
+
+This feature also depends on the ``OPENWISP_ADMIN_DASHBOARD_ENABLED``
+setting from :ref:`openwisp-utils <utils_admin_dashboard_enabled>` being
+set to ``True``, which is the default.
 
 .. _openwisp_monitoring_dashboard_traffic_chart:
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -310,7 +310,7 @@ This setting is independent of celery retry settings.
 Whether the :ref:`geographic map in the dashboard
 <openwisp_monitoring_geographic_map>` is enabled or not.
 
-Set it to ``False`` if you do not use geographic features of OpenWISP.
+Set it to ``False`` if you do not use the geographic features of OpenWISP.
 
 This feature also depends on the ``OPENWISP_ADMIN_DASHBOARD_ENABLED``
 setting from :ref:`openwisp-utils <utils_admin_dashboard_enabled>` being

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -302,30 +302,7 @@ This setting is independent of celery retry settings.
 ``OPENWISP_MONITORING_DASHBOARD_MAP``
 -------------------------------------
 
-============ ========
-**type**:    ``bool``
-**default**: ``True``
-============ ========
-
-Whether the geographic map in the dashboard is enabled or not. This
-feature provides a geographic map which shows the locations which have
-devices installed in and provides a visual representation of the
-monitoring status of the devices, this allows to get an overview of the
-network at glance.
-
-When a location contains multiple devices, its marker reflects the most
-common active health status. Deactivated devices are excluded from this
-calculation. If the most common statuses are tied, a tie including ``ok`` or
-``problem`` is shown as ``problem``; a tie between ``critical`` and
-``unknown`` is shown as ``critical``.
-
-This feature is enabled by default and depends on the setting
-``OPENWISP_ADMIN_DASHBOARD_ENABLED`` from :ref:`openwisp-utils
-<utils_admin_dashboard_enabled>` being set to ``True`` (which is the
-default).
-
-You can turn this off if you do not use the geographic features of
-OpenWISP.
+See :ref:`the dashboard map documentation <monitoring_dashboard_map>`.
 
 .. _openwisp_monitoring_dashboard_traffic_chart:
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -302,7 +302,8 @@ This setting is independent of celery retry settings.
 ``OPENWISP_MONITORING_DASHBOARD_MAP``
 -------------------------------------
 
-See :ref:`the dashboard map documentation <monitoring_dashboard_map>`.
+Whether the :ref:`geographic map in the dashboard <monitoring_dashboard_map>`
+is enabled or not.
 
 .. _openwisp_monitoring_dashboard_traffic_chart:
 

--- a/openwisp_monitoring/device/api/serializers.py
+++ b/openwisp_monitoring/device/api/serializers.py
@@ -131,6 +131,7 @@ class MonitoringGeoJsonLocationSerializer(GeoJsonLocationSerializer):
     problem_count = serializers.IntegerField()
     critical_count = serializers.IntegerField()
     unknown_count = serializers.IntegerField()
+    deactivated_count = serializers.IntegerField()
 
 
 class WifiClientSerializer(serializers.ModelSerializer):

--- a/openwisp_monitoring/device/api/views.py
+++ b/openwisp_monitoring/device/api/views.py
@@ -228,6 +228,12 @@ class MonitoringGeoJsonLocationList(GeoJsonLocationList):
                 "devicelocation",
                 filter=Q(devicelocation__content_object__monitoring__status="unknown"),
             ),
+            deactivated_count=Count(
+                "devicelocation",
+                filter=Q(
+                    devicelocation__content_object__monitoring__status="deactivated"
+                ),
+            ),
         )
         .order_by("-created")
     )

--- a/openwisp_monitoring/device/static/monitoring/js/device-map.js
+++ b/openwisp_monitoring/device/static/monitoring/js/device-map.js
@@ -4,7 +4,7 @@
   const loadingOverlay = $("#dashboard-map-overlay .ow-loading-spinner");
   const localStorageKey = "ow-map-shown";
   const mapContainer = $("#device-map-container");
-  const statuses = ["critical", "problem", "ok", "unknown", "deactivated"];
+  const healthStatuses = ["critical", "problem", "ok", "unknown"];
   window._owGeoMapConfig.STATUS_COLORS = {
     ok: "#267126",
     problem: "#ffb442",
@@ -27,34 +27,27 @@
     div.textContent = text;
     return div.innerHTML;
   };
-  const getColor = function (data) {
-    let deviceCount = data.device_count,
-      findResult = function (func) {
-        for (let i in statuses) {
-          let status = statuses[i],
-            statusCount = data[status + "_count"];
-          if (statusCount === 0) {
-            continue;
-          }
-          return func(status, statusCount);
-        }
-      };
-    // if one status has absolute majority, it's the winner
-    let majority = findResult(function (status, statusCount) {
-      if (statusCount > deviceCount / 2) {
-        return STATUS_COLORS[status];
-      }
-    });
-    if (majority) {
-      return majority;
+  const getStatus = function (data) {
+    const counts = healthStatuses.map((status) => ({
+      status,
+      count: data[status + "_count"] || 0,
+    }));
+    const highestCount = Math.max(...counts.map(({ count }) => count));
+    if (highestCount === 0) {
+      return data.deactivated_count ? "deactivated" : "unknown";
     }
-    // otherwise simply return the color based on the priority
-    return findResult(function (status, statusCount) {
-      // if one status has absolute majority, it's the winner
-      if (statusCount) {
-        return STATUS_COLORS[status];
-      }
-    });
+    const highestStatuses = counts
+      .filter(({ count }) => count === highestCount)
+      .map(({ status }) => status);
+    if (highestStatuses.length === 1) {
+      return highestStatuses[0];
+    }
+    return highestStatuses.some((status) => ["ok", "problem"].includes(status))
+      ? "problem"
+      : "critical";
+  };
+  const getColor = function (data) {
+    return STATUS_COLORS[getStatus(data)];
   };
 
   async function loadPopUpContent(nodeData) {
@@ -407,13 +400,7 @@
         if (Array.isArray(items)) {
           items.forEach((el) => {
             const props = el.properties || {};
-            let status = props.status?.toLowerCase();
-            if (!status) {
-              const color = getColor(props);
-              status =
-                Object.keys(STATUS_COLORS).find((k) => STATUS_COLORS[k] === color) ||
-                "unknown";
-            }
+            const status = props.status?.toLowerCase() || getStatus(props);
             props.status = status;
             props.category = status;
             el.category = status;

--- a/openwisp_monitoring/device/static/monitoring/js/device-map.js
+++ b/openwisp_monitoring/device/static/monitoring/js/device-map.js
@@ -28,6 +28,8 @@
     return div.innerHTML;
   };
   const getStatus = function (data) {
+    // Choose the most common active status. Deactivated devices are ignored
+    // unless all devices are deactivated; ties prefer problem, then critical.
     const counts = healthStatuses.map((status) => ({
       status,
       count: data[status + "_count"] || 0,

--- a/openwisp_monitoring/device/tests/test_api.py
+++ b/openwisp_monitoring/device/tests/test_api.py
@@ -1720,17 +1720,27 @@ class TestGeoApi(TestGeoMixin, AuthenticationMixin, DeviceMonitoringTestCase):
     def test_api_location_geojson(self):
         device_location = self._create_object_location()
         device_location.device.monitoring.update_status("ok")
+        deactivated_device = self._create_device(
+            organization=device_location.location.organization
+        )
+        deactivated_device.monitoring.update_status("deactivated")
+        self._create_object_location(
+            content_object=deactivated_device,
+            location=device_location.location,
+            organization=device_location.location.organization,
+        )
         self._login_admin()
         url = reverse("monitoring:api_location_geojson")
         response = self.client.get(url)
         data = response.data
         self.assertEqual(data["count"], 1)
         self.assertEqual(len(data["features"]), 1)
-        self.assertEqual(data["features"][0]["properties"]["device_count"], 1)
+        self.assertEqual(data["features"][0]["properties"]["device_count"], 2)
         self.assertEqual(data["features"][0]["properties"]["ok_count"], 1)
         self.assertEqual(data["features"][0]["properties"]["problem_count"], 0)
         self.assertEqual(data["features"][0]["properties"]["critical_count"], 0)
         self.assertEqual(data["features"][0]["properties"]["unknown_count"], 0)
+        self.assertEqual(data["features"][0]["properties"]["deactivated_count"], 1)
 
     def test_api_location_device_list(self):
         org = self._get_org()

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -377,6 +377,7 @@ class TestDashboardMap(
         cases = {
             "Predominantly healthy": ({"ok": 6, "unknown": 5, "critical": 2}, "ok"),
             "Tied healthy and critical": ({"ok": 1, "critical": 1}, "problem"),
+            "Tied problem and critical": ({"problem": 1, "critical": 1}, "problem"),
             "Tied critical and unknown": ({"critical": 1, "unknown": 1}, "critical"),
             "Only deactivated": ({"deactivated": 2}, "deactivated"),
             "Deactivated devices ignored": (
@@ -414,7 +415,7 @@ class TestDashboardMap(
                 lambda d: d.execute_script(
                     """
                     const nodes = window._owGeoMap?.data?.nodes;
-                    if (!nodes || nodes.length !== 5) return false;
+                    if (!nodes || nodes.length !== 6) return false;
                     return Object.fromEntries(nodes.map(node => [node.label, node.category]));
                 """
                 )

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -236,8 +236,7 @@ class TestDashboardCharts(
         self.wait_for_visibility(
             By.CSS_SELECTOR, "#chart-0 .js-plotly-plot", timeout=10
         )
-        self.web_driver.execute_script(
-            """
+        self.web_driver.execute_script("""
             window.dashboardChartRequests = 0;
             const originalAjax = django.jQuery.ajax;
             django.jQuery.ajax = function () {
@@ -248,8 +247,7 @@ class TestDashboardCharts(
               'plotly_relayout',
               { autosize: true },
             );
-        """
-        )
+        """)
         self.assertEqual(
             self.web_driver.execute_script("return window.dashboardChartRequests;"), 0
         )
@@ -415,13 +413,11 @@ class TestDashboardMap(
         self.login()
         try:
             statuses = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const nodes = window._owGeoMap?.data?.nodes;
                     if (!nodes || nodes.length !== 6) return false;
                     return Object.fromEntries(nodes.map(node => [node.label, node.category]));
-                """
-                )
+                """)
             )
         except TimeoutException:
             self.fail("Failed to retrieve dashboard map location statuses")
@@ -779,8 +775,7 @@ class TestDashboardMap(
                 == second_map_id
             )
         except TimeoutException:
-            floorplan_state = self.web_driver.execute_script(
-                """
+            floorplan_state = self.web_driver.execute_script("""
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return {
                   activeMapId: window._owIndoorMap?.config?.bookmarkableActions?.id,
@@ -788,8 +783,7 @@ class TestDashboardMap(
                   hash: window.location.hash,
                   locationId: state?.state?.locationId,
                 };
-                """
-            )
+                """)
             self.fail(
                 f"Hash change did not activate {second_map_id}; "
                 f"state is {floorplan_state}; logs are {self.get_browser_logs()}"
@@ -928,46 +922,32 @@ class TestDashboardMap(
         self.find_element(
             By.CSS_SELECTOR, "#floorplan-navigation .floor-btn[data-floor='2']"
         ).click()
-        WebDriverWait(self.web_driver, 2).until(
-            lambda d: d.execute_script(
-                """
+        WebDriverWait(self.web_driver, 2).until(lambda d: d.execute_script("""
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return (
                   state?.state?.currentFloor === 1 &&
                   !state.allResults[2] &&
                   !state.floorRequests[2]
                 );
-                """
-            )
-        )
+                """))
         self.find_element(
             By.CSS_SELECTOR, "#floorplan-navigation .floor-btn[data-floor='2']"
         ).click()
-        WebDriverWait(self.web_driver, 2).until(
-            lambda d: d.execute_script(
-                """
+        WebDriverWait(self.web_driver, 2).until(lambda d: d.execute_script("""
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return state?.allResults[2]?.length === 51;
-                """
-            )
-        )
-        self.web_driver.execute_script(
-            """
+                """))
+        self.web_driver.execute_script("""
             const floorButton = document.querySelector(
               "#floorplan-navigation .floor-btn[data-floor='3']",
             );
             floorButton.click();
             floorButton.click();
-            """
-        )
-        WebDriverWait(self.web_driver, 2).until(
-            lambda d: d.execute_script(
-                """
+            """)
+        WebDriverWait(self.web_driver, 2).until(lambda d: d.execute_script("""
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return state?.allResults[3]?.length === 51;
-                """
-            )
-        )
+                """))
 
     def test_switching_floorplan_in_fullscreen_mode(self):
         org = self._get_org()
@@ -1186,8 +1166,7 @@ class TestDashboardMap(
         location.save()
         try:
             series_value = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script(
-                    """
+                lambda d: d.execute_script("""
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1195,8 +1174,7 @@ class TestDashboardMap(
                     const item = series.data.find(d => d.name === "Test-Location");
                     if (!item) return false;
                     return item.value;
-                """
-                )
+                """)
             )
         except TimeoutException:
             self.fail("Failed to retrieve mobile location data")
@@ -1210,8 +1188,7 @@ class TestDashboardMap(
             location.save()
             try:
                 series_value = WebDriverWait(self.web_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1219,8 +1196,7 @@ class TestDashboardMap(
                         const item = series.data.find(d => d.name === "Test-Location");
                         if (!item) return false;
                         return item.value;
-                    """
-                    )
+                    """)
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve updated mobile location data")
@@ -1273,8 +1249,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(self.web_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1283,8 +1258,7 @@ class TestDashboardMap(
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         if (!org1_location || !org2_location) return false;
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve org location data from superuser")
@@ -1312,8 +1286,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org1_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1323,8 +1296,7 @@ class TestDashboardMap(
                         if (!org1_location) return false;
                         if (org2_location !== undefined) return false;
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve org1 location data from org1 user")
@@ -1351,8 +1323,7 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org2_driver, 5).until(
-                    lambda d: d.execute_script(
-                        """
+                    lambda d: d.execute_script("""
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1362,8 +1333,7 @@ class TestDashboardMap(
                         if (org1_location !== undefined) return false;
                         if (!org2_location) return false;
                         return {org1_location, org2_location}
-                    """
-                    )
+                    """)
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve org2 location data from org2 user")

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -372,6 +372,60 @@ class TestDashboardMap(
             print(self.get_browser_logs())
             self.fail(f"Popup table did not finish loading within {timeout}s: {e}")
 
+    def test_dashboard_map_location_health_status(self):
+        org = self._get_org()
+        cases = {
+            "Predominantly healthy": ({"ok": 6, "unknown": 5, "critical": 2}, "ok"),
+            "Tied healthy and critical": ({"ok": 1, "critical": 1}, "problem"),
+            "Tied critical and unknown": ({"critical": 1, "unknown": 1}, "critical"),
+            "Only deactivated": ({"deactivated": 2}, "deactivated"),
+            "Deactivated devices ignored": (
+                {"ok": 2, "critical": 1, "deactivated": 10},
+                "ok",
+            ),
+        }
+        for location_index, (name, (counts, _)) in enumerate(cases.items()):
+            location = self._create_location(
+                type="outdoor",
+                name=name,
+                organization=org,
+                geometry=Point(12.5 + location_index / 100, 41.9),
+            )
+            device_index = 0
+            for status, count in counts.items():
+                for _ in range(count):
+                    device = self._create_device(
+                        name=f"device-{location_index}-{device_index}",
+                        mac_address=(
+                            f"00:00:00:{location_index:02x}:{device_index:02x}:00"
+                        ),
+                        organization=org,
+                    )
+                    device.monitoring.update_status(status)
+                    self._create_object_location(
+                        content_object=device,
+                        location=location,
+                        organization=org,
+                    )
+                    device_index += 1
+        self.login()
+        try:
+            statuses = WebDriverWait(self.web_driver, 5).until(
+                lambda d: d.execute_script(
+                    """
+                    const nodes = window._owGeoMap?.data?.nodes;
+                    if (!nodes || nodes.length !== 5) return false;
+                    return Object.fromEntries(nodes.map(node => [node.label, node.category]));
+                """
+                )
+            )
+        except TimeoutException:
+            self.fail("Failed to retrieve dashboard map location statuses")
+        self.assertDictEqual(
+            statuses,
+            {name: status for name, (_, status) in cases.items()},
+        )
+
     def test_features_on_device_popup(self):
         org = self._get_org()
         d1 = self._create_device(

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -236,7 +236,8 @@ class TestDashboardCharts(
         self.wait_for_visibility(
             By.CSS_SELECTOR, "#chart-0 .js-plotly-plot", timeout=10
         )
-        self.web_driver.execute_script("""
+        self.web_driver.execute_script(
+            """
             window.dashboardChartRequests = 0;
             const originalAjax = django.jQuery.ajax;
             django.jQuery.ajax = function () {
@@ -247,7 +248,8 @@ class TestDashboardCharts(
               'plotly_relayout',
               { autosize: true },
             );
-        """)
+        """
+        )
         self.assertEqual(
             self.web_driver.execute_script("return window.dashboardChartRequests;"), 0
         )
@@ -777,7 +779,8 @@ class TestDashboardMap(
                 == second_map_id
             )
         except TimeoutException:
-            floorplan_state = self.web_driver.execute_script("""
+            floorplan_state = self.web_driver.execute_script(
+                """
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return {
                   activeMapId: window._owIndoorMap?.config?.bookmarkableActions?.id,
@@ -785,7 +788,8 @@ class TestDashboardMap(
                   hash: window.location.hash,
                   locationId: state?.state?.locationId,
                 };
-                """)
+                """
+            )
             self.fail(
                 f"Hash change did not activate {second_map_id}; "
                 f"state is {floorplan_state}; logs are {self.get_browser_logs()}"
@@ -924,32 +928,46 @@ class TestDashboardMap(
         self.find_element(
             By.CSS_SELECTOR, "#floorplan-navigation .floor-btn[data-floor='2']"
         ).click()
-        WebDriverWait(self.web_driver, 2).until(lambda d: d.execute_script("""
+        WebDriverWait(self.web_driver, 2).until(
+            lambda d: d.execute_script(
+                """
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return (
                   state?.state?.currentFloor === 1 &&
                   !state.allResults[2] &&
                   !state.floorRequests[2]
                 );
-                """))
+                """
+            )
+        )
         self.find_element(
             By.CSS_SELECTOR, "#floorplan-navigation .floor-btn[data-floor='2']"
         ).click()
-        WebDriverWait(self.web_driver, 2).until(lambda d: d.execute_script("""
+        WebDriverWait(self.web_driver, 2).until(
+            lambda d: d.execute_script(
+                """
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return state?.allResults[2]?.length === 51;
-                """))
-        self.web_driver.execute_script("""
+                """
+            )
+        )
+        self.web_driver.execute_script(
+            """
             const floorButton = document.querySelector(
               "#floorplan-navigation .floor-btn[data-floor='3']",
             );
             floorButton.click();
             floorButton.click();
-            """)
-        WebDriverWait(self.web_driver, 2).until(lambda d: d.execute_script("""
+            """
+        )
+        WebDriverWait(self.web_driver, 2).until(
+            lambda d: d.execute_script(
+                """
                 const state = django.jQuery("#floorplan-overlay").data("floorplanState");
                 return state?.allResults[3]?.length === 51;
-                """))
+                """
+            )
+        )
 
     def test_switching_floorplan_in_fullscreen_mode(self):
         org = self._get_org()
@@ -1168,7 +1186,8 @@ class TestDashboardMap(
         location.save()
         try:
             series_value = WebDriverWait(self.web_driver, 5).until(
-                lambda d: d.execute_script("""
+                lambda d: d.execute_script(
+                    """
                     const options = window._owGeoMap.echarts.getOption();
                     const series = options.series.find(
                         (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1176,7 +1195,8 @@ class TestDashboardMap(
                     const item = series.data.find(d => d.name === "Test-Location");
                     if (!item) return false;
                     return item.value;
-                """)
+                """
+                )
             )
         except TimeoutException:
             self.fail("Failed to retrieve mobile location data")
@@ -1190,7 +1210,8 @@ class TestDashboardMap(
             location.save()
             try:
                 series_value = WebDriverWait(self.web_driver, 5).until(
-                    lambda d: d.execute_script("""
+                    lambda d: d.execute_script(
+                        """
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1198,7 +1219,8 @@ class TestDashboardMap(
                         const item = series.data.find(d => d.name === "Test-Location");
                         if (!item) return false;
                         return item.value;
-                    """)
+                    """
+                    )
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve updated mobile location data")
@@ -1251,7 +1273,8 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(self.web_driver, 5).until(
-                    lambda d: d.execute_script("""
+                    lambda d: d.execute_script(
+                        """
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1260,7 +1283,8 @@ class TestDashboardMap(
                         const org2_location = series.data.find(l => l.name === "Org2-Location")
                         if (!org1_location || !org2_location) return false;
                         return {org1_location, org2_location}
-                    """)
+                    """
+                    )
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve org location data from superuser")
@@ -1288,7 +1312,8 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org1_driver, 5).until(
-                    lambda d: d.execute_script("""
+                    lambda d: d.execute_script(
+                        """
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1298,7 +1323,8 @@ class TestDashboardMap(
                         if (!org1_location) return false;
                         if (org2_location !== undefined) return false;
                         return {org1_location, org2_location}
-                    """)
+                    """
+                    )
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve org1 location data from org1 user")
@@ -1325,7 +1351,8 @@ class TestDashboardMap(
             sleep(0.3)  # Wait for JS animation
             try:
                 series_locations = WebDriverWait(org2_driver, 5).until(
-                    lambda d: d.execute_script("""
+                    lambda d: d.execute_script(
+                        """
                         const options = window._owGeoMap.echarts.getOption();
                         const series = options.series.find(
                             (s) => s.type === "scatter" || s.type === "effectScatter",
@@ -1335,7 +1362,8 @@ class TestDashboardMap(
                         if (org1_location !== undefined) return false;
                         if (!org2_location) return false;
                         return {org1_location, org2_location}
-                    """)
+                    """
+                    )
                 )
             except TimeoutException:
                 self.fail("Failed to retrieve org2 location data from org2 user")

--- a/openwisp_monitoring/tests/test_selenium.py
+++ b/openwisp_monitoring/tests/test_selenium.py
@@ -373,6 +373,7 @@ class TestDashboardMap(
             self.fail(f"Popup table did not finish loading within {timeout}s: {e}")
 
     def test_dashboard_map_location_health_status(self):
+        """Ensures markers use active status counts and the defined tie rules."""
         org = self._get_org()
         cases = {
             "Predominantly healthy": ({"ok": 6, "unknown": 5, "critical": 2}, "ok"),


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #849.

## Description of Changes

Location markers now reflect the most frequent active device health status. Deactivated devices are excluded from the health calculation unless every device at a location is deactivated, in which case the marker uses the deactivated color. The GeoJSON endpoint now includes the deactivated device count. Any tied set including `ok` or `problem` is shown as `problem`; a tie limited to `critical` and `unknown` is shown as `critical`.

## Screenshot

**Before**:

Multiple devices in one location, mostly OK, location shown on the map as a red point (which was misleading).

<img width="550" height="428" alt="image" src="https://github.com/user-attachments/assets/d51b5fc3-b281-4dd5-881a-a80709efc697" />

**After**:

Shows as green because most devices in this location are OK.

<img width="550" height="428" alt="image" src="https://github.com/user-attachments/assets/3926922d-5873-442d-b47d-d068530587dd" />
