### PR TITLE
[deps] Upgraded Docker base image to python:3.13-slim-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.13-slim-trixie
 
 RUN apt update && \
     apt install --yes zlib1g-dev libjpeg-dev gdal-bin libproj-dev \


### PR DESCRIPTION


## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Debian 11 (bullseye) reached end-of-life and its package pool no longer serves the versions referenced by its index, causing the Docker build to fail with 404 errors during apt install (e.g. libc-dev-bin, libxml2-dev).

Trixie is the current Debian stable release and its packages are served normally. Python is upgraded to 3.13 to match the CI test matrix.

## Screenshot

N/A
