### PR TITLE
[tests] Added query-count subtests to shared monitoring tests #855

### DIFF
--- a/openwisp_monitoring/device/tests/__init__.py
+++ b/openwisp_monitoring/device/tests/__init__.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from swapper import load_model
 
 from openwisp_controller.config.tests.utils import CreateConfigTemplateMixin
+from openwisp_utils.tests import AssertNumQueriesSubTestMixin
 
 from ...monitoring.tests import TestMonitoringMixin
 from ..utils import manage_short_retention_policy
@@ -20,7 +21,9 @@ Config = load_model("config", "Config")
 Device = load_model("config", "Device")
 
 
-class TestDeviceMonitoringMixin(CreateConfigTemplateMixin, TestMonitoringMixin):
+class TestDeviceMonitoringMixin(
+    AssertNumQueriesSubTestMixin, CreateConfigTemplateMixin, TestMonitoringMixin
+):
     device_model = Device
     config_model = Config
     _PING = "openwisp_monitoring.check.classes.Ping"

--- a/openwisp_monitoring/monitoring/tests/test_api.py
+++ b/openwisp_monitoring/monitoring/tests/test_api.py
@@ -7,6 +7,7 @@ from swapper import load_model
 
 from openwisp_controller.config.tests.utils import CreateConfigTemplateMixin
 from openwisp_controller.geo.tests.utils import TestGeoMixin
+from openwisp_utils.tests import AssertNumQueriesSubTestMixin
 
 from ..configuration import DEFAULT_DASHBOARD_TRAFFIC_CHART
 from . import TestMonitoringMixin
@@ -26,7 +27,11 @@ Device = load_model("config", "Device")
 @tag("flaky_with_udp_writes")
 @patch.dict(DEFAULT_DASHBOARD_TRAFFIC_CHART, {"__all__": ["wan"]})
 class TestDashboardTimeseriesView(
-    CreateConfigTemplateMixin, TestMonitoringMixin, TestGeoMixin, TestCase
+    AssertNumQueriesSubTestMixin,
+    CreateConfigTemplateMixin,
+    TestMonitoringMixin,
+    TestGeoMixin,
+    TestCase,
 ):
     location_model = Location
     floorplan_model = FloorPlan


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #855.

## Description of Changes

Added `AssertNumQueriesSubTestMixin` to the shared `TestDeviceMonitoringMixin` and to `TestDashboardTimeseriesView`, while keeping all existing `assertNumQueries()` calls unchanged.

The mixin is placed before `CreateConfigTemplateMixin` so its `assertNumQueries()` implementation takes precedence in the method resolution order.

`TestDashboardTimeseriesView` uses the mixin directly because `CreateConfigTemplateMixin` appears before the general `TestMonitoringMixin` in its inheritance chain. Adding the query-count mixin only to `TestMonitoringMixin` would therefore not override the existing query-count implementation and would also affect unrelated monitoring tests.

Verification performed:

- `openwisp-qa-format`
- `./run-qa-checks`
- Focused Monitoring and Device test suites: 183 tests passed
- Full `./runtests`: 408, 299, and 265 tests passed
- Manual negative-path check confirmed that execution continues after an intentional query-count mismatch

## Screenshot

N/A. This change affects test behavior only.